### PR TITLE
ci: restore sdk release automation

### DIFF
--- a/.github/scripts/release-artifact.sh
+++ b/.github/scripts/release-artifact.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+package=${1:?package path is required}
+artifact=${2:?artifact path is required}
+expected_version=$(jq -er --arg path "$package" '.[$path]' .release-please-manifest.json)
+release_type=$(jq -er --arg path "$package" '.packages[$path]["release-type"]' release-please-config.json)
+
+case "$release_type" in
+  node)
+    expected_name=$(jq -er '.name' "$package/package.json")
+    metadata=$(tar -xOf "$artifact" package/package.json)
+    packed_name=$(jq -er '.name' <<< "$metadata")
+    packed_version=$(jq -er '.version' <<< "$metadata")
+    ;;
+  python)
+    expected_name=$(jq -er --arg path "$package" '.packages[$path]["package-name"]' release-please-config.json)
+    metadata=$(python3 - "$artifact" <<'PY'
+import email.parser
+import json
+import sys
+import tarfile
+import zipfile
+
+path = sys.argv[1]
+if path.endswith(".whl"):
+    with zipfile.ZipFile(path) as archive:
+        members = [name for name in archive.namelist() if name.count("/") == 1 and name.endswith(".dist-info/METADATA")]
+        if len(members) != 1:
+            sys.exit("Expected one wheel metadata file")
+        content = archive.read(members[0])
+elif path.endswith(".tar.gz"):
+    with tarfile.open(path) as archive:
+        members = [member for member in archive.getmembers() if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO") and member.isfile()]
+        if len(members) != 1:
+            sys.exit("Expected one sdist metadata file")
+        content = archive.extractfile(members[0]).read()
+else:
+    sys.exit("Unsupported Python artifact")
+
+metadata = email.parser.BytesParser().parsebytes(content)
+if len(metadata.get_all("Name", [])) != 1 or len(metadata.get_all("Version", [])) != 1:
+    sys.exit("Expected one artifact name and version")
+print(json.dumps({"name": metadata["Name"], "version": metadata["Version"]}))
+PY
+    )
+    packed_name=$(jq -er '.name' <<< "$metadata")
+    packed_version=$(jq -er '.version' <<< "$metadata")
+    ;;
+  *)
+    echo "Unsupported release type: $release_type" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$packed_name" != "$expected_name" ]]; then
+  echo "Packed name $packed_name does not match release name $expected_name" >&2
+  exit 1
+fi
+if [[ "$packed_version" != "$expected_version" ]]; then
+  echo "Packed version $packed_version does not match release version $expected_version" >&2
+  exit 1
+fi

