### PR TITLE
fix(ci): keep SDK installs formatted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.vite-hooks/
 .venv/
 __pycache__/
 .pytest_cache/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  staged: {
+    "*": "vp check --fix",
+  },
   fmt: { ignorePatterns: ["sdks/**"] },
   lint: {
     ignorePatterns: ["sdks/**"],


### PR DESCRIPTION
`pnpm install` runs `vp config`, which adds the staged-file configuration and leaves `vite.config.ts` failing the formatting check in a clean checkout. Include that configuration in its formatted form and ignore the generated `.vite-hooks/` directory so installation leaves the checkout clean.