--- a/.github/scripts/release-source.sh
+++ b/.github/scripts/release-source.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+if ! git check-ref-format "refs/tags/$RELEASE_TAG"; then
+  echo "Invalid release tag" >&2
+  exit 1
+fi
+if [[ "$GITHUB_EVENT_NAME" != "release" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+  echo "Unsupported release event" >&2
+  exit 1
+fi
+
+tag_sha=$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")
+head_sha=$(git rev-parse HEAD)
+
+if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+  if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+    echo "Release retries must use the workflow from main" >&2
+    exit 1
+  fi
+  if [[ "$head_sha" != "$GITHUB_SHA" ]]; then
+    echo "Retry checkout and event commits do not match" >&2
+    exit 1
+  fi
+  if ! git merge-base --is-ancestor "$tag_sha" "$head_sha"; then
+    echo "Release tag is not an ancestor of the retry commit" >&2
+    exit 1
+  fi
+  release_paths=()
+  while IFS= read -r path; do
+    release_paths+=(":(literal)$path")
+  done < <(jq -er '.packages | keys[]' release-please-config.json)
+  release_inputs=(
+    .release-please-manifest.json
+    pnpm-lock.yaml
+    pnpm-workspace.yaml
+    release-please-config.json
+    scripts
+    tsconfig.json
+    vite.config.ts
+  )
+  if ! git diff --quiet "$tag_sha" "$head_sha" -- "${release_paths[@]}" "${release_inputs[@]}"; then
+    echo "Retry commit changes release source files" >&2
+    exit 1
+  fi
+  tag_package=$(git show "$tag_sha:package.json" | jq --sort-keys 'del(.packageManager)')
+  head_package=$(jq --sort-keys 'del(.packageManager)' package.json)
+  if [[ "$tag_package" != "$head_package" ]]; then
+    echo "Retry commit changes package.json outside packageManager" >&2
+    exit 1
+  fi
+  printf '%s\n' "$head_sha"
+  exit 0
+fi
+
+if [[ "$GITHUB_REF" != "refs/tags/$RELEASE_TAG" ]]; then
+  echo "Package publication must run from a release tag" >&2
+  exit 1
+fi
+if [[ "$tag_sha" != "$GITHUB_SHA" || "$head_sha" != "$GITHUB_SHA" ]]; then
+  echo "Release tag, event, and checkout commits do not match" >&2
+  exit 1
+fi
+printf '%s\n' "$tag_sha"

--- a/.github/scripts/release_test.sh
+++ b/.github/scripts/release_test.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+source_script="$root/.github/scripts/release-source.sh"
+artifact_script="$root/.github/scripts/release-artifact.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+repo="$tmp/repo"
+
+git init --quiet --initial-branch=main "$repo"
+git -C "$repo" config user.name "Release Test"
+git -C "$repo" config user.email "release-test@example.invalid"
+mkdir -p "$repo/.github/scripts" "$repo/.github/workflows" "$repo/scripts" "$repo/packages/mcp" "$repo/sdks/python"
+printf '{"name":"repo","packageManager":"pnpm@11.12.0"}\n' > "$repo/package.json"
+printf '{"packages/mcp":"0.1.1","sdks/python":"0.2.2"}\n' > "$repo/.release-please-manifest.json"
+printf '{"packages":{"packages/mcp":{"component":"mcp","release-type":"node"},"sdks/python":{"component":"python","release-type":"python","package-name":"telemetry-dev"}}}\n' > "$repo/release-please-config.json"
+printf '{"name":"@telemetry-dev/mcp","version":"0.1.1"}\n' > "$repo/packages/mcp/package.json"
+printf 'export const value = 1;\n' > "$repo/packages/mcp/index.ts"
+printf 'name: Release\n' > "$repo/.github/workflows/release.yml"
+git -C "$repo" add .
+git -C "$repo" commit --quiet -m release
+git -C "$repo" tag mcp-v0.1.1
+release_sha=$(git -C "$repo" rev-parse HEAD)
+
+run_source() {
+  local event=$1
+  local ref=$2
+  local sha=$3
+  (
+    cd "$repo"
+    RELEASE_TAG="${4:-mcp-v0.1.1}" \
+      GITHUB_EVENT_NAME="$event" \
+      GITHUB_REF="$ref" \
+      GITHUB_SHA="$sha" \
+      "$source_script"
+  )
+}
+
+expect_failure() {
+  local expected=$1
+  shift
+  local output
+  if output=$("$@" 2>&1); then
+    echo "Expected failure containing: $expected" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "Expected '$expected', received '$output'" >&2
+    exit 1
+  fi
+}
+
+extract_run() {
+  awk -v job="$1" '
+    $0 == "  " job ":" { selected = 1; next }
+    selected && /^  [a-z]/ { exit }
+    selected && /^        run: \|/ { emit = 1; next }
+    emit && /^          / { print substr($0, 11); next }
+    emit && /^$/ { print; next }
+    emit { exit }
+  ' "$root/.github/workflows/release.yml"
+}
+
+[[ "$(run_source release refs/tags/mcp-v0.1.1 "$release_sha")" == "$release_sha" ]]
+expect_failure "Package publication must run from a release tag" \
+  run_source release refs/heads/main "$release_sha"
+expect_failure "Release tag, event, and checkout commits do not match" \
+  run_source release refs/tags/mcp-v0.1.1 deadbeef
+expect_failure "Unsupported release event" \
+  run_source push refs/tags/mcp-v0.1.1 "$release_sha"
+expect_failure "Invalid release tag" \
+  run_source release 'refs/tags/mcp-v0.1.1^{}' "$release_sha" 'mcp-v0.1.1^{}'
+expect_failure "Invalid release tag" \
+  run_source release 'refs/tags/../main' "$release_sha" '../main'
+git -C "$repo" tag --annotate annotated-v0.1.1 --message release
+[[ "$(run_source release refs/tags/annotated-v0.1.1 "$release_sha" annotated-v0.1.1)" == "$release_sha" ]]
+
+printf '{"name":"repo","packageManager":"pnpm@11.25.0"}\n' > "$repo/package.json"
+printf 'name: CI\n' > "$repo/.github/workflows/ci.yml"
+printf 'name: Release fixed\n' > "$repo/.github/workflows/release.yml"
+cp "$source_script" "$artifact_script" "$repo/.github/scripts/"
+cp "$root/.github/scripts/release_test.sh" "$repo/.github/scripts/"
+printf 'SDK release recovery\n' > "$repo/README.md"
+git -C "$repo" add .
+git -C "$repo" commit --quiet -m recovery
+recovery_sha=$(git -C "$repo" rev-parse HEAD)
+
+[[ "$(run_source workflow_dispatch refs/heads/main "$recovery_sha")" == "$recovery_sha" ]]
+expect_failure "Retry checkout and event commits do not match" \
+  run_source workflow_dispatch refs/heads/main "$release_sha"
+expect_failure "Release retries must use the workflow from main" \
+  run_source workflow_dispatch refs/heads/recovery "$recovery_sha"
+
+mkdir -p "$tmp/bin"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$%s"\n' DRAFT > "$tmp/bin/gh"
+chmod +x "$tmp/bin/gh"
+extract_run discover-release > "$tmp/discover.sh"
+run_discovery() {
+  (
+    cd "$repo"
+    PATH="$tmp/bin:$PATH" DRAFT="$1" RELEASE_TAG="${2:-mcp-v0.1.1}" \
+      GITHUB_REPOSITORY=telemetry-dev/sdks GITHUB_EVENT_NAME=workflow_dispatch \
+      GITHUB_REF=refs/heads/main GITHUB_SHA="$recovery_sha" GITHUB_OUTPUT="$tmp/output" \
+      bash -eo pipefail "$tmp/discover.sh"
+  )
+}
+run_discovery false
+grep -Fxq 'npm=["packages/mcp"]' "$tmp/output"
+grep -Fxq 'python=[]' "$tmp/output"
+grep -Fxq "sha=$recovery_sha" "$tmp/output"
+expect_failure "Release mcp-v0.1.1 is still a draft" run_discovery true
+git -C "$repo" tag unknown-v0.1.1
+expect_failure "Expected one package for unknown-v0.1.1, found 0" run_discovery false unknown-v0.1.1
+git -C "$repo" tag python-v0.2.2 "$release_sha"
+run_discovery false python-v0.2.2
+grep -Fxq 'python=["sdks/python"]' "$tmp/output"
+
+release_tree=$(git -C "$repo" show --no-patch --format=%T "$release_sha")
+unrelated_sha=$(printf 'unrelated\n' | git -C "$repo" commit-tree "$release_tree")
+git -C "$repo" switch --quiet --detach "$unrelated_sha"
+expect_failure "Release tag is not an ancestor of the retry commit" \
+  run_source workflow_dispatch refs/heads/main "$unrelated_sha"
+
+git -C "$repo" switch --quiet --detach "$recovery_sha"
+printf 'export const value = 2;\n' > "$repo/packages/mcp/index.ts"
+git -C "$repo" add packages/mcp/index.ts
+git -C "$repo" commit --quiet -m source-change
+source_change_sha=$(git -C "$repo" rev-parse HEAD)
+expect_failure "Retry commit changes release source files" \
+  run_source workflow_dispatch refs/heads/main "$source_change_sha"
+
+for path in scripts/package-exports.mjs sdks/python/pyproject.toml pnpm-lock.yaml; do
+  git -C "$repo" switch --quiet --detach "$recovery_sha"
+  mkdir -p "$(dirname "$repo/$path")"
+  printf 'changed\n' > "$repo/$path"
+  git -C "$repo" add "$path"
+  git -C "$repo" commit --quiet -m input-change
+  expect_failure "Retry commit changes release source files" \
+    run_source workflow_dispatch refs/heads/main "$(git -C "$repo" rev-parse HEAD)"
+done
+
+git -C "$repo" switch --quiet --detach "$recovery_sha"
+jq '.packages[":(exclude)release-please-config.json"] = .packages["packages/mcp"] | .packages[":(exclude)packages/mcp"] = .packages["packages/mcp"]' \
+  "$repo/release-please-config.json" > "$repo/release-please-config.json.next"
+mv "$repo/release-please-config.json.next" "$repo/release-please-config.json"
+printf 'export const value = 3;\n' > "$repo/packages/mcp/index.ts"
+git -C "$repo" add release-please-config.json packages/mcp/index.ts
+git -C "$repo" commit --quiet -m pathspec-change
+pathspec_change_sha=$(git -C "$repo" rev-parse HEAD)
+expect_failure "Retry commit changes release source files" \
+  run_source workflow_dispatch refs/heads/main "$pathspec_change_sha"
+
+git -C "$repo" switch --quiet --detach "$recovery_sha"
+jq '.name = "changed"' "$repo/package.json" > "$repo/package.json.next"
+mv "$repo/package.json.next" "$repo/package.json"
+git -C "$repo" add package.json
+git -C "$repo" commit --quiet -m package-change
+package_change_sha=$(git -C "$repo" rev-parse HEAD)
+expect_failure "Retry commit changes package.json outside packageManager" \
+  run_source workflow_dispatch refs/heads/main "$package_change_sha"
+
+mkdir -p "$tmp/archive/package"
+printf '{"name":"@telemetry-dev/mcp","version":"0.1.1"}\n' > "$tmp/archive/package/package.json"
+tar -czf "$tmp/mcp.tgz" -C "$tmp/archive" package
+printf '{"packages/mcp":"0.1.1"}\n' > "$repo/.release-please-manifest.json"
+(
+  cd "$repo"
+  "$artifact_script" packages/mcp "$tmp/mcp.tgz"
+)
+printf '{"packages/mcp":"9.9.9"}\n' > "$repo/.release-please-manifest.json"
+expect_failure "Packed version 0.1.1 does not match release version 9.9.9" \
+  bash -c "cd '$repo' && '$artifact_script' packages/mcp '$tmp/mcp.tgz'"
+printf '{"name":"@telemetry-dev/other","version":"0.1.1"}\n' > "$tmp/archive/package/package.json"
+tar -czf "$tmp/wrong-name.tgz" -C "$tmp/archive" package
+expect_failure "Packed name @telemetry-dev/other does not match release name @telemetry-dev/mcp" \
+  bash -c "cd '$repo' && '$artifact_script' packages/mcp '$tmp/wrong-name.tgz'"
+
+mkdir -p "$tmp/publish/npm"
+printf 'mcp.tgz\n' > "$tmp/publish/npm/publish-order.txt"
+extract_run publish-npm > "$tmp/publish.sh"
+cat > "$tmp/bin/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$QUERIES"
+case "$*" in
+  "view @telemetry-dev/mcp@0.1.1 dist.integrity") printf '%s\n' "$REMOTE_INTEGRITY" ;;
+  "view @telemetry-dev/sdk@^0.1.1 version --json")
+    echo attempt >> "$ATTEMPTS"
+    [[ "$DEPENDENCY_AVAILABLE" == true ]] || { echo 'dependency unavailable' >&2; exit 1; }
+    printf '"0.1.1"\n'
+    ;;
+  "publish ./npm/mcp.tgz --access public") echo published >> "$PUBLISHED" ;;
+  *) echo "Unexpected npm arguments: $*" >&2; exit 1 ;;
+esac
+SH
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp/bin/sleep"
+chmod +x "$tmp/bin/npm" "$tmp/bin/sleep"
+run_publish() {
+  (
+    cd "$tmp/publish"
+    PATH="$tmp/bin:$PATH" REMOTE_INTEGRITY="$1" DEPENDENCY_AVAILABLE="$2" \
+      ATTEMPTS="$tmp/attempts" PUBLISHED="$tmp/published" QUERIES="$tmp/queries" \
+      bash -euo pipefail "$tmp/publish.sh"
+  )
+}
+for field in dependencies peerDependencies; do
+  jq -n --arg field "$field" '{
+    name: "@telemetry-dev/mcp", version: "0.1.1",
+    ($field): {"@telemetry-dev/sdk": "^0.1.1", "@telemetry-dev-extra/helper": "^0.1.1"}
+  }' > "$tmp/archive/package/package.json"
+  tar -czf "$tmp/publish/npm/mcp.tgz" -C "$tmp/archive" package
+  rm -f "$tmp/attempts" "$tmp/published" "$tmp/queries"
+  integrity="sha512-$(openssl dgst -sha512 -binary "$tmp/publish/npm/mcp.tgz" | openssl base64 -A)"
+  run_publish "$integrity" false
+  [[ ! -e "$tmp/published" && ! -e "$tmp/attempts" ]]
+  expect_failure 'Integrity mismatch' run_publish sha512-wrong true
+  expect_failure 'unable to verify that published @telemetry-dev/sdk satisfies ^0.1.1' run_publish '' false
+  [[ ! -e "$tmp/published" && $(wc -l < "$tmp/attempts") -eq 12 ]]
+  run_publish '' true
+  [[ $(wc -l < "$tmp/published") -eq 1 && $(wc -l < "$tmp/attempts") -eq 13 ]]
+  if grep -Fq '@telemetry-dev-extra/helper' "$tmp/queries"; then
+    echo "Unexpected registry query for namespace near-miss in $field" >&2
+    exit 1
+  fi
+done
+
+printf '{"sdks/python":"0.2.2"}\n' > "$repo/.release-please-manifest.json"
+printf '{"packages":{"sdks/python":{"component":"python","release-type":"python","package-name":"telemetry-dev"}}}\n' > "$repo/release-please-config.json"
+python3 - "$tmp" <<'PY'
+import io
+import pathlib
+import sys
+import tarfile
+import zipfile
+
+root = pathlib.Path(sys.argv[1])
+for label, name, version in [("valid", "telemetry-dev", "0.2.2"), ("version", "telemetry-dev", "9.9.9"), ("name", "other", "0.2.2")]:
+    metadata = f"Metadata-Version: 2.3\nName: {name}\nVersion: {version}\n".encode()
+    with zipfile.ZipFile(root / f"{label}.whl", "w") as archive:
+        archive.writestr("telemetry_dev-0.2.2.dist-info/METADATA", metadata)
+    with tarfile.open(root / f"{label}.tar.gz", "w:gz") as archive:
+        member = tarfile.TarInfo("telemetry_dev-0.2.2/PKG-INFO")
+        member.size = len(metadata)
+        archive.addfile(member, io.BytesIO(metadata))
+PY
+for suffix in whl tar.gz; do
+  (cd "$repo" && "$artifact_script" sdks/python "$tmp/valid.$suffix")
+  expect_failure "Packed version 9.9.9 does not match release version 0.2.2" \
+    bash -c "cd '$repo' && '$artifact_script' sdks/python '$tmp/version.$suffix'"
+  expect_failure "Packed name other does not match release name telemetry-dev" \
+    bash -c "cd '$repo' && '$artifact_script' sdks/python '$tmp/name.$suffix'"
+done
+
+package_pnpm=$(jq -er '.packageManager | capture("^pnpm@(?<version>.+)$").version' "$root/package.json")
+workflow_pnpm=$(
+  awk '
+    /uses: pnpm\/action-setup@/ { setup = 1; next }
+    setup && /version:/ { print $2; exit }
+    setup && /uses:|run:/ { exit 1 }
+  ' "$root/.github/workflows/release.yml"
+)
+[[ "$workflow_pnpm" == "$package_pnpm" ]]
+[[ $(grep -Ec '^[[:space:]]*concurrency:' "$root/.github/workflows/release.yml") -eq 1 ]]
+grep -Fxq "  group: release-\${{ github.event.release.tag_name || inputs.release_tag || github.ref }}" \
+  "$root/.github/workflows/release.yml"
+grep -Fxq "          NPM_CONFIG_PROVENANCE: \${{ github.event.repository.private && 'false' || 'true' }}" \
+  "$root/.github/workflows/release.yml"
+grep -Fxq "            npm publish \"./npm/\$tarball\" --access public" \
+  "$root/.github/workflows/release.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ permissions:
   contents: read
 
 jobs:
+  release-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - run: bash .github/scripts/release_test.sh
+      - run: shellcheck .github/scripts/*.sh
+
   typescript:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,248 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published release tag to retry from main
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  release-please:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [[ -z "$RELEASE_PLEASE_TOKEN" ]]; then
+            echo "RELEASE_PLEASE_TOKEN is required" >&2
+            exit 1
+          fi
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+  discover-release:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      npm-packages: ${{ steps.packages.outputs.npm }}
+      python-packages: ${{ steps.packages.outputs.python }}
+      source-sha: ${{ steps.packages.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - id: packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.ref_name }}
+        run: |
+          npm=()
+          python=()
+          matches=0
+          source_sha=$(.github/scripts/release-source.sh)
+
+          draft=$(gh release view --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' -- "$RELEASE_TAG")
+          if [[ "$draft" != "false" ]]; then
+            echo "Release $RELEASE_TAG is still a draft" >&2
+            exit 1
+          fi
+
+          while IFS= read -r path; do
+            component=$(jq -er --arg path "$path" '.packages[$path].component' release-please-config.json)
+            release_type=$(jq -er --arg path "$path" '.packages[$path]["release-type"]' release-please-config.json)
+            version=$(jq -er --arg path "$path" '.[$path]' .release-please-manifest.json)
+            tag="$component-v$version"
+
+            [[ "$tag" == "$RELEASE_TAG" ]] || continue
+
+            case "$release_type" in
+              node) npm+=("$path") ;;
+              python) python+=("$path") ;;
+              *)
+                echo "Unsupported release type for $path: $release_type" >&2
+                exit 1
+                ;;
+            esac
+            matches=$((matches + 1))
+          done < <(jq -r '.packages | to_entries[] | .key' release-please-config.json)
+
+          if [[ "$matches" != 1 ]]; then
+            echo "Expected one package for $RELEASE_TAG, found $matches" >&2
+            exit 1
+          fi
+
+          npm_json=$(printf '%s\n' "${npm[@]}" | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')
+          python_json=$(printf '%s\n' "${python[@]}" | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')
+          {
+            echo "npm=$npm_json"
+            echo "python=$python_json"
+            echo "sha=$source_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  build-npm:
+    needs: discover-release
+    if: needs.discover-release.outputs.npm-packages != '[]'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3
+        with:
+          version: 11.25.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.discover-release.outputs.source-sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.19.0
+          package-manager-cache: false
+      - run: pnpm install --frozen-lockfile
+      - env:
+          PACKAGES: ${{ needs.discover-release.outputs.npm-packages }}
+        run: |
+          output="$RUNNER_TEMP/npm"
+          mkdir -p "$output"
+          while IFS= read -r package; do
+            pnpm --dir "$package" run build
+            metadata=$(pnpm --dir "$package" pack --pack-destination "$output" --json)
+            tarball=$(jq -r '.filename' <<< "$metadata")
+            .github/scripts/release-artifact.sh "$package" "$tarball"
+            basename "$tarball" >> "$output/publish-order.txt"
+          done < <(jq -r '.[]' <<< "$PACKAGES")
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm
+          retention-days: 30
+          if-no-files-found: error
+
+  publish-npm:
+    needs: [discover-release, build-npm]
+    if: needs.discover-release.outputs.npm-packages != '[]'
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: npm-packages
+          path: npm
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.19.0
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - run: npm install --global npm@12.0.2
+      - env:
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.private && 'false' || 'true' }}
+        run: |
+          while IFS= read -r tarball; do
+            metadata=$(tar -xOf "npm/$tarball" package/package.json)
+            name=$(jq -r '.name' <<< "$metadata")
+            version=$(jq -r '.version' <<< "$metadata")
+            remote_integrity=$(npm view "$name@$version" dist.integrity 2>/dev/null || true)
+            if [[ -n "$remote_integrity" ]]; then
+              local_integrity="sha512-$(openssl dgst -sha512 -binary "npm/$tarball" | openssl base64 -A)"
+              if [[ "$remote_integrity" != "$local_integrity" ]]; then
+                echo "Integrity mismatch for $name@$version" >&2
+                exit 1
+              fi
+              echo "$name@$version is already published with matching integrity"
+              continue
+            fi
+            while IFS=$'\t' read -r dependency range; do
+              for attempt in {1..12}; do
+                dependency_error=$(npm view "${dependency}@${range}" version --json 2>&1) && continue 2
+                [[ "$attempt" == 12 ]] || sleep 10
+              done
+              echo "Cannot publish $name@$version: unable to verify that published $dependency satisfies $range" >&2
+              printf '%s\n' "$dependency_error" >&2
+              exit 1
+            done < <(jq -r '
+              ((.dependencies // {}), (.peerDependencies // {})) | to_entries[] |
+              select(.key | startswith("@telemetry-dev/")) |
+              [.key, .value] | @tsv
+            ' <<< "$metadata")
+            npm publish "./npm/$tarball" --access public
+          done < npm/publish-order.txt
+
+  build-python:
+    needs: discover-release
+    if: needs.discover-release.outputs.python-packages != '[]'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.discover-release.outputs.source-sha }}
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+        with:
+          version: 0.12.5
+          enable-cache: false
+      - env:
+          PACKAGES: ${{ needs.discover-release.outputs.python-packages }}
+        run: |
+          output="$RUNNER_TEMP/python"
+          mkdir -p "$output"
+          while IFS= read -r package; do
+            name=${package#sdks/}
+            uv build --no-sources "$package" --out-dir "$output/$name"
+            for artifact in "$output/$name"/*; do
+              .github/scripts/release-artifact.sh "$package" "$artifact"
+            done
+            echo "$name" >> "$output/publish-order.txt"
+          done < <(jq -r '.[]' <<< "$PACKAGES")
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: python-packages
+          path: ${{ runner.temp }}/python
+          retention-days: 30
+          if-no-files-found: error
+
+  publish-python:
+    needs: [discover-release, build-python]
+    if: needs.discover-release.outputs.python-packages != '[]'
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: python-packages
+          path: python
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+        with:
+          version: 0.12.5
+          enable-cache: false
+      - run: |
+          while IFS= read -r package; do
+            uv publish --trusted-publishing always --check-url https://pypi.org/simple "python/$package"/*
+          done < python/publish-order.txt

--- a/README.md
+++ b/README.md
@@ -26,7 +26,36 @@ pnpm run py:test
 pnpm run py:build
 ```
 
-CI verifies frozen dependency installs, checks, tests, and builds for both ecosystems. Publishing is intentionally disabled until a separate trusted-publisher handoff is completed; this repository contains no publish or release workflow.
+CI verifies frozen dependency installs, checks, tests, and builds for both ecosystems, plus the release safety tests.
+
+## Releases
+
+The [`Release` workflow](.github/workflows/release.yml) uses Release Please to propose version bumps on `main`. Merging a release PR lets Release Please create component releases such as `sdk-v0.1.3` or `python-v0.2.3`. Each published release builds and publishes only its matching package. Build jobs have no publishing credentials; separate publish jobs use registry OIDC trusted publishing, not long-lived npm or PyPI tokens.
+
+The manifest retains versions already published from the original repository. `bootstrap-sha` points to the initial SDK import so that import's `feat` commit does not trigger new versions. Do not create releases to republish these baseline versions: wait for subsequent releasable changes. No new version is required merely to transfer publishing to this repository.
+
+### Required setup
+
+The workflow is restored, but publishing is not fully configured until the following handoff is complete:
+
+- Provide the repository Actions secret `RELEASE_PLEASE_TOKEN`, authorized for `telemetry-dev/sdks` with contents, issues, and pull-request write permissions. The original repository's secret cannot be read or copied from GitHub; its owner must supply or replace it. The workflow deliberately fails when this secret is missing. Do not substitute `GITHUB_TOKEN`: releases created with it do not trigger the downstream release workflow.
+- Configure every npm package's GitHub Actions trusted publisher for owner `telemetry-dev`, repository `sdks`, and workflow filename `release.yml`, without an environment name. npm publishing runs on GitHub-hosted runners and includes provenance for this public repository.
+- Configure every PyPI project's GitHub Actions trusted publisher for owner `telemetry-dev`, repository `sdks`, workflow filename `release.yml`, and environment `pypi`. The repository's `pypi` environment permits branch `main` for retries and tags matching `python*-v*`; it has no required reviewers. These branch/tag restrictions are not a manual approval gate.
+- Require successful CI before merging release PRs. Verify all trusted-publisher settings and the secret before expecting an end-to-end publish to succeed.
+
+### Validation and retries
+
+Run the release safety suite locally with Bash, Git, jq, Python 3, tar, and OpenSSL; the registry commands in these tests are mocked and publish nothing:
+
+```sh
+bash .github/scripts/release_test.sh
+shellcheck .github/scripts/*.sh
+actionlint
+```
+
+To retry an existing published release, run the `Release` workflow from `main` and set `release_tag` to that release's full tag. This is a real publication attempt, not a dry run. The tag must be an ancestor of the selected `main` commit. Every configured SDK directory, shared build scripts, lockfiles, release configuration, and root build configuration must be unchanged from the tag; only `packageManager` may differ within root `package.json`. Workflow-only recovery changes are allowed. Source-changing fixes need a new release, not a retry of an old version.
+
+Artifact names and versions are checked before upload. npm retries skip an existing version only when its SHA-512 integrity matches the local tarball, and publication waits for published `@telemetry-dev/*` dependencies and peer dependencies to satisfy their declared ranges. PyPI retries use `uv publish --check-url` to check existing distributions. An integrity mismatch must be investigated, not bypassed or overwritten.
 
 ## License
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/v17.6.0/schemas/config.json",
+  "bootstrap-sha": "03243e73e66784fb0fa3242e15c8ce457672726f",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,


### PR DESCRIPTION
Restores Release Please and npm/PyPI publishing after the SDK repository split. Published versions remain the baseline, and the initial import is excluded from release history so it does not trigger another release.

Packages are built without registry credentials and checked for the expected names and versions before publishing. Retries reject source changes and mismatched npm tarballs, and concurrent releases of different versions no longer compete for one pending-job slot.

Publishing requires npm and PyPI trusted publishers for this repository. End-to-end registry publication has not been exercised.
