### PR TITLE
feat(sdk): add streaming latency metrics

### DIFF
--- a/packages/ai/src/config.ts
+++ b/packages/ai/src/config.ts
@@ -45,10 +45,12 @@ const DEFAULT_BASE_URL = "https://ingest.telemetry.dev";
 
 export function resolveConfig(options: TelemetryDevOptions = {}): ResolvedConfig {
   const env = globalThis.process?.env ?? {};
+
   const baseUrl = (options.baseUrl ?? env.TELEMETRY_DEV_BASE_URL ?? DEFAULT_BASE_URL).replace(
     /\/+$/,
     "",
   );
+
   return {
     apiKey: options.apiKey ?? env.TELEMETRY_DEV_API_KEY,
     baseUrl,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,4 +1,6 @@
 // Root entry: the ai@7 integration. On ai@6, import from "@telemetry-dev/ai-sdk/v6" instead.
 export { telemetryDev, type TelemetryDevIntegration } from "./integration_v7.ts";
+
 export type { TelemetryDevOptions } from "./config.ts";
+
 export type { TelemetryDevEvent } from "./shared.ts";

--- a/packages/ai/src/integration_v6.ts
+++ b/packages/ai/src/integration_v6.ts
@@ -26,6 +26,7 @@ import {
   SEVERITY_WARN,
   type TelemetryDevEvent,
   type JsonValue,
+  unknownErrorMessage,
 } from "./shared.ts";
 
 // Structural shapes of the ai@6 telemetry events the hooks read. Declared locally because the
@@ -131,6 +132,7 @@ export function telemetryDev(
     { ...config, sdkName: "@telemetry-dev/ai-sdk" },
     overrides,
   );
+
   const v6 = createV6Hooks(config, emitter);
 
   // The public parameters are loose supertypes; the ai@6 dispatcher guarantees these shapes.
@@ -163,13 +165,16 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
   let sessionId: string | null = null;
   let restMetadata: Record<string, JsonValue> | undefined;
   let samplingAttributes: Attributes = {};
+
   const steps = new Map<
     number,
     { span?: Span; ctx: Context; startedAt: Date; messages?: JsonValue }
   >();
+
   const toolStarts = new Map<string, Date>();
   let childSpans: Span[] = [];
   let hasToolSpan = false;
+
   // Per-step metric inputs, collected at onStepFinish and emitted at onFinish. Model/provider are
   // captured per step so fallback or mixed-model runs attribute tokens and duration to the model
   // that actually ran the step, not the root request's model.
@@ -181,6 +186,7 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
     requestModel: string;
     responseModel: string | null;
   }> = [];
+
   const toolMetrics: Array<{ durationSec: number }> = [];
 
   const conversationAttributes = (): Attributes =>
@@ -203,27 +209,34 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
         model = e.model.modelId;
 
         const input: Record<string, JsonValue> = {};
+
         if (e.system !== undefined) {
           input.system = e.system;
         }
+
         if (e.prompt !== undefined) {
           input.prompt = e.prompt;
         }
+
         if (e.messages !== undefined) {
           input.messages = e.messages;
         }
+
         rootInput = Object.keys(input).length > 0 ? input : undefined;
 
         const metadata = e.metadata;
         userId = readId(metadata?.userId);
         sessionId = readId(metadata?.sessionId);
+
         if (metadata) {
           const rest: Record<string, JsonValue> = {};
+
           for (const [key, value] of Object.entries(metadata)) {
             if (key !== "userId" && key !== "sessionId") {
               rest[key] = value;
             }
           }
+
           restMetadata = Object.keys(rest).length > 0 ? rest : undefined;
         } else {
           restMetadata = undefined;
@@ -258,11 +271,13 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
         // Open the step (model `chat`) span now so tool calls that finish within this step parent
         // to it. Attributes/finish state land at onStepFinish; the span ends there too.
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "chat",
           { startTime: startedAt, kind: SpanKind.CLIENT, attributes: conversationAttributes() },
           rootCtx,
         );
+
         steps.set(e.stepNumber, {
           span,
           ctx: trace.setSpan(rootCtx, span),
@@ -278,6 +293,7 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
       try {
         const endedAt = new Date();
         let step = steps.get(e.stepNumber);
+
         if (!step) {
           // No matching onStepStart: open the span anchored to the trace start so startTime never
           // exceeds endTime.
@@ -290,20 +306,28 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
             },
             rootCtx,
           );
+
           step = { span, ctx: trace.setSpan(rootCtx, span), startedAt: rootStartedAt };
           steps.set(e.stepNumber, step);
         }
+
         const span = step.span!;
+
         const startedAt =
           step.startedAt.getTime() <= endedAt.getTime() ? step.startedAt : rootStartedAt;
+
         const usage = e.usage;
         const inputTokens = usage.inputTokens ?? null;
         const outputTokens = usage.outputTokens ?? null;
+
         const cacheReadTokens =
           usage.inputTokenDetails?.cacheReadTokens ?? usage.cachedInputTokens ?? null;
+
         const cacheCreationTokens = usage.inputTokenDetails?.cacheWriteTokens ?? null;
+
         const reasoningTokens =
           usage.outputTokenDetails?.reasoningTokens ?? usage.reasoningTokens ?? null;
+
         const stepProvider = providerLabel(e.model.provider);
         responseModel = e.response?.modelId ?? responseModel;
 
@@ -331,6 +355,7 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
         }
 
         const stepWarnings = e.warnings ?? [];
+
         for (const warning of stepWarnings) {
           const detail =
             warning.message?.constructor === String
@@ -338,6 +363,7 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
               : warning.type?.constructor === String
                 ? String(warning.type)
                 : "warning";
+
           span.addEvent(
             "model.warning",
             omitUndefined({
@@ -375,9 +401,12 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
     onToolCallFinish(e: V6ToolCallFinishEvent) {
       try {
         const endedAt = new Date();
+
         const started =
           toolStarts.get(e.toolCall.toolCallId) ?? new Date(endedAt.getTime() - e.durationMs);
+
         const startedAt = started.getTime() <= endedAt.getTime() ? started : rootStartedAt;
+
         const parentCtx =
           (e.stepNumber != null ? steps.get(e.stepNumber)?.ctx : undefined) ?? rootCtx;
 
@@ -399,7 +428,8 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
         );
 
         if (!e.success) {
-          const message = e.error instanceof Error ? e.error.message : String(e.error);
+          const message = e.error instanceof Error ? e.error.message : unknownErrorMessage(e.error);
+
           const errorType = e.error instanceof Error ? e.error.name : "tool_error";
           span.setStatus({ code: SpanStatusCode.ERROR });
           span.setAttribute("error.type", errorType);
@@ -434,7 +464,9 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
         const inputTokens = stepMetrics.reduce((sum, s) => sum + (s.inputTokens ?? 0), 0);
         const outputTokens = stepMetrics.reduce((sum, s) => sum + (s.outputTokens ?? 0), 0);
         const tokenParts: string[] = [];
+
         if (inputPresent) tokenParts.push(`${inputTokens} in`);
+
         if (outputPresent) tokenParts.push(`${outputTokens} out`);
         const tokenText = tokenParts.length > 0 ? `: ${tokenParts.join(" / ")} tokens` : "";
         const hasError = e.finishReason === "error";
@@ -453,9 +485,11 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
             ...samplingAttributes,
           }),
         );
+
         if (restMetadata) {
           for (const [key, value] of Object.entries(restMetadata)) {
             const attr = value?.constructor === String ? String(value) : jsonAttr(value);
+
             if (attr !== undefined) {
               rootSpan.setAttribute(`td.metadata.${key}`, attr);
             }
@@ -491,6 +525,7 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
           "gen_ai.request.model": model ?? undefined,
           "gen_ai.response.model": responseModel ?? undefined,
         });
+
         for (const s of stepMetrics) {
           const stepAttrs: Attributes = omitUndefined({
             "gen_ai.provider.name": s.provider,
@@ -498,10 +533,14 @@ function createV6Hooks(config: ResolvedConfig, emitter: GenerationEmitter) {
             "gen_ai.response.model": s.responseModel ?? undefined,
             "gen_ai.operation.name": "chat",
           });
+
           emitter.recordDuration(s.durationSec, stepAttrs);
+
           if (s.inputTokens !== null) emitter.recordTokens("input", s.inputTokens, stepAttrs);
+
           if (s.outputTokens !== null) emitter.recordTokens("output", s.outputTokens, stepAttrs);
         }
+
         for (const t of toolMetrics) {
           emitter.recordDuration(t.durationSec, {
             ...metricBase,

--- a/packages/ai/src/integration_v7.ts
+++ b/packages/ai/src/integration_v7.ts
@@ -26,6 +26,7 @@ import {
   SEVERITY_WARN,
   type TelemetryDevEvent,
   type JsonValue,
+  unknownErrorMessage,
 } from "./shared.ts";
 
 type TelemetryDevHook = (event: TelemetryDevEvent) => void | PromiseLike<void>;
@@ -326,6 +327,7 @@ export function createV7Hooks(
 
   const stateOf = (event: TelemetryDevEvent): CallState | undefined => {
     const callId = callIdOf(event);
+
     return callId === undefined ? undefined : calls.get(callId);
   };
 
@@ -333,15 +335,19 @@ export function createV7Hooks(
     const userId = readId(runtimeContext?.userId);
     const sessionId = readId(runtimeContext?.sessionId);
     let restMetadata: Record<string, JsonValue> | undefined;
+
     if (runtimeContext) {
       const rest: Record<string, JsonValue> = {};
+
       for (const [key, value] of Object.entries(runtimeContext)) {
         if (key !== "userId" && key !== "sessionId") {
           rest[key] = value;
         }
       }
+
       restMetadata = Object.keys(rest).length > 0 ? rest : undefined;
     }
+
     return { userId, sessionId, restMetadata };
   };
 
@@ -368,14 +374,17 @@ export function createV7Hooks(
       "user.id": state.userId ?? undefined,
       ...state.samplingAttributes,
     });
+
     if (state.restMetadata) {
       for (const [key, value] of Object.entries(state.restMetadata)) {
         const attr = value?.constructor === String ? String(value) : jsonAttr(value);
+
         if (attr !== undefined) {
           attributes[`td.metadata.${key}`] = attr;
         }
       }
     }
+
     return attributes;
   };
 
@@ -387,15 +396,20 @@ export function createV7Hooks(
         "gen_ai.response.model": s.responseModel ?? undefined,
         "gen_ai.operation.name": s.operation,
       });
+
       emitter.recordDuration(s.durationSec, stepAttrs);
+
       if (s.inputTokens !== null) emitter.recordTokens("input", s.inputTokens, stepAttrs);
+
       if (s.outputTokens !== null) emitter.recordTokens("output", s.outputTokens, stepAttrs);
     }
+
     const metricBase: Attributes = omitUndefined({
       "gen_ai.provider.name": state.provider,
       "gen_ai.request.model": state.model,
       "gen_ai.response.model": state.responseModel ?? undefined,
     });
+
     for (const t of state.toolMetrics) {
       emitter.recordDuration(t.durationSec, {
         ...metricBase,
@@ -428,30 +442,38 @@ export function createV7Hooks(
       } else {
         span.end(endedAt);
       }
+
       state.childSpans.push(span);
     };
+
     for (const step of state.steps.values()) {
       if (step.open) {
         close(step.span);
         step.open = false;
       }
     }
+
     if (state.objectStep) {
       close(state.objectStep.span);
       state.objectStep = undefined;
     }
+
     for (const embed of state.embedSpans.values()) {
       close(embed.span);
     }
+
     state.embedSpans.clear();
+
     if (state.rerankSpan) {
       close(state.rerankSpan.span);
       state.rerankSpan = undefined;
     }
+
     for (const tool of state.toolSpans.values()) {
       close(tool.span);
       state.hasToolSpan = true;
     }
+
     state.toolSpans.clear();
   };
 
@@ -473,15 +495,21 @@ export function createV7Hooks(
         const startedAt = new Date();
 
         let rootInput: JsonValue;
+
         if (opKind === "text") {
           const input: Record<string, JsonValue> = {};
+
           if (e.instructions !== undefined) input.instructions = e.instructions;
+
           if (e.messages !== undefined) input.messages = e.messages;
           rootInput = Object.keys(input).length > 0 ? input : undefined;
         } else if (opKind === "object") {
           const input: Record<string, JsonValue> = {};
+
           if (e.system !== undefined) input.system = e.system;
+
           if (e.prompt !== undefined) input.prompt = e.prompt;
+
           if (e.messages !== undefined) input.messages = e.messages;
           rootInput = Object.keys(input).length > 0 ? input : undefined;
         } else if (opKind === "embed") {
@@ -548,12 +576,14 @@ export function createV7Hooks(
     onStepStart(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7StepStartEvent;
         applyRuntimeContext(state, e.runtimeContext);
         // Open the step (model `chat`) span now so tool calls that finish within this step parent
         // to it. Attributes/finish state land at onStepEnd; the span ends there too.
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "chat",
           {
@@ -568,6 +598,7 @@ export function createV7Hooks(
           },
           state.rootCtx,
         );
+
         state.steps.set(e.stepNumber, {
           span,
           ctx: trace.setSpan(state.rootCtx, span),
@@ -584,11 +615,13 @@ export function createV7Hooks(
     onStepEnd(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7StepEndEvent;
         applyRuntimeContext(state, e.runtimeContext);
         const endedAt = new Date();
         let step = state.steps.get(e.stepNumber);
+
         if (!step) {
           // No matching onStepStart: open the span anchored to the trace start so startTime never
           // exceeds endTime.
@@ -601,6 +634,7 @@ export function createV7Hooks(
             },
             state.rootCtx,
           );
+
           step = {
             span,
             ctx: trace.setSpan(state.rootCtx, span),
@@ -609,8 +643,10 @@ export function createV7Hooks(
           };
           state.steps.set(e.stepNumber, step);
         }
+
         const startedAt =
           step.startedAt.getTime() <= endedAt.getTime() ? step.startedAt : state.rootStartedAt;
+
         const usage = e.usage;
         const inputTokens = usage.inputTokens ?? null;
         const outputTokens = usage.outputTokens ?? null;
@@ -655,6 +691,7 @@ export function createV7Hooks(
               : warning.type?.constructor === String
                 ? String(warning.type)
                 : "warning";
+
           step.span.addEvent(
             "model.warning",
             omitUndefined({
@@ -694,17 +731,21 @@ export function createV7Hooks(
     // OTel context.
     executeLanguageModelCall({ callId, execute }) {
       const state = calls.get(callId);
+
       if (!state) return execute();
+
       const ctx =
         (state.currentStepNumber != null
           ? state.steps.get(state.currentStepNumber)?.ctx
           : undefined) ?? state.rootCtx;
+
       return otelContext.with(ctx, execute);
     },
 
     onToolExecutionStart(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7ToolExecutionStartEvent;
         state.toolStarts.set(e.toolCall.toolCallId, new Date());
@@ -720,34 +761,41 @@ export function createV7Hooks(
     executeTool({ callId, toolCallId, execute }) {
       let ctx: Context | undefined;
       const state = calls.get(callId);
+
       if (state) {
         try {
           const startedAt = state.toolStarts.get(toolCallId) ?? new Date();
+
           const parentCtx =
             (state.currentStepNumber != null
               ? state.steps.get(state.currentStepNumber)?.ctx
               : undefined) ?? state.rootCtx;
+
           const span = emitter.tracer.startSpan(
             "execute_tool",
             { startTime: startedAt, kind: SpanKind.INTERNAL },
             parentCtx,
           );
+
           state.toolSpans.set(toolCallId, { span, startedAt });
           ctx = trace.setSpan(parentCtx, span);
         } catch (err) {
           onError?.(err instanceof Error ? err : String(err));
         }
       }
+
       return ctx ? otelContext.with(ctx, execute) : execute();
     },
 
     onToolExecutionEnd(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7ToolExecutionEndEvent;
         const endedAt = new Date();
         const success = e.toolOutput.type === "tool-result";
+
         const attributes = omitUndefined({
           "gen_ai.operation.name": "execute_tool",
           "gen_ai.tool.name": e.toolCall.toolName,
@@ -764,29 +812,36 @@ export function createV7Hooks(
         // invoked by this ai version), create the span after the fact.
         let span = state.toolSpans.get(e.toolCall.toolCallId)?.span;
         state.toolSpans.delete(e.toolCall.toolCallId);
+
         if (span) {
           span.setAttributes(attributes);
         } else {
           const started =
             state.toolStarts.get(e.toolCall.toolCallId) ??
             new Date(endedAt.getTime() - e.toolExecutionMs);
+
           const startedAt = started.getTime() <= endedAt.getTime() ? started : state.rootStartedAt;
+
           // The event carries no stepNumber: the tool belongs to the currently open step.
           const parentCtx =
             (state.currentStepNumber != null
               ? state.steps.get(state.currentStepNumber)?.ctx
               : undefined) ?? state.rootCtx;
+
           span = emitter.tracer.startSpan(
             "execute_tool",
             { startTime: startedAt, kind: SpanKind.INTERNAL, attributes },
             parentCtx,
           );
         }
+
         state.toolStarts.delete(e.toolCall.toolCallId);
 
         if (e.toolOutput.type === "tool-error") {
           const error = e.toolOutput.error;
-          const message = error instanceof Error ? error.message : String(error);
+
+          const message = error instanceof Error ? error.message : unknownErrorMessage(error);
+
           const errorType = error instanceof Error ? error.name : "tool_error";
           span.setStatus({ code: SpanStatusCode.ERROR });
           span.setAttribute("error.type", errorType);
@@ -811,9 +866,11 @@ export function createV7Hooks(
     onObjectStepStart(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7ObjectStepStartEvent;
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "chat",
           {
@@ -830,6 +887,7 @@ export function createV7Hooks(
           },
           state.rootCtx,
         );
+
         state.objectStep = { span, startedAt };
       } catch (err) {
         onError?.(err instanceof Error ? err : String(err));
@@ -839,6 +897,7 @@ export function createV7Hooks(
     onObjectStepEnd(event) {
       try {
         const state = stateOf(event);
+
         if (!state?.objectStep) return;
         const e = event as V7ObjectStepEndEvent;
         const endedAt = new Date();
@@ -895,9 +954,11 @@ export function createV7Hooks(
     onEmbedStart(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7EmbedCallStartEvent;
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "embeddings",
           {
@@ -912,6 +973,7 @@ export function createV7Hooks(
           },
           state.rootCtx,
         );
+
         state.embedSpans.set(e.embedCallId, { span, startedAt });
       } catch (err) {
         onError?.(err instanceof Error ? err : String(err));
@@ -921,9 +983,11 @@ export function createV7Hooks(
     onEmbedEnd(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const e = event as V7EmbedCallEndEvent;
         const entry = state.embedSpans.get(e.embedCallId);
+
         if (!entry) return;
         const endedAt = new Date();
         const inputTokens = e.usage?.tokens ?? null;
@@ -956,9 +1020,11 @@ export function createV7Hooks(
     onRerankStart(event) {
       try {
         const state = stateOf(event);
+
         if (!state) return;
         const startedAt = new Date();
         const e = event as { provider?: string; modelId?: string };
+
         const span = emitter.tracer.startSpan(
           "rerank",
           {
@@ -973,6 +1039,7 @@ export function createV7Hooks(
           },
           state.rootCtx,
         );
+
         state.rerankSpan = { span, startedAt };
       } catch (err) {
         onError?.(err instanceof Error ? err : String(err));
@@ -982,6 +1049,7 @@ export function createV7Hooks(
     onRerankEnd(event) {
       try {
         const state = stateOf(event);
+
         if (!state?.rerankSpan) return;
         const endedAt = new Date();
         const { span, startedAt } = state.rerankSpan;
@@ -1013,6 +1081,7 @@ export function createV7Hooks(
       try {
         const callId = callIdOf(event);
         const state = callId === undefined ? undefined : calls.get(callId);
+
         if (!state || callId === undefined) return;
         const e = event as V7EndEvent;
         applyRuntimeContext(state, e.runtimeContext);
@@ -1026,7 +1095,9 @@ export function createV7Hooks(
           const inputTokens = e.usage?.inputTokens;
           const outputTokens = e.usage?.outputTokens;
           const tokenParts: string[] = [];
+
           if (inputTokens != null) tokenParts.push(`${inputTokens} in`);
+
           if (outputTokens != null) tokenParts.push(`${outputTokens} out`);
           const tokenText = tokenParts.length > 0 ? `: ${tokenParts.join(" / ")} tokens` : "";
 
@@ -1070,16 +1141,19 @@ export function createV7Hooks(
               "gen_ai.response.finish_reasons": e.finishReason ? [e.finishReason] : undefined,
             }),
           );
+
           // streamObject reports parse/schema-validation failures via `error` on the end event
           // (finishReason may still be "stop"); generateObject throws into onError instead.
           if (e.error !== undefined || e.finishReason === "error") {
             const errorType = e.error instanceof Error ? e.error.name || "error" : "error";
+
             const message =
               e.error !== undefined
                 ? e.error instanceof Error
                   ? e.error.message
                   : (jsonAttr(e.error) ?? "unknown error")
                 : `Generation failed (${e.finishReason})`;
+
             root.setStatus({ code: SpanStatusCode.ERROR });
             root.setAttribute("error.type", errorType);
             root.addEvent("exception", {
@@ -1121,6 +1195,7 @@ export function createV7Hooks(
         const errorEvent = event as { callId?: string; error?: unknown };
         const callId = callIdOf(errorEvent);
         const state = callId === undefined ? undefined : calls.get(callId);
+
         if (!state || callId === undefined) return;
         const error = errorEvent.error;
         const endedAt = new Date();
@@ -1150,6 +1225,7 @@ export function createV7Hooks(
       try {
         const callId = callIdOf(event);
         const state = callId === undefined ? undefined : calls.get(callId);
+
         if (!state || callId === undefined) return;
         const endedAt = new Date();
 

--- a/packages/ai/src/shared.ts
+++ b/packages/ai/src/shared.ts
@@ -15,9 +15,11 @@ export function readId(value: JsonValue): string | null {
   if (typeof value === "string") {
     return value.length > 0 ? value : null;
   }
+
   if (typeof value === "number" || typeof value === "bigint") {
     return String(value);
   }
+
   return null;
 }
 
@@ -26,6 +28,11 @@ export function readId(value: JsonValue): string | null {
 // Applied at both provider read sites so the chain root and its model steps never disagree.
 export function providerLabel(provider: string): string {
   return provider === "gateway" ? "Vercel AI Gateway" : provider;
+}
+
+export function unknownErrorMessage(value: unknown): string {
+  // oxlint-disable-next-line typescript/no-base-to-string -- error payloads must not be JSON-emitted.
+  return String(value);
 }
 
 export const SEVERITY_INFO = 9;

--- a/packages/ai/src/v6.ts
+++ b/packages/ai/src/v6.ts
@@ -1,4 +1,6 @@
 // The ai@6 integration entry ("@telemetry-dev/ai-sdk/v6"). On ai@7, import the package root.
 export { telemetryDev, type TelemetryDevIntegration } from "./integration_v6.ts";
+
 export type { TelemetryDevOptions } from "./config.ts";
+
 export type { TelemetryDevEvent } from "./shared.ts";

--- a/packages/ai/tests/integration.test.ts
+++ b/packages/ai/tests/integration.test.ts
@@ -21,11 +21,15 @@ interface MetricRecord {
   attributes: Attributes;
 }
 
+const requestUrl = (input: string | Request | URL): string =>
+  input instanceof Request ? input.url : input.toString();
+
 // Inject a capturing transport via the otel.ts test seam: spans are captured as the real
 // ReadableSpans the emitter would serialize, and metric points are captured in-process.
 function makeCapture() {
   const spanBatches: ReadableSpan[][] = [];
   const metrics: MetricRecord[] = [];
+
   const overrides = {
     sendSpans: async (spans: ReadableSpan[]) => {
       spanBatches.push(spans);
@@ -37,6 +41,7 @@ function makeCapture() {
       metrics.push({ metric: "tokens", tokenType, value, attributes });
     },
   };
+
   return { spanBatches, metrics, overrides };
 }
 
@@ -44,13 +49,16 @@ const model = { provider: "openai", modelId: "gpt-4o" } as const;
 
 const spanId = (s: ReadableSpan) => s.spanContext().spanId;
 const traceId = (s: ReadableSpan) => s.spanContext().traceId;
+
 const byOperation = (spans: ReadableSpan[], operation: string) =>
   spans.filter((s) => s.attributes["gen_ai.operation.name"] === operation);
+
 const eventNames = (s: ReadableSpan) => s.events.map((ev) => ev.name);
 const event = (s: ReadableSpan, name: string) => s.events.find((ev) => ev.name === name);
 
 test("single-step generateText emits a chat root + chat child with all five token kinds", async () => {
   const { spanBatches, metrics, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -88,6 +96,7 @@ test("single-step generateText emits a chat root + chat child with all five toke
 
   const [root] = byOperation(spans, "chat").filter((s) => s.kind === SpanKind.INTERNAL);
   const child = spans.find((s) => s.kind === SpanKind.CLIENT);
+
   if (!root || !child) throw new Error("missing spans");
 
   // Resource + scope ride along on every span (proves they serialize as gen_ai OTLP).
@@ -125,6 +134,7 @@ test("single-step generateText emits a chat root + chat child with all five toke
     expect(traceId(s)).toMatch(/^[0-9a-f]{32}$/);
     expect(spanId(s)).toMatch(/^[0-9a-f]{16}$/);
   }
+
   // One trace per call: every span shares the root trace id.
   expect(traceId(child)).toBe(traceId(root));
 
@@ -147,10 +157,12 @@ test("single-step generateText emits a chat root + chat child with all five toke
 
 test("multi-step run with a tool yields invoke_agent root and parents the tool to its step", async () => {
   const { spanBatches, metrics, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
   );
+
   const toolCall = { toolCallId: "call_1", toolName: "getWeather", input: { city: "SF" } };
 
   integ.onStart?.({
@@ -191,6 +203,7 @@ test("multi-step run with a tool yields invoke_agent root and parents the tool t
   const chatSteps = byOperation(spans, "chat").filter((s) => s.kind === SpanKind.CLIENT);
   const tool = byOperation(spans, "execute_tool")[0];
   expect(chatSteps).toHaveLength(2);
+
   if (!tool) throw new Error("missing tool span");
 
   // Tools push the root operation to invoke_agent.
@@ -212,15 +225,18 @@ test("multi-step run with a tool yields invoke_agent root and parents the tool t
   // Per-step duration + tokens (x2 steps) and a per-tool duration with operation=execute_tool.
   const durations = metrics.filter((m) => m.metric === "duration");
   expect(durations.filter((m) => m.attributes["gen_ai.operation.name"] === "chat")).toHaveLength(2);
+
   const toolDurations = durations.filter(
     (m) => m.attributes["gen_ai.operation.name"] === "execute_tool",
   );
+
   expect(toolDurations).toHaveLength(1);
   expect(metrics.filter((m) => m.metric === "tokens")).toHaveLength(4);
 });
 
 test("error finishReason marks root and step ERROR and emits an exception event", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -254,10 +270,12 @@ test("error finishReason marks root and step ERROR and emits an exception event"
 
 test("a failed tool call records ERROR status and an exception event", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
   );
+
   const callA = { toolCallId: "a", toolName: "t1", input: { n: 1 } };
   const callB = { toolCallId: "b", toolName: "t2", input: { n: 2 } };
 
@@ -293,10 +311,12 @@ test("a failed tool call records ERROR status and an exception event", async () 
   const tools = byOperation(spans, "execute_tool");
   const step = spans.find((s) => s.kind === SpanKind.CLIENT)!;
   expect(tools).toHaveLength(2);
+
   // Both tools parent to their step.
   for (const t of tools) {
     expect(t.parentSpanContext?.spanId).toBe(spanId(step));
   }
+
   const failed = tools.find((t) => t.attributes["gen_ai.tool.name"] === "t2")!;
   expect(failed.status.code).toBe(SpanStatusCode.ERROR);
   expect(failed.attributes["error.type"]).toBe("Error");
@@ -308,6 +328,7 @@ test("a failed tool call records ERROR status and an exception event", async () 
 
 test("gateway provider is relabeled to Vercel AI Gateway on every span", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -339,9 +360,11 @@ test("gateway provider is relabeled to Vercel AI Gateway on every span", async (
   // Every span that carries a provider carries the product name, never the bare slug.
   const withProvider = spans.filter((s) => "gen_ai.provider.name" in s.attributes);
   expect(withProvider.length).toBeGreaterThanOrEqual(2);
+
   for (const s of withProvider) {
     expect(s.attributes["gen_ai.provider.name"]).toBe("Vercel AI Gateway");
   }
+
   // The upstream model slug is left untouched (it still drives pricing lookups server-side).
   const step = spans.find((s) => s.kind === SpanKind.CLIENT)!;
   expect(step.attributes["gen_ai.request.model"]).toBe("openai/gpt-4o");
@@ -349,6 +372,7 @@ test("gateway provider is relabeled to Vercel AI Gateway on every span", async (
 
 test("non-gateway providers pass through unchanged", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -375,10 +399,12 @@ test("non-gateway providers pass through unchanged", async () => {
 
 test("model warnings become model.warning events at severity 13", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
   );
+
   integ.onStart?.({ model, prompt: "hi" });
   integ.onStepStart?.({ stepNumber: 0, model });
   integ.onStepFinish?.({
@@ -422,6 +448,7 @@ test("no apiKey is a complete no-op (transport never invoked)", async () => {
 
 test("a step with missing usage records no token metric and no summary usage attrs", async () => {
   const { spanBatches, metrics, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -454,6 +481,7 @@ test("a step with missing usage records no token metric and no summary usage att
 test("export failure reaches onError even on the waitUntil path", async () => {
   const errors: unknown[] = [];
   let handed: Promise<unknown> | undefined;
+
   const integ = telemetryDev(
     {
       apiKey: "td_live_test",
@@ -500,10 +528,12 @@ test("spans use each emitter's own transport (no cross-talk on a shared cached c
   const traceCalls: string[] = [];
   const aErrors: unknown[] = [];
   const bErrors: unknown[] = [];
+
   const makeFetch =
     (tag: string): typeof fetch =>
     async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) traceCalls.push(tag);
+      if (requestUrl(url).endsWith("/v1/traces")) traceCalls.push(tag);
+
       return new Response(null, { status: 200 });
     };
 
@@ -515,6 +545,7 @@ test("spans use each emitter's own transport (no cross-talk on a shared cached c
     fetch: makeFetch("A"),
     onError: (e) => aErrors.push(e),
   });
+
   // Second emitter reuses that cached core but supplies fetch B.
   telemetryDev({
     apiKey: "td_live_dup",
@@ -547,15 +578,18 @@ test("spans use each emitter's own transport (no cross-talk on a shared cached c
 test("trace export retries a transient ingest failure", async () => {
   const errors: unknown[] = [];
   let traceCalls = 0;
+
   const integ = telemetryDev({
     apiKey: "td_live_trace_retry",
     environment: "test",
     serviceName: "trace-retry",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) {
+      if (requestUrl(url).endsWith("/v1/traces")) {
         traceCalls += 1;
+
         return new Response(null, { status: traceCalls === 1 ? 503 : 200 });
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -580,15 +614,18 @@ test("trace export retries a transient ingest failure", async () => {
 test("trace export retries a transient network error", async () => {
   const errors: unknown[] = [];
   let traceCalls = 0;
+
   const integ = telemetryDev({
     apiKey: "td_live_trace_network_retry",
     environment: "test",
     serviceName: "trace-network-retry",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) {
+      if (requestUrl(url).endsWith("/v1/traces")) {
         traceCalls += 1;
+
         if (traceCalls === 1) throw new Error("socket closed");
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -614,15 +651,17 @@ test("trace export reports one error after exhausting network failures", async (
   const errors: unknown[] = [];
   let traceCalls = 0;
   const networkError = new Error("socket closed");
+
   const integ = telemetryDev({
     apiKey: "td_live_trace_network_exhausted",
     environment: "test",
     serviceName: "trace-network-exhausted",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) {
+      if (requestUrl(url).endsWith("/v1/traces")) {
         traceCalls += 1;
         throw networkError;
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -648,15 +687,18 @@ test("trace export reports one error after exhausting network failures", async (
 test("trace export does not retry non-retryable ingest failures", async () => {
   const errors: unknown[] = [];
   let traceCalls = 0;
+
   const integ = telemetryDev({
     apiKey: "td_live_trace_no_retry",
     environment: "test",
     serviceName: "trace-no-retry",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) {
+      if (requestUrl(url).endsWith("/v1/traces")) {
         traceCalls += 1;
+
         return new Response(null, { status: 400 });
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -684,15 +726,18 @@ test("trace export does not retry non-retryable ingest failures", async () => {
 test("trace export reports one error after exhausting retryable failures", async () => {
   const errors: unknown[] = [];
   let traceCalls = 0;
+
   const integ = telemetryDev({
     apiKey: "td_live_trace_retry_exhausted",
     environment: "test",
     serviceName: "trace-retry-exhausted",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/traces")) {
+      if (requestUrl(url).endsWith("/v1/traces")) {
         traceCalls += 1;
+
         return new Response(null, { status: 503 });
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -719,10 +764,12 @@ test("trace export reports one error after exhausting retryable failures", async
 
 test("step metrics attribute tokens and duration to each step's own model, not the root", async () => {
   const { metrics, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
   );
+
   const modelB = { provider: "anthropic", modelId: "claude-3-5-sonnet" } as const;
 
   // Root/step 0 run on openai/gpt-4o; step 1 falls back to anthropic/claude (mixed-model run).
@@ -753,9 +800,11 @@ test("step metrics attribute tokens and duration to each step's own model, not t
   // Each step's metric carries the model/provider that actually ran it — not the root's. Before the
   // fix every step inherited the root metricBase (gpt-4o), so the claude point below would not exist.
   const openaiDur = durations.find((m) => m.attributes["gen_ai.request.model"] === "gpt-4o");
+
   const claudeDur = durations.find(
     (m) => m.attributes["gen_ai.request.model"] === "claude-3-5-sonnet",
   );
+
   if (!openaiDur || !claudeDur) throw new Error("missing per-model duration metric");
   expect(openaiDur.attributes["gen_ai.provider.name"]).toBe("openai");
   expect(openaiDur.attributes["gen_ai.response.model"]).toBe("gpt-4o-2024-11-20");
@@ -764,13 +813,17 @@ test("step metrics attribute tokens and duration to each step's own model, not t
 
   // Tokens line up with their owning model too (20 in belongs to claude, 5 out to openai).
   const tokens = metrics.filter((m) => m.metric === "tokens");
+
   const claudeInput = tokens.find(
     (m) => m.tokenType === "input" && m.attributes["gen_ai.request.model"] === "claude-3-5-sonnet",
   );
+
   expect(claudeInput?.value).toBe(20);
+
   const openaiOutput = tokens.find(
     (m) => m.tokenType === "output" && m.attributes["gen_ai.request.model"] === "gpt-4o",
   );
+
   expect(openaiOutput?.value).toBe(5);
 });
 
@@ -778,10 +831,12 @@ test("metrics use each emitter's own transport (no cross-talk on a shared cached
   const metricCalls: string[] = [];
   const aErrors: unknown[] = [];
   const bErrors: unknown[] = [];
+
   const makeFetch =
     (tag: string): typeof fetch =>
     async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/metrics")) metricCalls.push(tag);
+      if (requestUrl(url).endsWith("/v1/metrics")) metricCalls.push(tag);
+
       return new Response(null, { status: 200 });
     };
 
@@ -793,6 +848,7 @@ test("metrics use each emitter's own transport (no cross-talk on a shared cached
     fetch: makeFetch("A"),
     onError: (e) => aErrors.push(e),
   });
+
   // Second emitter reuses that cached core but supplies fetch B.
   telemetryDev({
     apiKey: "td_live_dupm",
@@ -825,15 +881,18 @@ test("metrics use each emitter's own transport (no cross-talk on a shared cached
 test("metric export retries a transient ingest failure", async () => {
   const errors: unknown[] = [];
   let metricCalls = 0;
+
   const integ = telemetryDev({
     apiKey: "td_live_metric_retry",
     environment: "test",
     serviceName: "metric-retry",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/metrics")) {
+      if (requestUrl(url).endsWith("/v1/metrics")) {
         metricCalls += 1;
+
         return new Response(null, { status: metricCalls === 1 ? 503 : 200 });
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => errors.push(e),
@@ -862,15 +921,17 @@ test("a non-OK /v1/metrics response is reported as a failed export, not a succes
   // Capture OTel's global error handler: the metric reader only routes here when the export result
   // is FAILED (code 1). A success (code 0) report — the pre-fix behavior — never reaches it.
   setGlobalErrorHandler((e) => exportErrors.push(e));
+
   try {
     const integ = telemetryDev({
       apiKey: "td_live_metricfail",
       environment: "test",
       serviceName: "metricfail",
       fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-        if (String(url).endsWith("/v1/metrics")) metricCalls += 1;
+        if (requestUrl(url).endsWith("/v1/metrics")) metricCalls += 1;
+
         return new Response(null, {
-          status: String(url).endsWith("/v1/metrics") ? 503 : 200,
+          status: requestUrl(url).endsWith("/v1/metrics") ? 503 : 200,
         });
       },
       onError: (e) => errors.push(e),
@@ -905,6 +966,7 @@ test("a non-OK /v1/metrics response is reported as a failed export, not a succes
 
 test("each step span records its own per-step input messages, not the root input", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -912,6 +974,7 @@ test("each step span records its own per-step input messages, not the root input
 
   const toolCall = { toolCallId: "call_1", toolName: "getWeather", input: { city: "SF" } };
   const step0Messages = [{ role: "user", content: "weather in SF?" }];
+
   // The tool loop appends the assistant tool-call and the tool result before the next step runs, so
   // step 1's request differs from both step 0 and the root input.
   const step1Messages = [
@@ -966,6 +1029,7 @@ test("each step span records its own per-step input messages, not the root input
 
 test("a step finishing without onStepStart omits input messages", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
@@ -989,10 +1053,12 @@ test("a step finishing without onStepStart omits input messages", async () => {
 
 test("calls that share a sessionId share one trace under the session parent", async () => {
   const { spanBatches, overrides } = makeCapture();
+
   const integ = telemetryDev(
     { apiKey: "td_live_test", environment: "test", serviceName: "svc" },
     overrides,
   );
+
   const run = async (sessionId?: string) => {
     integ.onStart?.({ model, prompt: "hi", metadata: sessionId ? { sessionId } : undefined });
     integ.onStepStart?.({ stepNumber: 0, model });
@@ -1006,17 +1072,21 @@ test("calls that share a sessionId share one trace under the session parent", as
     });
     await integ.onFinish?.({ text: "ok", finishReason: "stop" });
   };
+
   await run("s1");
   await run("s1");
   await run();
 
   const session = sessionSpanContext("td_live_test", "s1");
   const [batch1, batch2, batch3] = spanBatches;
+
   for (const s of [...batch1!, ...batch2!]) expect(s.spanContext().traceId).toBe(session.traceId);
+
   for (const batch of [batch1!, batch2!]) {
     const root = batch.find((s) => s.kind === SpanKind.INTERNAL)!;
     expect(root.parentSpanContext?.spanId).toBe(session.spanId);
   }
+
   expect(batch3![0]!.spanContext().traceId).not.toBe(session.traceId);
 });
 
@@ -1027,10 +1097,12 @@ test("v6 exports session spans only when the configured sampler selects them", a
     new TraceIdRatioBasedSampler(0.5),
     { shouldSample: () => ({ decision: SamplingDecision.RECORD }), toString: () => "RecordOnly" },
   ];
+
   for (const root of roots) {
     const sampler = new ParentBasedSampler({ root });
     const { spanBatches, overrides } = makeCapture();
     const errors: unknown[] = [];
+
     const integ = telemetryDev(
       {
         apiKey: "td_live_test",
@@ -1040,10 +1112,13 @@ test("v6 exports session spans only when the configured sampler selects them", a
       },
       overrides,
     );
+
     const expected: string[] = [];
+
     for (let i = 0; i < 20; i++) {
       const sessionId = `session-${i}`;
       const id = sessionSpanContext("td_live_test", sessionId).traceId;
+
       if (
         sampler.shouldSample(ROOT_CONTEXT, id, "chat", SpanKind.INTERNAL, {}, []).decision ===
         SamplingDecision.RECORD_AND_SAMPLED
@@ -1060,6 +1135,7 @@ test("v6 exports session spans only when the configured sampler selects them", a
       });
       await integ.onFinish?.({ text: "ok", finishReason: "stop" });
     }
+
     expect(spanBatches.flat().map(traceId)).toEqual(expected);
     expect(errors).toEqual([]);
   }

--- a/packages/ai/tests/integration_v7.test.ts
+++ b/packages/ai/tests/integration_v7.test.ts
@@ -12,6 +12,11 @@ import { sessionSpanContext } from "@telemetry-dev/otel";
 import { expect, test } from "vitest";
 
 import { telemetryDev } from "../src/index.ts";
+import { unknownErrorMessage } from "../src/shared.ts";
+
+test("unknown errors do not expose structured payloads", () => {
+  expect(unknownErrorMessage({ code: "tool_failed", secret: "private" })).toBe("[object Object]");
+});
 
 interface MetricRecord {
   metric: "duration" | "tokens";
@@ -23,6 +28,7 @@ interface MetricRecord {
 function makeCapture() {
   const spanBatches: ReadableSpan[][] = [];
   const metrics: MetricRecord[] = [];
+
   const overrides = {
     sendSpans: async (spans: ReadableSpan[]) => {
       spanBatches.push(spans);
@@ -34,6 +40,7 @@ function makeCapture() {
       metrics.push({ metric: "tokens", tokenType, value, attributes });
     },
   };
+
   return { spanBatches, metrics, overrides };
 }
 
@@ -42,8 +49,10 @@ const baseOptions = { apiKey: "td_live_test", environment: "test", serviceName: 
 
 const spanId = (s: ReadableSpan) => s.spanContext().spanId;
 const traceId = (s: ReadableSpan) => s.spanContext().traceId;
+
 const byOperation = (spans: ReadableSpan[], operation: string) =>
   spans.filter((s) => s.attributes["gen_ai.operation.name"] === operation);
+
 const event = (s: ReadableSpan, name: string) => s.events.find((ev) => ev.name === name);
 
 test("single-step generateText flushes root+child with aggregated onEnd usage and responseTime duration", async () => {
@@ -219,10 +228,12 @@ test("runtimeContext refreshes user metadata but keeps the starting session", as
   const session = sessionSpanContext("td_live_test", "session-start");
 
   expect(root.parentSpanContext?.spanId).toBe(session.spanId);
+
   for (const span of spans) {
     expect(traceId(span)).toBe(session.traceId);
     expect(span.attributes["gen_ai.conversation.id"]).toBe("session-start");
   }
+
   expect(root.attributes["user.id"]).toBe("user-step");
   expect(root.attributes["td.metadata.plan"]).toBe("pro");
 });
@@ -230,6 +241,7 @@ test("runtimeContext refreshes user metadata but keeps the starting session", as
 test("missing or empty runtimeContext emits no identity or metadata attributes", async () => {
   const { spanBatches, overrides } = makeCapture();
   const integ = telemetryDev(baseOptions, overrides);
+
   const cases = [
     { callId: "call-runtime-absent", runtimeContext: undefined },
     { callId: "call-runtime-empty", runtimeContext: {} },
@@ -237,6 +249,7 @@ test("missing or empty runtimeContext emits no identity or metadata attributes",
 
   for (const { callId, runtimeContext } of cases) {
     const toolCall = { toolCallId: `${callId}-tool`, toolName: "lookup", input: { q: callId } };
+
     const startEvent = {
       callId,
       operationId: "ai.generateText",
@@ -245,6 +258,7 @@ test("missing or empty runtimeContext emits no identity or metadata attributes",
       messages: [{ role: "user", content: callId }],
       runtimeContext,
     };
+
     integ.onStart?.(startEvent);
     integ.onStepStart?.({ callId, stepNumber: 0 });
     integ.onToolExecutionEnd?.({
@@ -271,8 +285,10 @@ test("missing or empty runtimeContext emits no identity or metadata attributes",
   }
 
   expect(spanBatches).toHaveLength(2);
+
   for (const spans of spanBatches) {
     expect(spans).toHaveLength(3);
+
     for (const span of spans) {
       expect(span.attributes["user.id"]).toBeUndefined();
       expect(span.attributes["gen_ai.conversation.id"]).toBeUndefined();
@@ -287,6 +303,7 @@ test("onStepFinish is not implemented, so ai@7's step-end fan-out cannot double 
   const { spanBatches, metrics, overrides } = makeCapture();
   const integ = telemetryDev(baseOptions, overrides);
   const callId = "call-dedupe";
+
   const stepResult = {
     callId,
     stepNumber: 0,
@@ -339,7 +356,9 @@ test("two interleaved callIds on one integration produce disjoint traces per flu
       modelId: "gpt-4o",
       functionId: fn,
     });
+
   const stepStart = (callId: string) => integ.onStepStart?.({ callId, stepNumber: 0 });
+
   const stepEnd = (callId: string, text: string) =>
     integ.onStepEnd?.({
       callId,
@@ -350,6 +369,7 @@ test("two interleaved callIds on one integration produce disjoint traces per flu
       response: { id: `resp-${callId}`, modelId: "gpt-4o" },
       usage: { inputTokens: 1, outputTokens: 1 },
     });
+
   const end = (callId: string, text: string) =>
     integ.onEnd?.({
       callId,
@@ -371,7 +391,9 @@ test("two interleaved callIds on one integration produce disjoint traces per flu
 
   const batchFor = (fn: string) => {
     const batch = spanBatches.find((spans) => spans.some((s) => s.name === fn));
+
     if (!batch) throw new Error(`missing batch for ${fn}`);
+
     return batch;
   };
 
@@ -385,13 +407,16 @@ test("two interleaved callIds on one integration produce disjoint traces per flu
   const traceA = traceId(batchA[0]!);
   const traceB = traceId(batchB[0]!);
   expect(traceA).not.toBe(traceB);
+
   for (const s of batchA) expect(traceId(s)).toBe(traceA);
+
   for (const s of batchB) expect(traceId(s)).toBe(traceB);
 });
 
 test("calls that share a sessionId share one trace under the session parent", async () => {
   const { spanBatches, overrides } = makeCapture();
   const integ = telemetryDev(baseOptions, overrides);
+
   const run = async (callId: string, sessionId?: string) => {
     integ.onStart?.({
       callId,
@@ -418,17 +443,21 @@ test("calls that share a sessionId share one trace under the session parent", as
       usage: { inputTokens: 1, outputTokens: 1 },
     });
   };
+
   await run("turn-1", "s1");
   await run("turn-2", "s1");
   await run("solo");
 
   const session = sessionSpanContext(baseOptions.apiKey, "s1");
   const [batch1, batch2, batch3] = spanBatches;
+
   for (const s of [...batch1!, ...batch2!]) expect(traceId(s)).toBe(session.traceId);
+
   for (const batch of [batch1!, batch2!]) {
     const root = batch.find((s) => s.kind === SpanKind.INTERNAL)!;
     expect(root.parentSpanContext?.spanId).toBe(session.spanId);
   }
+
   expect(traceId(batch3![0]!)).not.toBe(session.traceId);
   expect(batch3!.find((s) => s.kind === SpanKind.INTERNAL)!.parentSpanContext).toBeUndefined();
 });
@@ -555,6 +584,7 @@ test("tool success and tool error spans parent to the open step with execute_too
   const toolDurations = metrics.filter(
     (m) => m.metric === "duration" && m.attributes["gen_ai.operation.name"] === "execute_tool",
   );
+
   expect(toolDurations.map((m) => m.value).sort((a, b) => a - b)).toEqual([0.4, 0.8]);
 });
 
@@ -712,11 +742,13 @@ test("embedMany flushes two embedding children and aggregated root usage on onEn
   expect(children).toHaveLength(2);
   expect(root.attributes["gen_ai.operation.name"]).toBe("embeddings");
   expect(root.attributes["gen_ai.usage.input_tokens"]).toBe(8);
+
   for (const child of children) {
     expect(child.name).toBe("embeddings");
     expect(child.attributes["gen_ai.operation.name"]).toBe("embeddings");
     expect(child.attributes["gen_ai.usage.input_tokens"]).toBeDefined();
   }
+
   expect(
     children.map((s) => Number(s.attributes["gen_ai.usage.input_tokens"])).sort((a, b) => a - b),
   ).toEqual([3, 5]);
@@ -727,6 +759,7 @@ test("embedMany flushes two embedding children and aggregated root usage on onEn
       m.tokenType === "input" &&
       m.attributes["gen_ai.operation.name"] === "embeddings",
   );
+
   expect(embedTokens).toHaveLength(2);
   expect(embedTokens.map((m) => m.value).sort((a, b) => a - b)).toEqual([3, 5]);
 });
@@ -771,6 +804,7 @@ test("rerank success flushes root and child spans with rerank duration metrics",
   const duration = metrics.find(
     (m) => m.metric === "duration" && m.attributes["gen_ai.operation.name"] === "rerank",
   )!;
+
   expect(duration.value).toBeGreaterThanOrEqual(0);
   expect(duration.attributes["gen_ai.provider.name"]).toBe("cohere");
   expect(duration.attributes["gen_ai.request.model"]).toBe("rerank-english-v3.0");
@@ -928,19 +962,24 @@ test("v7 exports session spans only when the configured sampler selects them", a
     new TraceIdRatioBasedSampler(0.5),
     { shouldSample: () => ({ decision: SamplingDecision.RECORD }), toString: () => "RecordOnly" },
   ];
+
   for (const root of roots) {
     const sampler = new ParentBasedSampler({ root });
     const { spanBatches, overrides } = makeCapture();
     const errors: unknown[] = [];
+
     const integ = telemetryDev(
       { ...baseOptions, sampler, onError: (error) => errors.push(error) },
       overrides,
     );
+
     const expected: string[] = [];
+
     for (let i = 0; i < 20; i++) {
       const callId = `sample-${i}`;
       const sessionId = `session-${i}`;
       const id = sessionSpanContext("td_live_test", sessionId).traceId;
+
       if (
         sampler.shouldSample(ROOT_CONTEXT, id, "chat", SpanKind.INTERNAL, {}, []).decision ===
         SamplingDecision.RECORD_AND_SAMPLED
@@ -965,6 +1004,7 @@ test("v7 exports session spans only when the configured sampler selects them", a
       });
       await integ.onEnd?.({ callId, text: "ok", finishReason: "stop" });
     }
+
     expect(spanBatches.flat().map(traceId)).toEqual(expected);
     expect(errors).toEqual([]);
   }

--- a/packages/ai/tests/type_conformance.test.ts
+++ b/packages/ai/tests/type_conformance.test.ts
@@ -10,8 +10,11 @@ import { telemetryDev as telemetryDevV6 } from "../src/v6.ts";
 // was removed in v7; v7 `Telemetry` does not exist in v6). A break here fails typecheck, not
 // runtime.
 const integ = telemetryDev({ apiKey: "td_live_t" });
+
 void (integ satisfies Telemetry);
+
 const integV6 = telemetryDevV6({ apiKey: "td_live_t" });
+
 void (integV6 satisfies TelemetryIntegration);
 
 test("each entry's telemetryDev satisfies its ai major's integration type", () => {

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -14,38 +14,54 @@ const WRAPPED_ORIGINAL = Symbol("telemetry.dev.anthropic.original");
 const wrappedClients = new WeakSet<object>();
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 interface OpaqueValue {}
+
 type Value = string | number | boolean | null | undefined | OpaqueValue;
+
+function unknownErrorMessage(value: Value): string {
+  // oxlint-disable-next-line typescript/no-base-to-string -- error payloads must not be JSON-emitted.
+  return String(value);
+}
+
 interface ValueRecord {
   [key: string]: JsonValue | undefined;
   [key: symbol]: JsonValue | undefined;
 }
+
 interface CallableRecord {
   [key: string]: JsonValue | AnyFunction | undefined;
 }
+
 type AnyFunction = (...args: never[]) => OpaqueValue;
+
 type WrappedFunction = AnyFunction & {
   [WRAPPED]?: true;
   [WRAPPED_ORIGINAL]?: AnyFunction;
 };
+
 type ProviderResolver = (resource: Value) => string;
 
 interface AnthropicClient {
   messages: object;
 }
+
 interface RequestMapping {
   name: string;
   fields: StartSpanOptions;
 }
+
 interface WrappedResponse<T> {
   data: T;
   response: Response;
   request_id: string | null;
 }
+
 interface ToolBlockState {
   data: ValueRecord;
   inputJson: string;
 }
+
 interface StreamState {
   blocks: Map<number, ValueRecord | ToolBlockState>;
   usage?: SpanFields["usage"];
@@ -54,34 +70,48 @@ interface StreamState {
 
 function asRecord<T>(value: T): (T & ValueRecord) | undefined {
   if (value === null || value === undefined || value instanceof Function) return undefined;
+
   return Object(value) === value ? (value as T & ValueRecord) : undefined;
 }
+
 function readString<T>(value: T): string | undefined {
   return String(value) === value ? (value as string) : undefined;
 }
+
 function readNumber<T>(value: T): number | undefined {
   return Number(value) === value ? (value as number) : undefined;
 }
+
 function compactUsage(usage: SpanFields["usage"]): SpanFields["usage"] {
   if (!usage) return undefined;
+
   return Object.values(usage).some((value) => value !== undefined) ? usage : undefined;
 }
+
 function stopSequences<T>(value: T): string[] | undefined {
   const single = readString(value);
+
   if (single !== undefined) return [single];
+
   if (!Array.isArray(value)) return undefined;
+
   const strings = value.flatMap((item) => {
     const string = readString(item);
+
     return string === undefined ? [] : [string];
   });
+
   return strings.length > 0 ? strings : undefined;
 }
+
 function messagesRequest(body: ValueRecord): RequestMapping {
   const model = readString(body.model);
+
   const input =
     body.tools !== undefined || body.tool_choice !== undefined
       ? { messages: body.messages, tools: body.tools, tool_choice: body.tool_choice }
       : body.messages;
+
   return {
     name: `chat ${model ?? "unknown"}`,
     fields: {
@@ -97,9 +127,11 @@ function messagesRequest(body: ValueRecord): RequestMapping {
     },
   };
 }
+
 function messagesUsage<T>(usage: T): SpanFields["usage"] {
   const record = asRecord(usage);
   const details = asRecord(record?.output_tokens_details);
+
   return compactUsage({
     inputTokens: readNumber(record?.input_tokens),
     outputTokens: readNumber(record?.output_tokens),
@@ -108,11 +140,13 @@ function messagesUsage<T>(usage: T): SpanFields["usage"] {
     reasoningOutputTokens: readNumber(details?.thinking_tokens),
   });
 }
+
 function mergeUsage(
   current: SpanFields["usage"],
   incoming: SpanFields["usage"],
 ): SpanFields["usage"] {
   if (!incoming) return current;
+
   return compactUsage({
     inputTokens: incoming.inputTokens ?? current?.inputTokens,
     outputTokens: incoming.outputTokens ?? current?.outputTokens,
@@ -122,9 +156,11 @@ function mergeUsage(
     reasoningOutputTokens: incoming.reasoningOutputTokens ?? current?.reasoningOutputTokens,
   });
 }
+
 function messagesResponse<T>(response: T): SpanFields {
   const record: ValueRecord = asRecord(response) ?? {};
   const role = readString(record.role) ?? "assistant";
+
   return {
     responseModel: readString(record.model),
     responseId: readString(record.id),
@@ -133,11 +169,14 @@ function messagesResponse<T>(response: T): SpanFields {
     usage: messagesUsage(record.usage),
   };
 }
+
 function constructorName<T>(value: T): string | undefined {
   if (value === null || value === undefined) return undefined;
   const ctor = Object(value).constructor;
+
   return ctor instanceof Function ? ctor.name : undefined;
 }
+
 function providerForClient<T>(client: T): string {
   switch (constructorName(client)) {
     case "AnthropicBedrock":
@@ -150,20 +189,27 @@ function providerForClient<T>(client: T): string {
       return "anthropic";
   }
 }
+
 function providerForResource<T>(resource: T): string {
   return providerForClient(asRecord(resource)?._client);
 }
+
 function isWrapped<T>(fn: T): fn is T & WrappedFunction {
   if (!(fn instanceof Function)) return false;
+
   return (fn as WrappedFunction)[WRAPPED] === true;
 }
+
 function markWrapped<T extends WrappedFunction>(fn: T, original: AnyFunction): T {
   Object.defineProperty(fn, WRAPPED, { value: true });
   Object.defineProperty(fn, WRAPPED_ORIGINAL, { value: original });
+
   return fn;
 }
+
 function endOnce(span: SpanHandle): (fields?: SpanFields) => void {
   let ended = false;
+
   return (fields?: SpanFields) => {
     if (ended) return;
     ended = true;
@@ -176,6 +222,7 @@ type TracedResult<T> = Promise<T> & {
   withResponse(): Promise<WrappedResponse<T>>;
   _thenUnwrap<U>(transform: (data: T, ...args: Value[]) => U): TracedResult<U>;
 };
+
 interface TracePromiseContext {
   end: (fields?: SpanFields) => void;
   span: SpanHandle;
@@ -183,9 +230,11 @@ interface TracePromiseContext {
   streaming: boolean;
   mapResponse: (response: Value) => SpanFields;
 }
+
 interface StreamLike<T> extends AsyncIterable<T> {
   controller: AbortController;
 }
+
 interface InnerAPIPromise {
   then: Promise<Value>["then"];
   catch: Promise<Value>["catch"];
@@ -193,40 +242,55 @@ interface InnerAPIPromise {
   asResponse?: () => Promise<Response>;
   _thenUnwrap?: <U>(transform: (data: Value, ...args: Value[]) => U) => InnerAPIPromise;
 }
+
 function mapRawResponse(response: Response): SpanFields {
   const fields: SpanFields = { attributes: { "http.response.status_code": response.status } };
   const requestId = response.headers.get("request-id");
+
   if (requestId) fields.responseId = requestId;
+
   return fields;
 }
+
 function finalizeParsedValue(value: Value, ctx: TracePromiseContext): Value {
   if (ctx.streaming) {
     const wrapped = wrapStream(value, ctx.span, ctx.startedAt, ctx.end);
+
     if (wrapped !== value) return wrapped;
   }
+
   ctx.end(ctx.mapResponse(value));
+
   return value;
 }
+
 function rejectMissing(method: string): Promise<never> {
   return Promise.reject(new TypeError(`wrapped result has no ${method}`));
 }
+
 function makeTracedPromise<T>(inner: InnerAPIPromise, ctx: TracePromiseContext): TracedResult<T> {
   const source = inner;
   const originalThen = source.then.bind(source);
   const originalAsResponse = source.asResponse?.bind(source);
   const originalThenUnwrap = source._thenUnwrap?.bind(source);
+
   const handleError = (error: Value): never => {
-    ctx.end({ error: error instanceof Error ? error : new Error(String(error)) });
+    ctx.end({
+      error: error instanceof Error ? error : new Error(unknownErrorMessage(error)),
+    });
     throw error;
   };
+
   const onParsed = (value: Value) => finalizeParsedValue(value, ctx) as T;
   const parsed = () => originalThen(onParsed, handleError);
   let traced: TracedResult<T>;
+
   if (constructorName(source) === "APIPromise") {
     traced = source as TracedResult<T>;
   } else {
     traced = new Promise<T>((resolve, reject) => parsed().then(resolve, reject)) as TracedResult<T>;
   }
+
   if (traced === source) {
     // oxlint-disable-next-line unicorn/no-thenable -- preserve Anthropic APIPromise subclass contract.
     traced.then = ((onfulfilled, onrejected) =>
@@ -234,24 +298,31 @@ function makeTracedPromise<T>(inner: InnerAPIPromise, ctx: TracePromiseContext):
     traced.catch = ((onrejected) => parsed().catch(onrejected)) as TracedResult<T>["catch"];
     traced.finally = ((onfinally) => parsed().finally(onfinally)) as TracedResult<T>["finally"];
   }
+
   traced.asResponse = () => {
     if (!originalAsResponse) return rejectMissing("asResponse");
+
     return originalAsResponse().then((response) => {
       ctx.end(mapRawResponse(response));
+
       return response;
     }, handleError);
   };
+
   traced.withResponse = () => {
     if (!originalAsResponse) return rejectMissing("withResponse");
+
     return Promise.all([parsed(), originalAsResponse()]).then(
       ([data, response]) => ({ data, response, request_id: response.headers.get("request-id") }),
       handleError,
     );
   };
+
   traced._thenUnwrap = <U>(transform: (data: T, ...args: Value[]) => U): TracedResult<U> => {
     if (!originalThenUnwrap) {
       return rejectMissing("_thenUnwrap") as Promise<never> & TracedResult<U>;
     }
+
     return makeTracedPromise(
       originalThenUnwrap((data, ...args) => {
         return transform(data as T, ...args);
@@ -259,12 +330,14 @@ function makeTracedPromise<T>(inner: InnerAPIPromise, ctx: TracePromiseContext):
       ctx,
     );
   };
+
   return traced;
 }
 
 function isToolBlockState(value: ValueRecord | ToolBlockState): value is ToolBlockState {
   return "data" in value && "inputJson" in value;
 }
+
 function setFirstStreamUpdate(
   span: SpanHandle,
   startedAt: number,
@@ -279,21 +352,27 @@ function setFirstStreamUpdate(
     responseModel: fields.responseModel,
   });
 }
+
 function parseToolInput(inputJson: string): JsonValue {
   if (inputJson.length === 0) return {};
+
   try {
     return JSON.parse(inputJson);
   } catch {
     return inputJson;
   }
 }
+
 function finalizeBlock(block: ValueRecord | ToolBlockState) {
   if (!isToolBlockState(block)) return block;
   const input = parseToolInput(block.inputJson);
+
   if (block.data.input === undefined) return { ...block.data, input };
+
   if (block.inputJson.length === 0) return block.data;
   const existingInput: ValueRecord | undefined = asRecord(block.data.input);
   const parsedInput: ValueRecord | undefined = asRecord(input);
+
   return {
     ...block.data,
     input:
@@ -302,105 +381,143 @@ function finalizeBlock(block: ValueRecord | ToolBlockState) {
         : input,
   };
 }
+
 function streamOutput(state: StreamState): ValueRecord[] | undefined {
   if (state.blocks.size === 0) return undefined;
+
   const content = [...state.blocks.entries()]
     .sort(([left], [right]) => left - right)
     .map(([, block]) => finalizeBlock(block));
+
   return [{ role: "assistant", content: content as JsonValue[] }];
 }
+
 function streamPartialFields(state: StreamState): SpanFields {
   return { output: streamOutput(state), usage: state.usage, finishReason: state.finishReason };
 }
+
 function recordContentBlockStart(event: ValueRecord, state: StreamState): void {
   const index = readNumber(event.index) ?? state.blocks.size;
   const contentBlock: ValueRecord = asRecord(event.content_block) ?? {};
   const type = readString(contentBlock.type);
+
   if (type === "text") {
     state.blocks.set(index, { type, text: readString(contentBlock.text) ?? "" });
+
     return;
   }
+
   if (type === "tool_use" || type === "server_tool_use") {
     const data = { ...contentBlock, type };
     state.blocks.set(index, { data, inputJson: "" });
+
     return;
   }
+
   if (type === "thinking") {
     state.blocks.set(index, { type, thinking: readString(contentBlock.thinking) ?? "" });
+
     return;
   }
+
   state.blocks.set(index, { ...contentBlock });
 }
+
 function blockForDelta(
   index: number,
   deltaType: string | undefined,
   state: StreamState,
 ): ValueRecord | ToolBlockState {
   const existing = state.blocks.get(index);
+
   if (existing) return existing;
+
   if (deltaType === "input_json_delta") {
     const block = { data: { type: "tool_use" }, inputJson: "" };
     state.blocks.set(index, block);
+
     return block;
   }
+
   const block =
     deltaType === "thinking_delta"
       ? { type: "thinking", thinking: "" }
       : { type: "text", text: "" };
+
   state.blocks.set(index, block);
+
   return block;
 }
+
 function appendStringField(target: ValueRecord, key: string, value: string | undefined): void {
   if (value === undefined) return;
   const existing = readString(target[key]) ?? "";
   target[key] = `${existing}${value}`;
 }
+
 function appendArrayField(target: ValueRecord, key: string, value: JsonValue | undefined): void {
   if (value === undefined) return;
   const existing = Array.isArray(target[key]) ? target[key] : [];
   target[key] = [...existing, value];
 }
+
 function recordContentBlockDelta(event: ValueRecord, state: StreamState): void {
   const index = readNumber(event.index) ?? 0;
   const delta: ValueRecord = asRecord(event.delta) ?? {};
   const deltaType = readString(delta.type);
   const block = blockForDelta(index, deltaType, state);
+
   if (deltaType === "input_json_delta") {
     if (isToolBlockState(block)) block.inputJson += readString(delta.partial_json) ?? "";
+
     return;
   }
+
   const data = isToolBlockState(block) ? block.data : block;
+
   if (deltaType === "text_delta") appendStringField(data, "text", readString(delta.text));
+
   if (deltaType === "citations_delta") appendArrayField(data, "citations", delta.citation);
+
   if (deltaType === "thinking_delta")
     appendStringField(data, "thinking", readString(delta.thinking));
+
   if (deltaType === "signature_delta" && delta.signature !== undefined)
     data.signature = delta.signature;
 }
+
 function recordStreamEvent<T>(event: T, state: StreamState): SpanFields {
   const record: ValueRecord = asRecord(event) ?? {};
   const type = readString(record.type);
   const fields: SpanFields = {};
+
   if (type === "message_start") {
     const message: ValueRecord = asRecord(record.message) ?? {};
     fields.responseId = readString(message.id);
     fields.responseModel = readString(message.model);
     state.usage = mergeUsage(state.usage, messagesUsage(message.usage));
   }
+
   if (type === "content_block_start") recordContentBlockStart(record, state);
+
   if (type === "content_block_delta") recordContentBlockDelta(record, state);
+
   if (type === "message_delta") {
     const delta = asRecord(record.delta) ?? {};
     state.finishReason = readString(delta.stop_reason) ?? state.finishReason;
     state.usage = mergeUsage(state.usage, messagesUsage(record.usage));
   }
+
   return fields;
 }
+
 function isStreamLike<T>(value: T): value is T & StreamLike<Value> {
   const stream = asRecord(value);
+
   if (!stream) return false;
   const controller = asRecord(stream.controller);
   const signal = asRecord(controller?.signal);
+
   if (
     !controller ||
     !(controller.abort instanceof Function) ||
@@ -409,8 +526,10 @@ function isStreamLike<T>(value: T): value is T & StreamLike<Value> {
     !(signal.addEventListener instanceof Function)
   )
     return false;
+
   return stream[Symbol.asyncIterator] instanceof Function;
 }
+
 function createObservedMessagesStream(
   source: StreamLike<Value>,
   span: SpanHandle,
@@ -420,6 +539,7 @@ function createObservedMessagesStream(
   const state: StreamState = { blocks: new Map() };
   let consumed = false;
   const signal = source.controller.signal;
+
   const endAborted = () => {
     if (consumed) return;
     end({
@@ -427,12 +547,15 @@ function createObservedMessagesStream(
       error: signal.reason instanceof Error ? signal.reason : new Error("Request aborted"),
     });
   };
+
   if (signal.aborted) endAborted();
   else signal.addEventListener("abort", endAborted, { once: true });
+
   async function* iterator() {
     consumed = true;
     const sawFirst = { value: false };
     let terminalError: Value;
+
     try {
       for await (const event of source) {
         const receivedAt = performance.now();
@@ -447,12 +570,16 @@ function createObservedMessagesStream(
       throw error;
     } finally {
       const fields = streamPartialFields(state);
+
       if (terminalError !== undefined)
         fields.error =
-          terminalError instanceof Error ? terminalError : new Error(String(terminalError));
+          terminalError instanceof Error
+            ? terminalError
+            : new Error(unknownErrorMessage(terminalError));
       end(fields);
     }
   }
+
   return new Stream(() => iterator(), source.controller);
 }
 
@@ -479,8 +606,10 @@ function wrapStream<T>(
   end: (fields?: SpanFields) => void,
 ): T | Stream<Value> {
   if (!isStreamLike(value)) return value;
+
   return createObservedMessagesStream(value, span, startedAt, end);
 }
+
 function wrapCreate<Fn extends AnyFunction>(
   original: Fn,
   mapRequest: (body: ValueRecord) => RequestMapping,
@@ -488,6 +617,7 @@ function wrapCreate<Fn extends AnyFunction>(
   provider: ProviderResolver,
 ): Fn {
   if (isWrapped(original)) return original;
+
   const wrapped: WrappedFunction = function (this: Value, ...args: Value[]): OpaqueValue {
     const body: ValueRecord = asRecord(args[0]) ?? {};
     const streaming = body.stream === true;
@@ -495,8 +625,10 @@ function wrapCreate<Fn extends AnyFunction>(
     const span = startSpan(request.name, { ...request.fields, provider: provider(this) });
     const end = endOnce(span);
     const startedAt = Date.now();
+
     try {
       const result = original.apply(this, args as never[]);
+
       return makeTracedPromise(result as InnerAPIPromise, {
         end,
         span,
@@ -509,8 +641,10 @@ function wrapCreate<Fn extends AnyFunction>(
       throw error;
     }
   };
+
   return markWrapped(wrapped, original) as AnyFunction & Fn;
 }
+
 function patchInstanceMethod<T extends ValueRecord>(
   target: T,
   key: keyof T,
@@ -519,8 +653,10 @@ function patchInstanceMethod<T extends ValueRecord>(
   provider: string,
 ): void {
   const current = target[key];
+
   if (isWrapped(current) && Object.hasOwn(target, key)) return;
   const original = isWrapped(current) ? current[WRAPPED_ORIGINAL] : current;
+
   if (!(original instanceof Function)) return;
   const callable = original as AnyFunction;
   target[key] = wrapCreate(
@@ -530,6 +666,7 @@ function patchInstanceMethod<T extends ValueRecord>(
     () => provider,
   ) as AnyFunction & T[keyof T];
 }
+
 function patchPrototype(
   klass: { prototype: object },
   key: string,
@@ -538,8 +675,11 @@ function patchPrototype(
 ): () => void {
   const prototype = klass.prototype as CallableRecord;
   const original = prototype[key];
+
   if (!(original instanceof Function) || isWrapped(original)) return () => {};
+
   prototype[key] = wrapCreate(original, request, response, providerForResource);
+
   return () => {
     prototype[key] = original;
   };
@@ -552,18 +692,23 @@ export function wrapAnthropic<T extends AnthropicClient>(client: T): T {
   if (wrappedClients.has(client)) return client;
   const provider = providerForClient(client);
   const messages = asRecord(client.messages);
+
   if (messages)
     patchInstanceMethod(messages, "create", messagesRequest, messagesResponse, provider);
   wrappedClients.add(client);
+
   return client;
 }
+
 export function instrumentAnthropic(): void {
   if (installed) return;
   restorePatches = [patchPrototype(Messages, "create", messagesRequest, messagesResponse)];
   installed = true;
 }
+
 export function uninstrumentAnthropic(): void {
   if (!installed) return;
+
   for (const restore of restorePatches.reverse()) restore();
   restorePatches = [];
   installed = false;

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -435,8 +435,11 @@ function createObservedMessagesStream(
     let terminalError: Value;
     try {
       for await (const event of source) {
+        const receivedAt = performance.now();
         const fields = recordStreamEvent(event, state);
         setFirstStreamUpdate(span, startedAt, sawFirst, fields);
+
+        if (streamEventHasOutput(event)) span.recordOutputChunk?.(receivedAt);
         yield event;
       }
     } catch (error) {
@@ -452,6 +455,23 @@ function createObservedMessagesStream(
   }
   return new Stream(() => iterator(), source.controller);
 }
+
+function streamEventHasOutput(event: unknown): boolean {
+  const record = asRecord(event);
+  const type = record?.type;
+
+  if (!record || (type !== "content_block_start" && type !== "content_block_delta")) return false;
+  const value = asRecord(type === "content_block_delta" ? record.delta : record.content_block);
+  const input = asRecord(value?.input);
+
+  return (
+    [value?.text, value?.thinking, value?.partial_json].some(
+      (part) => typeof part === "string" && part.length > 0,
+    ) ||
+    (input !== undefined && Object.keys(input).length > 0)
+  );
+}
+
 function wrapStream<T>(
   value: T,
   span: SpanHandle,

--- a/packages/anthropic/tests/anthropic.test.ts
+++ b/packages/anthropic/tests/anthropic.test.ts
@@ -9,6 +9,7 @@ const SPAN_STATUS_UNSET = 0;
 const SPAN_STATUS_ERROR = 2;
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -21,6 +22,7 @@ interface CapturedRequest {
 
 function asRecord<T>(value: T): (T & JsonRecord) | undefined {
   if (value === null || value === undefined || Array.isArray(value)) return undefined;
+
   return Object(value) === value ? (value as T & JsonRecord) : undefined;
 }
 
@@ -47,8 +49,12 @@ function jsonErrorResponse(status: number, message: string): Response {
 
 function namedSseResponse(events: JsonRecord[]): Response {
   const body = events
-    .map((event) => `event: ${String(event.type)}\ndata: ${JSON.stringify(event)}\n\n`)
+    .map(
+      (event) =>
+        `event: ${typeof event.type === "string" ? event.type : ""}\ndata: ${JSON.stringify(event)}\n\n`,
+    )
     .join("");
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream", "request-id": "req_stream" },
@@ -63,19 +69,26 @@ interface CountedResponse {
 
 function countedSseResponse(events: JsonRecord[]): CountedResponse {
   const encoder = new TextEncoder();
+
   const parts = events.map(
-    (event) => `event: ${String(event.type)}\ndata: ${JSON.stringify(event)}\n\n`,
+    (event) =>
+      `event: ${typeof event.type === "string" ? event.type : ""}\ndata: ${JSON.stringify(event)}\n\n`,
   );
+
   let index = 0;
   let pulled = 0;
+
   const body = new ReadableStream<Uint8Array>(
     {
       pull(controller) {
         const part = parts[index];
+
         if (part === undefined) {
           controller.close();
+
           return;
         }
+
         index += 1;
         pulled += 1;
         controller.enqueue(encoder.encode(part));
@@ -83,6 +96,7 @@ function countedSseResponse(events: JsonRecord[]): CountedResponse {
     },
     { highWaterMark: 0 },
   );
+
   return {
     response: new Response(body, {
       status: 200,
@@ -98,11 +112,15 @@ async function parseRequestBody(
   init: RequestInit | undefined,
 ): Promise<JsonValue | undefined> {
   const initBody = init?.body;
-  if (String(initBody) === initBody) return JSON.parse(initBody);
+
+  if (typeof initBody === "string") return JSON.parse(initBody);
+
   if (input instanceof Request) {
     const text = await input.clone().text();
+
     return text ? JSON.parse(text) : undefined;
   }
+
   return undefined;
 }
 
@@ -113,6 +131,7 @@ interface FakeFetch {
 
 function createFakeFetch(...responses: Response[]): FakeFetch {
   const requests: CapturedRequest[] = [];
+
   const fetchImpl: typeof fetch = async (input, init) => {
     const url = input instanceof Request ? input.url : String(input);
     requests.push({
@@ -121,9 +140,12 @@ function createFakeFetch(...responses: Response[]): FakeFetch {
       body: await parseRequestBody(input, init),
     });
     const response = responses.shift();
+
     if (!response) throw new Error(`unexpected request to ${url}`);
+
     return response;
   };
+
   return { fetch: fetchImpl, requests };
 }
 
@@ -140,6 +162,7 @@ function setupSpans(): InMemorySpanExporter {
     },
     { spanExporter },
   );
+
   return spanExporter;
 }
 
@@ -154,28 +177,36 @@ async function finishedSpans(
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await flush();
     const spans = exporter.getFinishedSpans();
+
     if (spans.length === expectedCount) return spans;
+
     if (spans.length > expectedCount) expect(spans).toHaveLength(expectedCount);
     await Promise.resolve();
   }
+
   expect(exporter.getFinishedSpans()).toHaveLength(expectedCount);
+
   return exporter.getFinishedSpans();
 }
 
 async function exportedSpan(exporter: InMemorySpanExporter): Promise<ReadableSpan> {
   const spans = await finishedSpans(exporter, 1);
+
   return spans[0]!;
 }
 
 function jsonAttr<T>(span: ReadableSpan, key: string): T {
   const value = span.attributes[key];
   expect(String(value) === value).toBe(true);
+
   return JSON.parse(String(value)) as T;
 }
 
 async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   const chunks: unknown[] = [];
+
   for await (const chunk of stream) chunks.push(chunk);
+
   return chunks;
 }
 
@@ -319,17 +350,20 @@ test("messages.create records one error span when the Anthropic API returns 4xx"
 
 test("messages.create preserves request tools and tool-use blocks in output", async () => {
   const spans = setupSpans();
+
   const toolUse = {
     type: "tool_use",
     id: "toolu_1",
     name: "get_weather",
     input: { location: "Paris" },
   };
+
   const tool = {
     name: "get_weather",
     description: "Get weather",
     input_schema: { type: "object", properties: { location: { type: "string" } } },
   } as const;
+
   const fake = createFakeFetch(
     jsonResponse(
       messagePayload({
@@ -369,6 +403,7 @@ test("messages.create streaming preserves events and records aggregated text usa
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   const visibleEvents = await collectStream(stream);
 
   expect(fake.requests[0]?.body).toMatchObject({ stream: true });
@@ -392,6 +427,7 @@ test("messages.create streaming preserves events and records aggregated text usa
 
 test("messages.create streaming observes duck-typed stream responses", async () => {
   const spans = setupSpans();
+
   class AlternateStream implements AsyncIterable<unknown> {
     private abortController = new AbortController();
     controller = {
@@ -403,6 +439,7 @@ test("messages.create streaming observes duck-typed stream responses", async () 
       for (const event of streamEvents()) yield event;
     }
   }
+
   const client = wrapAnthropic({
     messages: {
       create: (_params: JsonValue) => Promise.resolve(new AlternateStream()),
@@ -415,6 +452,7 @@ test("messages.create streaming observes duck-typed stream responses", async () 
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -475,6 +513,7 @@ test("message timestamps precede telemetry mapping", async () => {
 
 test("messages.create streaming preserves citation deltas", async () => {
   const spans = setupSpans();
+
   const citation = {
     type: "char_location",
     cited_text: "quoted text",
@@ -483,6 +522,7 @@ test("messages.create streaming preserves citation deltas", async () => {
     start_char_index: 0,
     end_char_index: 11,
   };
+
   const fake = createFakeFetch(
     namedSseResponse([
       { type: "message_start", message: messagePayload({ id: "msg_cited", content: [] }) },
@@ -501,6 +541,7 @@ test("messages.create streaming preserves citation deltas", async () => {
     messages: [{ role: "user", content: "Cite this" }],
     stream: true,
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -511,6 +552,7 @@ test("messages.create streaming preserves citation deltas", async () => {
 
 test("messages.create streaming aggregates tool-use input JSON fragments", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     namedSseResponse([
       { type: "message_start", message: messagePayload({ id: "msg_tool_stream", content: [] }) },
@@ -553,6 +595,7 @@ test("messages.create streaming aggregates tool-use input JSON fragments", async
     messages: [{ role: "user", content: "Weather in Paris?" }],
     stream: true,
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -576,6 +619,7 @@ test("messages.create streaming aggregates tool-use input JSON fragments", async
 
 test("messages.create streaming aggregates thinking and signature deltas", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     namedSseResponse([
       { type: "message_start", message: messagePayload({ id: "msg_thinking", content: [] }) },
@@ -602,6 +646,7 @@ test("messages.create streaming aggregates thinking and signature deltas", async
     messages: [{ role: "user", content: "Think" }],
     stream: true,
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -652,6 +697,7 @@ test("messages.create streaming ends with error when aborted before iteration st
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   stream.controller.abort();
 
   const span = await exportedSpan(spans);
@@ -670,6 +716,7 @@ test("messages.stream helper routes through create and records one span", async 
     max_tokens: 64,
     messages: [{ role: "user", content: "Say hello" }],
   });
+
   const events = await collectStream(stream);
   const finalMessage = await stream.finalMessage();
 
@@ -745,10 +792,12 @@ test("wrapAnthropic keeps a client instrumented after global instrumentation is 
 test("instrumentAnthropic and wrapAnthropic together record one span per call", async () => {
   const spans = setupSpans();
   instrumentAnthropic();
+
   const fake = createFakeFetch(
     jsonResponse(messagePayload({ id: "msg_global_wrapped" })),
     jsonResponse(messagePayload({ id: "msg_instance_wrapped_after_global" })),
   );
+
   const client = wrapAnthropic(new Anthropic({ apiKey: "test", fetch: fake.fetch, maxRetries: 0 }));
 
   await client.messages.create({
@@ -775,6 +824,7 @@ test("instrumentAnthropic and wrapAnthropic together record one span per call", 
 
 test("wrapAnthropic records Bedrock provider names from client constructor names", async () => {
   const spans = setupSpans();
+
   class AnthropicBedrock {
     messages = {
       create: async (_params: JsonValue) => messagePayload({ id: "msg_bedrock" }),

--- a/packages/anthropic/tests/anthropic.test.ts
+++ b/packages/anthropic/tests/anthropic.test.ts
@@ -1,7 +1,7 @@
 import { InMemorySpanExporter, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { flush, init, shutdown } from "@telemetry-dev/sdk";
 import Anthropic from "@anthropic-ai/sdk";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 import { instrumentAnthropic, uninstrumentAnthropic, wrapAnthropic } from "../src/index.ts";
 
@@ -225,6 +225,7 @@ function streamEvents(): JsonRecord[] {
 afterEach(async () => {
   uninstrumentAnthropic();
   await shutdown();
+  vi.restoreAllMocks();
 });
 
 test("messages.create maps request, response, usage, finish reason, provider, and sampling attributes", async () => {
@@ -422,6 +423,54 @@ test("messages.create streaming observes duck-typed stream responses", async () 
   ]);
   expect(span.attributes["gen_ai.usage.input_tokens"]).toBe(9);
   expect(span.attributes["gen_ai.usage.output_tokens"]).toBe(2);
+});
+
+test("message timestamps precede telemetry mapping", async () => {
+  const spans = setupSpans();
+  let now = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+
+  const source = {
+    controller: new AbortController(),
+    async *[Symbol.asyncIterator]() {
+      for (const [receivedAt, mappingMs] of [
+        [100, 30],
+        [240, 90],
+      ] as const) {
+        now = receivedAt;
+        yield {
+          type: "content_block_delta",
+          index: 0,
+          get delta() {
+            now = receivedAt + mappingMs;
+
+            return { type: "text_delta", text: "A" };
+          },
+        };
+      }
+    },
+  };
+
+  const client = wrapAnthropic({
+    messages: { create: async (_params: unknown) => source },
+  });
+
+  const stream = await client.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 64,
+    messages: [],
+    stream: true,
+  });
+
+  expect(await collectStream(stream)).toHaveLength(2);
+  expect(await exportedSpan(spans)).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: {
+      count: 1,
+      sum: 0.14,
+      min: 0.14,
+      max: 0.14,
+    },
+  });
 });
 
 test("messages.create streaming preserves citation deltas", async () => {

--- a/packages/bedrock/src/agent-handlers.ts
+++ b/packages/bedrock/src/agent-handlers.ts
@@ -20,6 +20,7 @@ import {
 
 export function agentInputMessages<T>(inputText: T): JsonValue {
   const text = stringValue(inputText);
+
   return text ? [{ role: "user", parts: [{ type: "text", content: text }] }] : undefined;
 }
 
@@ -63,35 +64,47 @@ export class AgentStreamState implements StreamState {
 
   feed<T>(event: T): void {
     const raw: unknown = event;
+
     if (!isRecord(raw)) return;
     const streamError = modeledStreamError(raw);
+
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
+
       return;
     }
+
     const chunk = isRecord(raw.chunk) ? raw.chunk : undefined;
     const bytes = chunk?.bytes;
+
     if (bytes !== undefined) this.text += bytesToString(bytes) ?? "";
     const attribution = isRecord(chunk?.attribution) ? chunk.attribution : undefined;
     const citations = arrayValue<unknown>(attribution?.citations);
+
     if (citations) this.citationCount += citations.length;
 
     const files = isRecord(raw.files) ? arrayValue<JsonValue>(raw.files.files) : undefined;
+
     if (files) this.outputFiles.push(...files.map(sanitizeOutputFile));
 
     const returnControl = isRecord(raw.returnControl) ? raw.returnControl : undefined;
+
     if (returnControl) this.returnControl = returnControl;
 
     const traceEvent = isRecord(raw.trace) ? raw.trace : undefined;
+
     if (traceEvent) {
       this.traceEventCount += 1;
+
       if (this.options.captureAgentTrace) this.traces.push(traceEvent);
       collectTrace(traceEvent, (usage) => this.addUsage(usage));
       const failure = findKey(traceEvent, "failureTrace");
+
       if (isRecord(failure))
         this.failureReason = stringValue(failure.failureReason) ?? this.failureReason;
       const guardrail = findKey(traceEvent, "guardrailTrace");
+
       if (isRecord(guardrail))
         this.guardrailAction = stringValue(guardrail.action) ?? this.guardrailAction;
     }
@@ -108,6 +121,7 @@ export class AgentStreamState implements StreamState {
       agent_trace:
         this.options.captureAgentTrace && this.traces.length > 0 ? this.traces : undefined,
     });
+
     return mergeFields(
       omitUndefined({
         output: this.returnControl
@@ -124,14 +138,18 @@ export class AgentStreamState implements StreamState {
   }
   private addUsage<T>(value: T): void {
     const raw: unknown = value;
+
     if (!isRecord(raw)) return;
     const inputTokens = numberValue(raw.inputTokens);
     const outputTokens = numberValue(raw.outputTokens);
     const totalTokens = numberValue(raw.totalTokens);
+
     if (inputTokens !== undefined)
       this.usage.inputTokens = (this.usage.inputTokens ?? 0) + inputTokens;
+
     if (outputTokens !== undefined)
       this.usage.outputTokens = (this.usage.outputTokens ?? 0) + outputTokens;
+
     if (totalTokens !== undefined)
       this.usage.totalTokens = (this.usage.totalTokens ?? 0) + totalTokens;
     else if (inputTokens !== undefined || outputTokens !== undefined) {
@@ -142,7 +160,9 @@ export class AgentStreamState implements StreamState {
 
 function sanitizeOutputFile<T>(value: T): JsonValue {
   const raw: unknown = value;
+
   if (!isRecord(raw)) return undefined;
+
   return omitUndefined({
     name: stringValue(raw.name),
     type: stringValue(raw.type),
@@ -161,6 +181,7 @@ export function retrieveResponseFields<T>(output: T): SpanFields {
   const raw: unknown = output;
   const result = isRecord(raw) ? raw : {};
   const retrievalResults = arrayValue<unknown>(result.retrievalResults);
+
   return mergeFields(awsMetadataFields(result.$metadata), {
     output: retrievalResults,
     metadata: omitUndefined({
@@ -174,17 +195,21 @@ export function ragModel(input: JsonRecord): string | undefined {
   const config = isRecord(input.retrieveAndGenerateConfiguration)
     ? input.retrieveAndGenerateConfiguration
     : undefined;
+
   const kb = isRecord(config?.knowledgeBaseConfiguration)
     ? config?.knowledgeBaseConfiguration
     : undefined;
+
   const external = isRecord(config?.externalSourcesConfiguration)
     ? config?.externalSourcesConfiguration
     : undefined;
+
   return stringValue(kb?.modelArn) ?? stringValue(external?.modelArn);
 }
 
 export function ragRequestFields(input: JsonRecord): SpanFields {
   const text = isRecord(input.input) ? stringValue(input.input.text) : undefined;
+
   return omitUndefined({
     provider: PROVIDER,
     model: ragModel(input),
@@ -197,6 +222,7 @@ export function ragResponseFields<T>(output: T): SpanFields {
   const raw: unknown = output;
   const result = isRecord(raw) ? raw : {};
   const text = isRecord(result.output) ? stringValue(result.output.text) : undefined;
+
   return mergeFields(awsMetadataFields(result.$metadata), {
     output: text ? [{ role: "assistant", parts: [{ type: "text", content: text }] }] : undefined,
     metadata: omitUndefined({
@@ -216,15 +242,20 @@ export class RagStreamState implements StreamState {
 
   feed<T>(event: T): void {
     const raw: unknown = event;
+
     if (!isRecord(raw)) return;
     const streamError = modeledStreamError(raw);
+
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
+
       return;
     }
+
     const output = isRecord(raw.output) ? raw.output : undefined;
     this.text += stringValue(output?.text) ?? "";
+
     if (raw.citation) this.citationCount += 1;
     const guardrail = isRecord(raw.guardrail) ? raw.guardrail : undefined;
     this.guardrailAction = stringValue(guardrail?.action) ?? this.guardrailAction;
@@ -263,18 +294,25 @@ export class FlowStreamState implements StreamState {
 
   feed<T>(event: T): void {
     const raw: unknown = event;
+
     if (!isRecord(raw)) return;
     const streamError = modeledStreamError(raw);
+
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
+
       return;
     }
+
     const output = isRecord(raw.flowOutputEvent) ? raw.flowOutputEvent : undefined;
+
     if (output) this.outputs.push(output.content);
+
     const inputRequest = isRecord(raw.flowMultiTurnInputRequestEvent)
       ? raw.flowMultiTurnInputRequestEvent
       : undefined;
+
     if (inputRequest) this.outputs.push(inputRequest.content);
     const completion = isRecord(raw.flowCompletionEvent) ? raw.flowCompletionEvent : undefined;
     this.completionReason = stringValue(completion?.completionReason) ?? this.completionReason;
@@ -302,12 +340,15 @@ export function ragName(input: JsonRecord): string {
 
 function collectTrace<T>(value: T, onUsage: <TUsage>(usage: TUsage) => void): void {
   const raw: unknown = value;
+
   if (!isRecord(raw)) return;
   const output = isRecord(raw.modelInvocationOutput) ? raw.modelInvocationOutput : undefined;
+
   if (output) {
     const metadata = isRecord(output.metadata) ? output.metadata : undefined;
     onUsage(metadata?.usage);
   }
+
   for (const child of Object.values(raw)) {
     if (isRecord(child)) collectTrace(child, onUsage);
     else if (Array.isArray(child)) child.forEach((item) => collectTrace(item, onUsage));
@@ -316,11 +357,16 @@ function collectTrace<T>(value: T, onUsage: <TUsage>(usage: TUsage) => void): vo
 
 function findKey<T>(value: T, key: string): JsonValue {
   const raw: unknown = value;
+
   if (!isRecord(raw)) return undefined;
+
   if (raw[key] !== undefined) return raw[key];
+
   for (const child of Object.values(raw)) {
     const found = findKey(child, key);
+
     if (found !== undefined) return found;
   }
+
   return undefined;
 }

--- a/packages/bedrock/src/agents.ts
+++ b/packages/bedrock/src/agents.ts
@@ -28,6 +28,7 @@ export function wrapBedrockAgents<T extends WrappableBedrockAgentClient>(
     writable: true,
   });
   WRAPPED.add(client as object);
+
   return client;
 }
 
@@ -37,13 +38,16 @@ export function instrumentBedrockAgents(options: BedrockInstrumentationOptions =
   const hadOwn = Object.prototype.hasOwnProperty.call(proto, "send");
   const original = proto.send;
   const instrumentedSend = createInstrumentedSend(original, options, AGENT_HANDLERS);
+
   const wrapper = function telemetryDevBedrockAgentSend(
     this: WrappableBedrockAgentClient,
     ...args: unknown[]
   ) {
     if (WRAPPED.has(this as object)) return original.apply(this, args);
+
     return instrumentedSend.apply(this, args);
   };
+
   ORIGINAL = { proto, hadOwn, value: original, wrapper };
   Object.defineProperty(proto, "send", {
     configurable: true,
@@ -54,9 +58,12 @@ export function instrumentBedrockAgents(options: BedrockInstrumentationOptions =
 
 export function uninstrumentBedrockAgents(): void {
   const original = ORIGINAL;
+
   if (!original) return;
+
   if (Object.getOwnPropertyDescriptor(original.proto, "send")?.value !== original.wrapper) return;
   ORIGINAL = undefined;
+
   if (original.hadOwn) {
     Object.defineProperty(original.proto, "send", {
       configurable: true,

--- a/packages/bedrock/src/converse.ts
+++ b/packages/bedrock/src/converse.ts
@@ -17,6 +17,7 @@ import {
 } from "./internal.ts";
 
 export type MessagePart = object;
+
 export interface NormalizedMessage {
   role: string | undefined;
   parts: MessagePart[];
@@ -26,6 +27,7 @@ export interface NormalizedMessage {
 export function converseRequestFields(input: JsonRecord): SpanFields {
   const inference = isRecord(input.inferenceConfig) ? input.inferenceConfig : {};
   const guardrail = isRecord(input.guardrailConfig) ? input.guardrailConfig : undefined;
+
   return omitUndefined({
     provider: PROVIDER,
     model: stringValue(input.modelId),
@@ -53,6 +55,7 @@ export function converseResponseFields<T>(output: T): SpanFields {
   const guardrail = isRecord(trace?.guardrail) ? trace?.guardrail : undefined;
   const stopReason = stringValue(result.stopReason);
   const message = isRecord(result.output) ? result.output.message : undefined;
+
   return mergeFields(awsMetadataFields(result.$metadata), {
     output: normalizeOutputMessage(message, stopReason),
     usage,
@@ -68,6 +71,7 @@ export function converseResponseFields<T>(output: T): SpanFields {
 
 export function usageFromConverse<T>(value: T): SpanFields["usage"] | undefined {
   if (!isRecord(value)) return undefined;
+
   return omitUndefined({
     inputTokens: numberValue(value.inputTokens),
     outputTokens: numberValue(value.outputTokens),
@@ -79,7 +83,9 @@ export function usageFromConverse<T>(value: T): SpanFields["usage"] | undefined 
 
 export function normalizeMessages<T>(value: T): NormalizedMessage[] | undefined {
   const messages = arrayValue<JsonRecord>(value);
+
   if (!messages) return undefined;
+
   return messages.map((message) => ({
     role: stringValue(message.role),
     parts: normalizeContentList(message.content),
@@ -91,29 +97,36 @@ export function normalizeOutputMessage<T>(
   finishReason?: string,
 ): NormalizedMessage[] | undefined {
   if (!isRecord(value)) return undefined;
+
   const message = omitUndefined({
     role: stringValue(value.role),
     parts: normalizeContentList(value.content),
     finish_reason: finishReason,
   });
+
   return [message];
 }
 
 export function normalizeSystem<T>(value: T): MessagePart[] | undefined {
   const blocks = arrayValue<JsonRecord>(value);
+
   if (!blocks) return undefined;
   const parts = blocks.flatMap((block) => normalizeContentBlock(block));
+
   return parts.length > 0 ? parts : undefined;
 }
 
 function normalizeContentList<T>(value: T): MessagePart[] {
   const blocks = arrayValue<JsonRecord>(value);
+
   if (!blocks) return [];
+
   return blocks.flatMap((block) => normalizeContentBlock(block));
 }
 
 function normalizeContentBlock(block: JsonRecord): MessagePart[] {
   const text = stringValue(block.text);
+
   if (text !== undefined)
     return [
       omitUndefined({
@@ -124,6 +137,7 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
     ];
 
   const toolUse = isRecord(block.toolUse) ? block.toolUse : undefined;
+
   if (toolUse) {
     return [
       omitUndefined({
@@ -136,6 +150,7 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
   }
 
   const toolResult = isRecord(block.toolResult) ? block.toolResult : undefined;
+
   if (toolResult) {
     return [
       omitUndefined({
@@ -147,8 +162,10 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
   }
 
   const reasoning = isRecord(block.reasoningContent) ? block.reasoningContent : undefined;
+
   if (reasoning) {
     const reasoningText = isRecord(reasoning.reasoningText) ? reasoning.reasoningText : undefined;
+
     return [
       {
         type: "reasoning",
@@ -160,9 +177,11 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
 
   for (const modality of ["image", "document", "video", "audio"] as const) {
     const media = isRecord(block[modality]) ? block[modality] : undefined;
+
     if (!media) continue;
     const format = stringValue(media.format);
     const source = isRecord(media.source) ? media.source : undefined;
+
     if (source?.bytes !== undefined) {
       return [
         omitUndefined({
@@ -172,25 +191,32 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
         }),
       ];
     }
+
     const s3 = isRecord(source?.s3Location) ? source?.s3Location : undefined;
     const uri = stringValue(source?.uri) ?? stringValue(s3?.uri) ?? s3Uri(s3);
+
     if (uri) return [omitUndefined({ type: "uri", uri, modality, mime_type: format })];
   }
 
   const citationsContent = isRecord(block.citationsContent) ? block.citationsContent : undefined;
+
   if (citationsContent) {
     const contentBlocks = arrayValue<JsonRecord>(citationsContent.content) ?? [];
     const citations = arrayValue<JsonValue>(citationsContent.citations);
+
     return contentBlocks.flatMap((contentBlock) => {
       if (!citations) return normalizeContentBlock(contentBlock);
+
       return normalizeContentBlock({ ...contentBlock, citations });
     });
   }
 
   const guardContent = isRecord(block.guardContent) ? block.guardContent : undefined;
+
   if (guardContent) {
     const guardText = isRecord(guardContent.text) ? guardContent.text : undefined;
     const content = stringValue(guardText?.text) ?? stringValue(guardContent.text);
+
     if (content) return [{ type: "text", content }];
   }
 
@@ -203,15 +229,19 @@ function normalizeContentBlock(block: JsonRecord): MessagePart[] {
 
 function simplifyToolResult<T>(content: T): JsonValue {
   const blocks = arrayValue<JsonRecord>(content);
+
   if (!blocks) return isJsonValue(content) ? content : undefined;
   const text = stringValue(blocks[0]?.text);
+
   if (blocks.length === 1 && text !== undefined) return text;
+
   return blocks.flatMap((block) => normalizeContentBlock(block)) as JsonValue[];
 }
 
 function s3Uri(value: JsonRecord | undefined): string | undefined {
   const bucket = stringValue(value?.bucket);
   const key = stringValue(value?.key);
+
   return bucket && key ? `s3://${bucket}/${key}` : undefined;
 }
 
@@ -238,15 +268,20 @@ export class ConverseStreamState implements StreamState {
   feed<T>(event: T): void {
     if (!isRecord(event)) return;
     const streamError = modeledStreamError(event);
+
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
+
       return;
     }
+
     const messageStart = isRecord(event.messageStart) ? event.messageStart : undefined;
+
     if (messageStart) this.role = stringValue(messageStart.role) ?? this.role;
 
     const blockStart = isRecord(event.contentBlockStart) ? event.contentBlockStart : undefined;
+
     if (blockStart) {
       const index = numberValue(blockStart.contentBlockIndex) ?? this.blocks.size;
       const start = isRecord(blockStart.start) ? blockStart.start : undefined;
@@ -280,34 +315,44 @@ export class ConverseStreamState implements StreamState {
     }
 
     const deltaEvent = isRecord(event.contentBlockDelta) ? event.contentBlockDelta : undefined;
+
     if (deltaEvent) {
       const index = numberValue(deltaEvent.contentBlockIndex) ?? 0;
       const delta = isRecord(deltaEvent.delta) ? deltaEvent.delta : {};
       const block = this.blocks.get(index) ?? { kind: "text", text: "" };
       const text = stringValue(delta.text);
+
       if (text !== undefined) {
         block.kind = "text";
         block.text = `${block.text ?? ""}${text}`;
       }
+
       const toolUse = isRecord(delta.toolUse) ? delta.toolUse : undefined;
       const input = stringValue(toolUse?.input);
+
       if (toolUse && input !== undefined) {
         block.kind = "tool";
         block.input = `${block.input ?? ""}${input}`;
       }
+
       const reasoning = isRecord(delta.reasoningContent) ? delta.reasoningContent : undefined;
+
       if (reasoning) {
         block.kind = "reasoning";
         block.text = `${block.text ?? ""}${stringValue(reasoning.text) ?? (reasoning.redactedContent ? "[redacted]" : "")}`;
       }
+
       const image = isRecord(delta.image) ? delta.image : undefined;
+
       if (image) {
         const content = isRecord(block.content) ? block.content : {};
         const current: JsonRecord = isRecord(content.image) ? content.image : {};
         block.kind = "content";
         block.content = { image: { ...current, ...image } };
       }
+
       const toolResult = arrayValue<JsonRecord>(delta.toolResult);
+
       if (toolResult) {
         const content = isRecord(block.content) ? block.content : {};
         const current: JsonRecord = isRecord(content.toolResult) ? content.toolResult : {};
@@ -320,16 +365,20 @@ export class ConverseStreamState implements StreamState {
           },
         };
       }
+
       if (isRecord(delta.citation)) {
         block.citations = [...(block.citations ?? []), delta.citation];
       }
+
       this.blocks.set(index, block);
     }
 
     const stop = isRecord(event.messageStop) ? event.messageStop : undefined;
+
     if (stop) this.stopReason = stringValue(stop.stopReason) ?? this.stopReason;
 
     const metadata = isRecord(event.metadata) ? event.metadata : undefined;
+
     if (metadata) {
       this.usage = usageFromConverse(metadata.usage) ?? this.usage;
       const metrics = isRecord(metadata.metrics) ? metadata.metrics : undefined;
@@ -352,6 +401,7 @@ export class ConverseStreamState implements StreamState {
     const parts = [...this.blocks.entries()]
       .sort(([left], [right]) => left - right)
       .map(([, block]) => blockToPart(block));
+
     return mergeFields(
       omitUndefined({
         output:
@@ -395,9 +445,12 @@ function blockToPart(block: StreamBlock) {
       arguments: parseJson(block.input) ?? block.input ?? "",
     });
   }
+
   if (block.kind === "reasoning") return { type: "reasoning", content: block.text ?? "" };
+
   if (block.kind === "content" && block.content)
     return normalizeContentBlock(block.content)[0] ?? {};
+
   return omitUndefined({
     type: "text",
     content: block.text ?? "",

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -28,6 +28,7 @@ export function wrapBedrock<T extends WrappableBedrockClient>(
     writable: true,
   });
   WRAPPED.add(client as object);
+
   return client;
 }
 
@@ -37,13 +38,16 @@ export function instrumentBedrock(options: BedrockInstrumentationOptions = {}): 
   const hadOwn = Object.prototype.hasOwnProperty.call(proto, "send");
   const original = proto.send;
   const instrumentedSend = createInstrumentedSend(original, options, RUNTIME_HANDLERS);
+
   const wrapper = function telemetryDevBedrockSend(
     this: WrappableBedrockClient,
     ...args: unknown[]
   ) {
     if (WRAPPED.has(this as object)) return original.apply(this, args);
+
     return instrumentedSend.apply(this, args);
   };
+
   ORIGINAL = { proto, hadOwn, value: original, wrapper };
   Object.defineProperty(proto, "send", {
     configurable: true,
@@ -54,9 +58,12 @@ export function instrumentBedrock(options: BedrockInstrumentationOptions = {}): 
 
 export function uninstrumentBedrock(): void {
   const original = ORIGINAL;
+
   if (!original) return;
+
   if (Object.getOwnPropertyDescriptor(original.proto, "send")?.value !== original.wrapper) return;
   ORIGINAL = undefined;
+
   if (original.hadOwn) {
     Object.defineProperty(original.proto, "send", {
       configurable: true,

--- a/packages/bedrock/src/internal-handlers.ts
+++ b/packages/bedrock/src/internal-handlers.ts
@@ -39,6 +39,7 @@ export const RUNTIME_HANDLERS = {
     requestFields: converseRequestFields,
     onResult(result, span) {
       endSpan(span, converseResponseFields(result));
+
       return result;
     },
   },
@@ -48,10 +49,13 @@ export const RUNTIME_HANDLERS = {
     requestFields: converseRequestFields,
     onResult(result, span, t0) {
       const response = result as { stream?: unknown; $metadata?: unknown };
+
       if (!response.stream) {
         endSpan(span, awsMetadataFields(response.$metadata));
+
         return result;
       }
+
       return {
         ...response,
         stream: wrapAsyncIterable(
@@ -70,6 +74,7 @@ export const RUNTIME_HANDLERS = {
     requestFields: invokeModelRequestFields,
     onResult(result, span, _t0, input) {
       endSpan(span, invokeModelResponseFields(input, result));
+
       return result;
     },
   },
@@ -79,10 +84,13 @@ export const RUNTIME_HANDLERS = {
     requestFields: invokeModelRequestFields,
     onResult(result, span, t0) {
       const response = result as { body?: unknown; $metadata?: unknown };
+
       if (!response.body) {
         endSpan(span, awsMetadataFields(response.$metadata));
+
         return result;
       }
+
       return {
         ...response,
         body: wrapAsyncIterable(
@@ -119,6 +127,7 @@ export const RUNTIME_HANDLERS = {
           }),
         }),
       );
+
       return result;
     },
   },
@@ -143,6 +152,7 @@ export const AGENT_HANDLERS = {
     requestFields: retrieveRequestFields,
     onResult(result, span) {
       endSpan(span, retrieveResponseFields(result));
+
       return result;
     },
   },
@@ -152,6 +162,7 @@ export const AGENT_HANDLERS = {
     requestFields: ragRequestFields,
     onResult(result, span) {
       endSpan(span, ragResponseFields(result));
+
       return result;
     },
   },
@@ -161,13 +172,17 @@ export const AGENT_HANDLERS = {
     requestFields: ragRequestFields,
     onResult(result, span, t0) {
       const response = result as { stream?: unknown; $metadata?: unknown; sessionId?: string };
+
       const base = mergeFields(awsMetadataFields(response.$metadata), {
         metadata: omitUndefined({ bedrock_session_id: stringValue(response.sessionId) }),
       });
+
       if (!response.stream) {
         endSpan(span, base);
+
         return result;
       }
+
       return {
         ...response,
         stream: wrapAsyncIterable(response.stream, new RagStreamState(), span, t0, base, false),
@@ -180,10 +195,13 @@ export const AGENT_HANDLERS = {
     requestFields: flowRequestFields,
     onResult(result, span, t0) {
       const response = result as { responseStream?: unknown; $metadata?: unknown };
+
       if (!response.responseStream) {
         endSpan(span, awsMetadataFields(response.$metadata));
+
         return result;
       }
+
       return {
         ...response,
         responseStream: wrapAsyncIterable(
@@ -213,16 +231,20 @@ function streamAgentResult(key: "completion") {
       sessionId?: string;
       memoryId?: string;
     };
+
     const base = mergeFields(awsMetadataFields(response.$metadata), {
       metadata: omitUndefined({
         bedrock_session_id: stringValue(response.sessionId),
         bedrock_memory_id: stringValue(response.memoryId),
       }),
     });
+
     if (!response[key]) {
       endSpan(span, base);
+
       return result;
     }
+
     return {
       ...response,
       [key]: wrapAsyncIterable(response[key], new AgentStreamState(options), span, t0, base, false),

--- a/packages/bedrock/src/internal-handlers.ts
+++ b/packages/bedrock/src/internal-handlers.ts
@@ -170,7 +170,7 @@ export const AGENT_HANDLERS = {
       }
       return {
         ...response,
-        stream: wrapAsyncIterable(response.stream, new RagStreamState(), span, t0, base),
+        stream: wrapAsyncIterable(response.stream, new RagStreamState(), span, t0, base, false),
       };
     },
   },
@@ -192,6 +192,7 @@ export const AGENT_HANDLERS = {
           span,
           t0,
           awsMetadataFields(response.$metadata),
+          false,
         ),
       };
     },
@@ -224,7 +225,7 @@ function streamAgentResult(key: "completion") {
     }
     return {
       ...response,
-      [key]: wrapAsyncIterable(response[key], new AgentStreamState(options), span, t0, base),
+      [key]: wrapAsyncIterable(response[key], new AgentStreamState(options), span, t0, base, false),
     };
   };
 }

--- a/packages/bedrock/src/internal.ts
+++ b/packages/bedrock/src/internal.ts
@@ -254,7 +254,7 @@ export function parseJson<T>(value: T): JsonValue {
 }
 
 export interface StreamState {
-  feed<T>(event: T): void;
+  feed<T>(event: T): boolean | void;
   finish(partial: boolean): SpanFields;
 }
 
@@ -264,6 +264,7 @@ export function wrapAsyncIterable<T>(
   span: SpanHandle,
   t0: number,
   baseFields: SpanFields,
+  trackOutputChunks = true,
 ): T {
   if (!iterable || !isAsyncIterable(iterable)) {
     endSpan(span, baseFields);
@@ -284,11 +285,18 @@ export function wrapAsyncIterable<T>(
     let completed = false;
     try {
       for await (const event of iterable) {
+        const receivedAt = performance.now();
+
         if (!first) {
           first = true;
-          updateSpan(span, { timeToFirstChunkMs: performance.now() - t0 });
+          updateSpan(span, { timeToFirstChunkMs: receivedAt - t0 });
         }
-        safe(() => state.feed(event));
+
+        const stateHasOutput = safe(() => state.feed(event));
+
+        if (trackOutputChunks && (stateHasOutput ?? bedrockEventHasOutput(event))) {
+          safe(() => span.recordOutputChunk?.(receivedAt));
+        }
         yield event;
       }
       completed = true;
@@ -318,6 +326,70 @@ export function wrapAsyncIterable<T>(
   };
   STREAM_FINALIZER?.register(wrapped, finishAbandoned, unregisterToken);
   return wrapped as T;
+}
+
+function bedrockEventHasOutput(event: unknown): boolean {
+  const record = isRecord(event) ? event : undefined;
+
+  if (!record) return false;
+  const output = isRecord(record.output) ? record.output : undefined;
+
+  if (typeof output?.text === "string" && output.text.length > 0) return true;
+  const block = isRecord(record.contentBlockDelta) ? record.contentBlockDelta : undefined;
+  const delta = isRecord(block?.delta) ? block.delta : undefined;
+  const reasoning = isRecord(delta?.reasoningContent) ? delta.reasoningContent : undefined;
+  const toolUse = isRecord(delta?.toolUse) ? delta.toolUse : undefined;
+
+  if (
+    (typeof delta?.text === "string" && delta.text.length > 0) ||
+    (typeof reasoning?.text === "string" && reasoning.text.length > 0) ||
+    (typeof toolUse?.input === "string" && toolUse.input.length > 0)
+  )
+    return true;
+  const chunk = isRecord(record.chunk) ? record.chunk : undefined;
+  const raw = chunk?.bytes;
+
+  if (raw === undefined) return false;
+
+  const text =
+    typeof raw === "string"
+      ? raw
+      : raw instanceof Uint8Array
+        ? new TextDecoder().decode(raw)
+        : undefined;
+
+  if (!text) return false;
+  const parsed = parseJson(text);
+
+  if (parsed === undefined) return text.length > 0;
+
+  if (!isRecord(parsed)) return false;
+  const parsedDelta = isRecord(parsed.delta) ? parsed.delta : undefined;
+
+  const contentDelta = isRecord(parsed.contentBlockDelta ?? parsed.content_block_delta)
+    ? (parsed.contentBlockDelta ?? parsed.content_block_delta)
+    : undefined;
+
+  const nested =
+    isRecord(contentDelta) && isRecord(contentDelta.delta) ? contentDelta.delta : undefined;
+
+  const generations = Array.isArray(parsed.generations) ? parsed.generations : [];
+  const generation = isRecord(generations[0]) ? generations[0] : undefined;
+  const outputs = Array.isArray(parsed.outputs) ? parsed.outputs : [];
+  const firstOutput = isRecord(outputs[0]) ? outputs[0] : undefined;
+
+  return [
+    parsed.outputText,
+    parsed.generation,
+    parsed.completion,
+    parsed.text,
+    parsedDelta?.text,
+    parsedDelta?.thinking,
+    parsedDelta?.partial_json,
+    nested?.text,
+    firstOutput?.text,
+    generation?.text,
+  ].some((value) => typeof value === "string" && value.length > 0);
 }
 
 function isAsyncIterable<T>(value: T): value is T & AsyncIterable<unknown> {

--- a/packages/bedrock/src/internal.ts
+++ b/packages/bedrock/src/internal.ts
@@ -20,6 +20,7 @@ export type JsonValue =
   | JsonValue[]
   | JsonRecord
   | ((...args: JsonValue[]) => JsonValue);
+
 export interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -53,6 +54,7 @@ export function createInstrumentedSend(
     const rawRest = rest.map(asJsonValue);
     const name = isRecord(rawCommand) ? rawCommand.constructor?.name : undefined;
     const handler = String(name) === name ? handlers[name] : undefined;
+
     if (!handler) {
       return originalSend.apply(this, [rawCommand, ...rawRest]);
     }
@@ -64,25 +66,32 @@ export function createInstrumentedSend(
     const fields = safe(() => handler.requestFields(input, options)) ?? {};
     const span = startSpan(spanName, { type: spanType, ...fields });
     const callbackIndex = rawRest.findIndex((arg) => arg instanceof Function);
+
     if (callbackIndex !== -1) {
       const callback = rawRest[callbackIndex] as (cause: JsonValue, data?: JsonValue) => void;
       const wrappedRest = [...rawRest];
       wrappedRest[callbackIndex] = <TError, TData>(error: TError, data?: TData) => {
         const rawError: unknown = error;
         const rawData: unknown = data;
+
         if (rawError != null) {
           endSpan(span, { ...awsMetadataFields(metadataOf(rawError)), error: asError(rawError) });
           callback(asJsonValue(rawError), asJsonValue(rawData));
+
           return;
         }
+
         let nextData: JsonValue | object = asJsonValue(rawData);
+
         try {
           nextData = handler.onResult(asJsonValue(rawData), span, t0, input, options);
         } catch {
           endSpan(span, awsMetadataFields(metadataOf(rawData)));
         }
+
         callback(asJsonValue(rawError), asJsonValue(nextData));
       };
+
       try {
         return originalSend.apply(this, [rawCommand, ...wrappedRest]);
       } catch (error) {
@@ -92,6 +101,7 @@ export function createInstrumentedSend(
     }
 
     let result: JsonValue | object | Promise<JsonValue | object>;
+
     try {
       result = originalSend.apply(this, [rawCommand, ...rawRest]);
     } catch (error) {
@@ -105,6 +115,7 @@ export function createInstrumentedSend(
           return handler.onResult(asJsonValue(resolved), span, t0, input, options);
         } catch {
           endSpan(span, awsMetadataFields(metadataOf(resolved)));
+
           return resolved;
         }
       },
@@ -118,6 +129,7 @@ export function createInstrumentedSend(
 
 export function commandInput<T>(command: T): JsonRecord {
   if (!isRecord(command)) return {};
+
   return isRecord(command.input) ? command.input : {};
 }
 
@@ -151,6 +163,7 @@ export function updateSpan(span: SpanHandle, fields: SpanFields): void {
 
 export function metadataOf<T>(value: T): JsonValue {
   if (!isRecord(value)) return undefined;
+
   return value.$metadata;
 }
 
@@ -172,31 +185,42 @@ export function modeledStreamError(
     throttlingException: "ThrottlingException",
     validationException: "ValidationException",
   } as const;
+
   for (const [key, name] of Object.entries(keys)) {
     const exception = isRecord(event[key]) ? event[key] : undefined;
+
     if (!exception) continue;
+
     const error = new Error(
       stringValue(exception.message) ?? stringValue(exception.originalMessage) ?? name,
     );
+
     error.name = stringValue(exception.name) ?? name;
+
     return { error, fields: awsMetadataFields(exception.$metadata) };
   }
+
   return undefined;
 }
 
 export function awsMetadataFields<T>(metadata: T): SpanFields {
   const raw: unknown = metadata;
+
   if (!isRecord(raw)) return {};
   const requestId = stringValue(raw.requestId);
   const attempts = numberValue(raw.attempts);
   const httpStatusCode = numberValue(raw.httpStatusCode);
   const totalRetryDelay = numberValue(raw.totalRetryDelay);
   const attributes: SpanFields["attributes"] = {};
+
   if (httpStatusCode !== undefined) attributes["aws.http.status_code"] = httpStatusCode;
+
   if (attempts !== undefined && attempts > 1) attributes["aws.request.attempts"] = attempts;
+
   if (totalRetryDelay !== undefined) {
     attributes["aws.request.total_retry_delay_ms"] = totalRetryDelay;
   }
+
   return omitUndefined({
     responseId: requestId,
     attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
@@ -205,14 +229,19 @@ export function awsMetadataFields<T>(metadata: T): SpanFields {
 
 export function mergeFields(...fields: Array<SpanFields | undefined>): SpanFields {
   const merged: SpanFields = {};
+
   for (const field of fields) {
     if (!field) continue;
     const { metadata, attributes, usage, ...rest } = field;
     Object.assign(merged, omitUndefined(rest));
+
     if (usage) merged.usage = { ...merged.usage, ...usage };
+
     if (metadata) merged.metadata = { ...merged.metadata, ...metadata };
+
     if (attributes) merged.attributes = { ...merged.attributes, ...attributes };
   }
+
   return merged;
 }
 
@@ -222,11 +251,13 @@ export function omitUndefined<T extends object>(value: T): T {
 
 export function stringValue<T>(value: T): string | undefined {
   const raw: unknown = value;
+
   return String(raw) === raw && raw.length > 0 ? raw : undefined;
 }
 
 export function numberValue<T>(value: T): number | undefined {
   const raw: unknown = value;
+
   return Number(raw) === raw && Number.isFinite(raw) ? raw : undefined;
 }
 
@@ -236,8 +267,11 @@ export function arrayValue<T, TValue = unknown>(value: TValue): T[] | undefined 
 
 export function bytesToString<T>(value: T): string | undefined {
   const raw: unknown = value;
+
   if (String(raw) === raw) return raw;
+
   if (raw instanceof Uint8Array) return new TextDecoder().decode(raw);
+
   if (ArrayBuffer.isView(raw)) {
     return new TextDecoder().decode(new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength));
   }
@@ -245,7 +279,9 @@ export function bytesToString<T>(value: T): string | undefined {
 
 export function parseJson<T>(value: T): JsonValue {
   const text = bytesToString(value);
+
   if (text === undefined) return undefined;
+
   try {
     return asJsonValue(JSON.parse(text));
   } catch {
@@ -268,12 +304,14 @@ export function wrapAsyncIterable<T>(
 ): T {
   if (!iterable || !isAsyncIterable(iterable)) {
     endSpan(span, baseFields);
+
     return iterable;
   }
 
   let ended = false;
   let first = false;
   const unregisterToken = {};
+
   const endOnce = (fields?: SpanFields) => {
     if (ended) return;
     ended = true;
@@ -283,6 +321,7 @@ export function wrapAsyncIterable<T>(
 
   const generator = async function* () {
     let completed = false;
+
     try {
       for await (const event of iterable) {
         const receivedAt = performance.now();
@@ -297,8 +336,10 @@ export function wrapAsyncIterable<T>(
         if (trackOutputChunks && (stateHasOutput ?? bedrockEventHasOutput(event))) {
           safe(() => span.recordOutputChunk?.(receivedAt));
         }
+
         yield event;
       }
+
       completed = true;
     } catch (error) {
       endOnce(
@@ -313,18 +354,23 @@ export function wrapAsyncIterable<T>(
   };
 
   const wrapped: { [key: PropertyKey]: JsonValue | (() => AsyncGenerator<unknown>) } = {};
+
   if (isRecord(iterable)) {
     for (const key of Reflect.ownKeys(iterable)) {
       wrapped[key] = (iterable as { [key: PropertyKey]: JsonValue })[key];
     }
   }
+
   const finishAbandoned = () => endOnce(safe(() => state.finish(true)));
   wrapped[Symbol.asyncIterator] = () => {
     const iterator = generator();
     STREAM_FINALIZER?.register(iterator, finishAbandoned, unregisterToken);
+
     return iterator;
   };
+
   STREAM_FINALIZER?.register(wrapped, finishAbandoned, unregisterToken);
+
   return wrapped as T;
 }
 
@@ -406,6 +452,8 @@ function asError<T>(value: T): Error {
 
 export function basenameArn<T>(value: T): string | undefined {
   const text = stringValue(value);
+
   if (!text) return undefined;
+
   return text.split(/[/:]/).filter(Boolean).at(-1) ?? text;
 }

--- a/packages/bedrock/src/invoke-model.ts
+++ b/packages/bedrock/src/invoke-model.ts
@@ -18,6 +18,7 @@ import {
 
 export function isEmbeddingModel<T>(modelId: T): boolean {
   const model = stringValue(modelId)?.toLowerCase() ?? "";
+
   return (
     model.includes("titan-embed") || model.includes("cohere.embed") || model.includes("-embedding")
   );
@@ -25,12 +26,14 @@ export function isEmbeddingModel<T>(modelId: T): boolean {
 
 export function invokeModelSpanName(input: JsonRecord): string {
   const model = stringValue(input.modelId) ?? "unknown";
+
   return `${isEmbeddingModel(model) ? "embeddings" : "chat"} ${model}`;
 }
 
 export function invokeModelRequestFields(input: JsonRecord): SpanFields {
   const model = stringValue(input.modelId);
   const body = parseBody(input.body, input.contentType);
+
   return omitUndefined({
     provider: PROVIDER,
     model,
@@ -44,20 +47,25 @@ export function invokeModelResponseFields(input: JsonRecord, output: JsonValue):
   const model = stringValue(input.modelId);
   const body = isRecord(output) ? parseBody(output.body, output.contentType) : undefined;
   const metadata = isRecord(output) ? output.$metadata : undefined;
+
   return mergeFields(awsMetadataFields(metadata), nativeResponseFields(model, body, metadata));
 }
 
 export function parseBody<TBody, TContentType>(body: TBody, contentType: TContentType): JsonValue {
   const type = stringValue(contentType) ?? "application/json";
+
   if (!type.includes("json")) return undefined;
+
   return parseJson(body);
 }
 
 function nativeSamplingFields<T>(model: string | undefined, body: T): SpanFields {
   if (!isRecord(body)) return {};
   const lower = model?.toLowerCase() ?? "";
+
   if (lower.includes("amazon.titan")) {
     const cfg = isRecord(body.textGenerationConfig) ? body.textGenerationConfig : {};
+
     return omitUndefined({
       temperature: numberValue(cfg.temperature),
       topP: numberValue(cfg.topP),
@@ -65,8 +73,10 @@ function nativeSamplingFields<T>(model: string | undefined, body: T): SpanFields
       stopSequences: arrayValue<string>(cfg.stopSequences),
     });
   }
+
   if (lower.includes("amazon.nova")) {
     const cfg = isRecord(body.inferenceConfig) ? body.inferenceConfig : {};
+
     return omitUndefined({
       temperature: numberValue(cfg.temperature),
       topP: numberValue(cfg.topP) ?? numberValue(cfg.top_p),
@@ -75,6 +85,7 @@ function nativeSamplingFields<T>(model: string | undefined, body: T): SpanFields
       stopSequences: arrayValue<string>(cfg.stopSequences),
     });
   }
+
   if (lower.includes("anthropic.claude")) {
     return omitUndefined({
       temperature: numberValue(body.temperature),
@@ -84,6 +95,7 @@ function nativeSamplingFields<T>(model: string | undefined, body: T): SpanFields
       stopSequences: arrayValue<string>(body.stop_sequences),
     });
   }
+
   if (lower.includes("meta.llama")) {
     return omitUndefined({
       temperature: numberValue(body.temperature),
@@ -91,6 +103,7 @@ function nativeSamplingFields<T>(model: string | undefined, body: T): SpanFields
       maxTokens: numberValue(body.max_gen_len),
     });
   }
+
   return omitUndefined({
     temperature: numberValue(body.temperature),
     topP: numberValue(body.top_p) ?? numberValue(body.topP),
@@ -105,6 +118,7 @@ function nativeResponseFields(
 ): SpanFields {
   if (!isRecord(body)) return headerUsageFields(metadata);
   const lower = model?.toLowerCase() ?? "";
+
   if (isEmbeddingModel(model)) {
     return withHeaderUsage(
       {
@@ -115,8 +129,10 @@ function nativeResponseFields(
       metadata,
     );
   }
+
   if (lower.includes("amazon.titan")) {
     const first = Array.isArray(body.results) && isRecord(body.results[0]) ? body.results[0] : {};
+
     return omitUndefined({
       output: body,
       finishReason: stringValue(first.completionReason),
@@ -126,8 +142,10 @@ function nativeResponseFields(
       }),
     });
   }
+
   if (lower.includes("amazon.nova")) {
     const usage = isRecord(body.usage) ? body.usage : {};
+
     return omitUndefined({
       output: body,
       finishReason: stringValue(body.stopReason),
@@ -138,8 +156,10 @@ function nativeResponseFields(
       }),
     });
   }
+
   if (lower.includes("anthropic.claude")) {
     const usage = isRecord(body.usage) ? body.usage : {};
+
     return withHeaderUsage(
       {
         output: body,
@@ -154,6 +174,7 @@ function nativeResponseFields(
       metadata,
     );
   }
+
   if (lower.includes("meta.llama")) {
     return omitUndefined({
       output: body,
@@ -164,32 +185,39 @@ function nativeResponseFields(
       }),
     });
   }
+
   if (lower.includes("mistral")) {
     const first = Array.isArray(body.outputs) && isRecord(body.outputs[0]) ? body.outputs[0] : {};
+
     return withHeaderUsage(
       { output: body, finishReason: stringValue(first.stop_reason) },
       metadata,
     );
   }
+
   if (lower.includes("cohere.command-r")) {
     return withHeaderUsage(
       { output: body, finishReason: stringValue(body.finish_reason) },
       metadata,
     );
   }
+
   if (lower.includes("cohere.command")) {
     const first =
       Array.isArray(body.generations) && isRecord(body.generations[0]) ? body.generations[0] : {};
+
     return withHeaderUsage(
       { output: body, finishReason: stringValue(first.finish_reason) },
       metadata,
     );
   }
+
   return withHeaderUsage({ output: body }, metadata);
 }
 
 function withHeaderUsage<T>(fields: SpanFields, metadata: T): SpanFields {
   if (fields.usage && Object.keys(fields.usage).length > 0) return fields;
+
   return mergeFields(fields, headerUsageFields(metadata));
 }
 
@@ -201,19 +229,24 @@ function headerUsageFields<T>(metadata: T): SpanFields {
         ? metadata.HTTPHeaders
         : undefined
     : undefined;
+
   const usage = omitUndefined({
     inputTokens: headerNumber(headers?.["x-amzn-bedrock-input-token-count"]),
     outputTokens: headerNumber(headers?.["x-amzn-bedrock-output-token-count"]),
   });
+
   return { usage: Object.keys(usage).length > 0 ? usage : undefined };
 }
 
 function headerNumber<T>(value: T): number | undefined {
   const text = stringValue(value);
+
   if (text !== undefined) {
     const parsed = Number.parseInt(text, 10);
+
     return Number.isFinite(parsed) ? parsed : undefined;
   }
+
   return numberValue(value);
 }
 
@@ -227,12 +260,14 @@ export class InvokeModelStreamState implements StreamState {
   feed<T>(event: T): boolean {
     if (!isRecord(event)) return false;
     const streamError = modeledStreamError(event);
+
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
 
       return false;
     }
+
     const chunk = isRecord(event.chunk) ? event.chunk : undefined;
     const parsed = parseJson(chunk?.bytes);
 
@@ -244,22 +279,27 @@ export class InvokeModelStreamState implements StreamState {
 
     this.chunks.push(parsed);
     this.text += textFromProviderChunk(parsed);
+
     if (isRecord(parsed)) {
       const delta = isRecord(parsed.delta) ? parsed.delta : undefined;
       const message = isRecord(parsed.message) ? parsed.message : undefined;
       const messageUsage = isRecord(message?.usage) ? message?.usage : undefined;
       const usage = isRecord(parsed.usage) ? parsed.usage : undefined;
+
       const metrics = isRecord(parsed["amazon-bedrock-invocationMetrics"])
         ? parsed["amazon-bedrock-invocationMetrics"]
         : undefined;
+
       const outputs =
         Array.isArray(parsed.outputs) && isRecord(parsed.outputs[0])
           ? parsed.outputs[0]
           : undefined;
+
       const generation =
         Array.isArray(parsed.generations) && isRecord(parsed.generations[0])
           ? parsed.generations[0]
           : undefined;
+
       this.finishReason =
         stringValue(delta?.stop_reason) ??
         stringValue(parsed.stop_reason) ??
@@ -314,16 +354,20 @@ export class InvokeModelStreamState implements StreamState {
 function textFromProviderChunk<T>(value: T): string {
   if (!isRecord(value)) return "";
   const delta = isRecord(value.delta) ? value.delta : undefined;
+
   const contentBlockDelta = isRecord(value.contentBlockDelta)
     ? value.contentBlockDelta
     : isRecord(value.content_block_delta)
       ? value.content_block_delta
       : undefined;
+
   const nestedDelta = isRecord(contentBlockDelta?.delta) ? contentBlockDelta?.delta : undefined;
+
   const generation =
     Array.isArray(value.generations) && isRecord(value.generations[0])
       ? value.generations[0]
       : undefined;
+
   return (
     stringValue(value.outputText) ??
     stringValue(value.generation) ??

--- a/packages/bedrock/src/invoke-model.ts
+++ b/packages/bedrock/src/invoke-model.ts
@@ -224,17 +224,24 @@ export class InvokeModelStreamState implements StreamState {
   private finishReason: string | undefined;
   private error: Error | undefined;
   private errorFields: SpanFields | undefined;
-  feed<T>(event: T): void {
-    if (!isRecord(event)) return;
+  feed<T>(event: T): boolean {
+    if (!isRecord(event)) return false;
     const streamError = modeledStreamError(event);
     if (streamError) {
       this.error = streamError.error;
       this.errorFields = streamError.fields;
-      return;
+
+      return false;
     }
     const chunk = isRecord(event.chunk) ? event.chunk : undefined;
     const parsed = parseJson(chunk?.bytes);
-    if (parsed === undefined) return;
+
+    if (parsed === undefined) {
+      const raw = chunk?.bytes;
+
+      return (typeof raw === "string" || raw instanceof Uint8Array) && raw.length > 0;
+    }
+
     this.chunks.push(parsed);
     this.text += textFromProviderChunk(parsed);
     if (isRecord(parsed)) {
@@ -279,6 +286,8 @@ export class InvokeModelStreamState implements StreamState {
           this.usage?.cacheCreationInputTokens,
       });
     }
+
+    return providerChunkHasOutput(parsed);
   }
 
   finish(): SpanFields {
@@ -327,5 +336,16 @@ function textFromProviderChunk<T>(value: T): string {
       : undefined) ??
     stringValue(generation?.text) ??
     ""
+  );
+}
+
+function providerChunkHasOutput<T>(value: T): boolean {
+  if (!isRecord(value)) return false;
+  const delta = isRecord(value.delta) ? value.delta : undefined;
+
+  return (
+    textFromProviderChunk(value).length > 0 ||
+    (typeof delta?.thinking === "string" && delta.thinking.length > 0) ||
+    (typeof delta?.partial_json === "string" && delta.partial_json.length > 0)
   );
 }

--- a/packages/bedrock/tests/agents.test.ts
+++ b/packages/bedrock/tests/agents.test.ts
@@ -22,6 +22,7 @@ afterEach(async () => {
 
 test("InvokeAgent aggregates trace usage and return control", async () => {
   const spans = setup();
+
   const client = wrapBedrockAgents(
     new FakeClient([
       {
@@ -53,6 +54,7 @@ test("InvokeAgent aggregates trace usage and return control", async () => {
     ]),
     { captureAgentTrace: true },
   );
+
   const response = (await client.send(
     new InvokeAgentCommand({
       agentId: "agent-1",
@@ -62,6 +64,7 @@ test("InvokeAgent aggregates trace usage and return control", async () => {
       enableTrace: true,
     }),
   )) as { completion: AsyncIterable<unknown> };
+
   await collect(response.completion);
 
   const [span] = spans.getFinishedSpans();
@@ -86,6 +89,7 @@ test("InvokeAgent aggregates trace usage and return control", async () => {
 
 test("Retrieve and RetrieveAndGenerate capture outputs and citations", async () => {
   const spans = setup();
+
   const client = wrapBedrockAgents(
     new FakeClient([
       {
@@ -127,6 +131,7 @@ test("Retrieve and RetrieveAndGenerate capture outputs and citations", async () 
 
 test("RetrieveAndGenerateStream and InvokeFlow finish from streams", async () => {
   const spans = setup();
+
   const client = wrapBedrockAgents(
     new FakeClient([
       {
@@ -150,13 +155,17 @@ test("RetrieveAndGenerateStream and InvokeFlow finish from streams", async () =>
       },
     ]),
   );
+
   const rag = (await client.send(
     new RetrieveAndGenerateStreamCommand({ input: { text: "q" } }),
   )) as { stream: AsyncIterable<unknown> };
+
   await collect(rag.stream);
+
   const flow = (await client.send(
     new InvokeFlowCommand({ flowIdentifier: "flow-1", flowAliasIdentifier: "alias", inputs: [] }),
   )) as { responseStream: AsyncIterable<unknown> };
+
   await collect(flow.responseStream);
 
   const [ragSpan, flowSpan] = spans.getFinishedSpans();
@@ -171,8 +180,10 @@ test("RetrieveAndGenerateStream and InvokeFlow finish from streams", async () =>
   ]);
   expect(flowSpan.attributes["gen_ai.response.finish_reasons"]).toEqual(["SUCCESS"]);
 });
+
 test("modeled stream errors from Agent, RAG, and Flow mark spans as errors", async () => {
   const spans = setup();
+
   const client = wrapBedrockAgents(
     new FakeClient([
       {
@@ -213,17 +224,23 @@ test("modeled stream errors from Agent, RAG, and Flow mark spans as errors", asy
       },
     ]),
   );
+
   const agent = (await client.send(
     new InvokeAgentCommand({ agentId: "agent-1", agentAliasId: "alias", sessionId: "sess" }),
   )) as { completion: AsyncIterable<unknown> };
+
   await collect(agent.completion);
+
   const rag = (await client.send(
     new RetrieveAndGenerateStreamCommand({ input: { text: "q" } }),
   )) as { stream: AsyncIterable<unknown> };
+
   await collect(rag.stream);
+
   const flow = (await client.send(
     new InvokeFlowCommand({ flowIdentifier: "flow-1", flowAliasIdentifier: "alias", inputs: [] }),
   )) as { responseStream: AsyncIterable<unknown> };
+
   await collect(flow.responseStream);
 
   const [agentSpan, ragSpan, flowSpan] = spans.getFinishedSpans();
@@ -243,10 +260,12 @@ test("modeled stream errors from Agent, RAG, and Flow mark spans as errors", asy
 
 test("global agents instrumentation is idempotent", async () => {
   const spans = setup();
+
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     BedrockAgentRuntimeClient.prototype,
     "send",
   );
+
   const fakeSend = async () => ({
     completion: streamOf([{ chunk: { bytes: bytes("global") } }]),
     $metadata: { requestId: "agent-global-1" },
@@ -261,13 +280,16 @@ test("global agents instrumentation is idempotent", async () => {
   try {
     instrumentBedrockAgents();
     instrumentBedrockAgents();
+
     const client = new BedrockAgentRuntimeClient({
       region: "us-east-1",
       credentials: { accessKeyId: "test", secretAccessKey: "test" },
     });
+
     const response = (await client.send(
       new InvokeAgentCommand({ agentId: "agent-1", agentAliasId: "alias", sessionId: "sess" }),
     )) as { completion: AsyncIterable<unknown> };
+
     await collect(response.completion);
     expect(spans.getFinishedSpans()).toHaveLength(1);
     expect(spans.getFinishedSpans()[0]!.attributes["gen_ai.response.id"]).toBe("agent-global-1");
@@ -277,6 +299,7 @@ test("global agents instrumentation is idempotent", async () => {
     ).toBe(fakeSend);
   } finally {
     uninstrumentBedrockAgents();
+
     if (originalDescriptor) {
       Object.defineProperty(BedrockAgentRuntimeClient.prototype, "send", originalDescriptor);
     }

--- a/packages/bedrock/tests/bedrock.test.ts
+++ b/packages/bedrock/tests/bedrock.test.ts
@@ -19,6 +19,7 @@ afterEach(async () => {
 
 test("Converse captures normalized messages, usage, metadata, request id, and sampling", async () => {
   const spans = setup();
+
   const request: ConverseCommandInput = {
     modelId: "anthropic.claude-3-5-haiku-20241022-v1:0",
     messages: [
@@ -33,7 +34,9 @@ test("Converse captures normalized messages, usage, metadata, request id, and sa
     system: [{ text: "be terse" }],
     inferenceConfig: { temperature: 0.2, topP: 0.8, maxTokens: 64, stopSequences: ["stop"] },
   };
+
   const requestSnapshot = structuredClone(request);
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -87,6 +90,7 @@ test("Converse captures normalized messages, usage, metadata, request id, and sa
 
 test("Converse normalizes tool calls, tool results, and reasoning", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -141,12 +145,15 @@ test("Converse normalizes tool calls, tool results, and reasoning", async () => 
     { type: "reasoning", content: "Need weather." },
   ]);
 });
+
 test("Converse normalizes citationsContent as cited text", async () => {
   const spans = setup();
+
   const citation = {
     title: "source",
     location: { s3Location: { uri: "s3://bucket/doc.txt" } },
   };
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -179,6 +186,7 @@ test("Converse normalizes citationsContent as cited text", async () => {
 
 test("ConverseStream accumulates output and ends partial on early break", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -193,9 +201,11 @@ test("ConverseStream accumulates output and ends partial on early break", async 
       },
     ]),
   );
+
   const response = (await client.send(
     new ConverseStreamCommand({ modelId: "anthropic.claude", messages: [] }),
   )) as { stream: AsyncIterable<unknown> };
+
   await collect(response.stream, 3);
 
   const [span] = spans.getFinishedSpans();
@@ -209,6 +219,7 @@ test("ConverseStream accumulates output and ends partial on early break", async 
 
 test("ConverseStream records modeled errors and non-text blocks", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -243,9 +254,11 @@ test("ConverseStream records modeled errors and non-text blocks", async () => {
       },
     ]),
   );
+
   const response = (await client.send(
     new ConverseStreamCommand({ modelId: "anthropic.claude", messages: [] }),
   )) as { stream: AsyncIterable<unknown> };
+
   await collect(response.stream);
 
   const [span] = spans.getFinishedSpans();
@@ -261,6 +274,7 @@ test("ConverseStream records modeled errors and non-text blocks", async () => {
 
 test("ConverseStream records stream errors with partial output", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -278,9 +292,11 @@ test("ConverseStream records stream errors with partial output", async () => {
       },
     ]),
   );
+
   const response = (await client.send(
     new ConverseStreamCommand({ modelId: "anthropic.claude", messages: [] }),
   )) as { stream: AsyncIterable<unknown> };
+
   await expect(collect(response.stream)).rejects.toThrow("stream boom");
 
   const [span] = spans.getFinishedSpans();
@@ -293,6 +309,7 @@ test("ConverseStream records stream errors with partial output", async () => {
 
 test("InvokeModel captures provider-native bodies and embedding spans", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -366,6 +383,7 @@ test("InvokeModel captures Nova native sampling fields", async () => {
 
 test("InvokeModelWithResponseStream preserves optional invocation metrics", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -383,6 +401,7 @@ test("InvokeModelWithResponseStream preserves optional invocation metrics", asyn
       },
     ]),
   );
+
   const response = (await client.send(
     new InvokeModelWithResponseStreamCommand({
       modelId: "anthropic.claude",
@@ -390,6 +409,7 @@ test("InvokeModelWithResponseStream preserves optional invocation metrics", asyn
       body: bytes({ messages: [], max_tokens: 10 }),
     }),
   )) as { body: AsyncIterable<unknown> };
+
   await collect(response.body);
 
   const [span] = spans.getFinishedSpans();
@@ -437,6 +457,7 @@ test("InvokeModelWithResponseStream parses each payload once and delivers malfor
 
 test("InvokeModelWithResponseStream captures Titan token counts and Cohere generations", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -465,6 +486,7 @@ test("InvokeModelWithResponseStream captures Titan token counts and Cohere gener
       },
     ]),
   );
+
   const titan = (await client.send(
     new InvokeModelWithResponseStreamCommand({
       modelId: "amazon.titan-text-express-v1",
@@ -472,7 +494,9 @@ test("InvokeModelWithResponseStream captures Titan token counts and Cohere gener
       body: bytes({ inputText: "hello" }),
     }),
   )) as { body: AsyncIterable<unknown> };
+
   await collect(titan.body);
+
   const cohere = (await client.send(
     new InvokeModelWithResponseStreamCommand({
       modelId: "cohere.command-text-v14",
@@ -480,6 +504,7 @@ test("InvokeModelWithResponseStream captures Titan token counts and Cohere gener
       body: bytes({ prompt: "hello" }),
     }),
   )) as { body: AsyncIterable<unknown> };
+
   await collect(cohere.body);
 
   const [titanSpan, cohereSpan] = spans.getFinishedSpans();
@@ -493,6 +518,7 @@ test("InvokeModelWithResponseStream captures Titan token counts and Cohere gener
 
 test("InvokeModelWithResponseStream normalizes Nova contentBlockDelta chunks", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -503,6 +529,7 @@ test("InvokeModelWithResponseStream normalizes Nova contentBlockDelta chunks", a
       },
     ]),
   );
+
   const response = (await client.send(
     new InvokeModelWithResponseStreamCommand({
       modelId: "amazon.nova-pro-v1:0",
@@ -510,6 +537,7 @@ test("InvokeModelWithResponseStream normalizes Nova contentBlockDelta chunks", a
       body: bytes({ messages: [] }),
     }),
   )) as { body: AsyncIterable<unknown> };
+
   await collect(response.body);
 
   const [span] = spans.getFinishedSpans();
@@ -518,6 +546,7 @@ test("InvokeModelWithResponseStream normalizes Nova contentBlockDelta chunks", a
 
 test("InvokeModelWithResponseStream records modeled stream errors with partial output", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -534,6 +563,7 @@ test("InvokeModelWithResponseStream records modeled stream errors with partial o
       },
     ]),
   );
+
   const response = (await client.send(
     new InvokeModelWithResponseStreamCommand({
       modelId: "anthropic.claude",
@@ -541,6 +571,7 @@ test("InvokeModelWithResponseStream records modeled stream errors with partial o
       body: bytes({ messages: [], max_tokens: 10 }),
     }),
   )) as { body: AsyncIterable<unknown> };
+
   await collect(response.body);
 
   const [span] = spans.getFinishedSpans();
@@ -552,6 +583,7 @@ test("InvokeModelWithResponseStream records modeled stream errors with partial o
 
 test("ApplyGuardrail captures action metadata", async () => {
   const spans = setup();
+
   const client = wrapBedrock(
     new FakeClient([
       {
@@ -581,10 +613,12 @@ test("ApplyGuardrail captures action metadata", async () => {
 
 test("errors, fail-open, idempotency, and prototype restore behave", async () => {
   const spans = setup();
+
   const error = Object.assign(new Error("throttled"), {
     name: "ThrottlingException",
     $metadata: { requestId: "err-1", attempts: 2, httpStatusCode: 429, totalRetryDelay: 25 },
   });
+
   const client = wrapBedrock(wrapBedrock(new FakeClient([error])));
 
   await expect(client.send(new ConverseCommand({ modelId: "m", messages: [] }))).rejects.toThrow(
@@ -608,18 +642,22 @@ test("errors, fail-open, idempotency, and prototype restore behave", async () =>
 test("callback-style send creates a span while returning undefined", () => {
   const spans = setup();
   let callbackData: unknown;
+
   const client = wrapBedrock({
     calls: 0,
     send<TCommand>(_command: TCommand, ...rest: unknown[]): undefined {
       this.calls += 1;
+
       const callback = rest.find(
         (arg): arg is (cause: unknown, data?: { output: object; $metadata: object }) => void =>
           arg instanceof Function,
       );
+
       callback?.(undefined, {
         output: { message: { role: "assistant", content: [{ text: "ok" }] } },
         $metadata: { requestId: "callback-1" },
       });
+
       return undefined;
     },
   });
@@ -645,10 +683,12 @@ test("callback-style send creates a span while returning undefined", () => {
 
 test("global instrumentation is idempotent", async () => {
   const spans = setup();
+
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     BedrockRuntimeClient.prototype,
     "send",
   );
+
   const fakeSend = async () => ({
     output: { message: { content: [] } },
     $metadata: { requestId: "global-1" },
@@ -663,17 +703,21 @@ test("global instrumentation is idempotent", async () => {
   try {
     instrumentBedrock();
     instrumentBedrock();
+
     const client = new BedrockRuntimeClient({
       region: "us-east-1",
       credentials: { accessKeyId: "test", secretAccessKey: "test" },
     });
+
     await client.send(new ConverseCommand({ modelId: "m", messages: [] }));
     expect(spans.getFinishedSpans()).toHaveLength(1);
     expect(spans.getFinishedSpans()[0]!.attributes["gen_ai.response.id"]).toBe("global-1");
+
     const telemetryWrapper = Object.getOwnPropertyDescriptor(
       BedrockRuntimeClient.prototype,
       "send",
     )?.value;
+
     const laterWrapper = async () => ({ output: { message: { content: [] } } });
     Object.defineProperty(BedrockRuntimeClient.prototype, "send", {
       configurable: true,
@@ -695,6 +739,7 @@ test("global instrumentation is idempotent", async () => {
     );
   } finally {
     uninstrumentBedrock();
+
     if (originalDescriptor) {
       Object.defineProperty(BedrockRuntimeClient.prototype, "send", originalDescriptor);
     }

--- a/packages/bedrock/tests/bedrock.test.ts
+++ b/packages/bedrock/tests/bedrock.test.ts
@@ -7,7 +7,7 @@ import {
   InvokeModelWithResponseStreamCommand,
   type ConverseCommandInput,
 } from "@aws-sdk/client-bedrock-runtime";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 import { instrumentBedrock, uninstrumentBedrock, wrapBedrock } from "../src/index.ts";
 import { FakeClient, bytes, collect, jsonAttr, setup, streamOf, teardown } from "./helpers.ts";
@@ -372,6 +372,8 @@ test("InvokeModelWithResponseStream preserves optional invocation metrics", asyn
         body: streamOf([
           { chunk: { bytes: bytes({ message: { usage: { input_tokens: 2 } } }) } },
           { chunk: { bytes: bytes({ delta: { text: "hi", stop_reason: "end_turn" } }) } },
+          { chunk: { bytes: bytes({ delta: { thinking: "reasoning" } }) } },
+          { chunk: { bytes: bytes({ delta: { partial_json: '{"city":' } }) } },
           { chunk: { bytes: bytes({ completion: " legacy" }) } },
           { chunk: { bytes: bytes({ outputs: [{ text: " mistral", stop_reason: "stop" }] }) } },
           {
@@ -395,6 +397,42 @@ test("InvokeModelWithResponseStream preserves optional invocation metrics", asyn
   expect(span.attributes["gen_ai.usage.output_tokens"]).toBeUndefined();
   expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual(["stop"]);
   expect(jsonAttr(span, "gen_ai.output.messages")[0].parts[0].content).toBe("hi legacy mistral");
+  expect(span).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 4 },
+  });
+});
+
+test("InvokeModelWithResponseStream parses each payload once and delivers malformed payloads", async () => {
+  const spans = setup();
+  const parse = vi.spyOn(JSON, "parse");
+  const malformed = new TextEncoder().encode("not-json");
+
+  const events = [
+    { chunk: { bytes: bytes({ delta: { text: "hi" } }) } },
+    { chunk: { bytes: new Uint8Array() } },
+    { chunk: { bytes: bytes({ delta: { text: "there" } }) } },
+    { chunk: { bytes: malformed } },
+  ];
+
+  const client = wrapBedrock(new FakeClient([{ body: streamOf(events) }]));
+
+  const response = (await client.send(
+    new InvokeModelWithResponseStreamCommand({
+      modelId: "anthropic.claude",
+      contentType: "application/json",
+      body: bytes({ messages: [], max_tokens: 10 }),
+    }),
+  )) as { body: AsyncIterable<unknown> };
+
+  const before = parse.mock.calls.length;
+
+  expect(await collect(response.body)).toEqual(events);
+  expect(parse.mock.calls.length - before).toBe(4);
+  parse.mockRestore();
+  const [span] = spans.getFinishedSpans();
+  expect(span).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 2 },
+  });
 });
 
 test("InvokeModelWithResponseStream captures Titan token counts and Cohere generations", async () => {

--- a/packages/bedrock/tests/helpers.ts
+++ b/packages/bedrock/tests/helpers.ts
@@ -16,6 +16,7 @@ export function setup(): InMemorySpanExporter {
     },
     { spanExporter: spans, logRecordExporter: new InMemoryLogRecordExporter() },
   );
+
   return spans;
 }
 
@@ -25,7 +26,9 @@ export async function teardown(): Promise<void> {
 
 export function jsonAttr(span: ReadableSpan, key: string): any {
   const value = span.attributes[key];
+
   if (String(value) !== value) throw new Error(`${key} is not a string attribute`);
+
   return JSON.parse(value);
 }
 
@@ -36,19 +39,25 @@ export class FakeClient {
   async send(command: any, ..._rest: any[]): Promise<any> {
     const input =
       command && Object(command) === command && "input" in command ? command.input : undefined;
+
     this.calls.push(structuredClone(input));
     const response = this.responses.shift();
+
     if (response instanceof Error) throw response;
+
     return response;
   }
 }
 
 export async function collect<T>(iterable: AsyncIterable<T>, limit?: number): Promise<T[]> {
   const out: T[] = [];
+
   for await (const item of iterable) {
     out.push(item);
+
     if (limit !== undefined && out.length >= limit) break;
   }
+
   return out;
 }
 
@@ -65,6 +74,7 @@ export async function* streamOf(
     if (throwAt === i) throw error;
     yield events[i];
   }
+
   if (throwAt === events.length) {
     throw error;
   }

--- a/packages/cursor/src/config.ts
+++ b/packages/cursor/src/config.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { init, shutdown, type ClientOverrides, type TelemetryOptions } from "@telemetry-dev/sdk";
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -34,16 +35,21 @@ export function configPath(): string {
  */
 export function fileConfig(): TelemetryDevCursorOptions {
   let parsed: unknown;
+
   try {
     parsed = JSON.parse(readFileSync(configPath(), "utf8"));
   } catch {
     // A missing or malformed file must never crash the daemon.
     return {};
   }
+
   const record = asRecord(parsed);
+
   if (!record) return {};
+
   const pick = (key: string, envVar: string): string | undefined =>
     process.env[envVar] === undefined ? readString(record[key]) : undefined;
+
   return {
     apiKey: pick("apiKey", "TELEMETRY_DEV_API_KEY"),
     baseUrl: pick("baseUrl", "TELEMETRY_DEV_BASE_URL"),
@@ -87,5 +93,6 @@ function asRecord<T>(value: T): JsonRecord | undefined {
 
 function readString<T>(value: T): string | undefined {
   const raw: unknown = value;
+
   return String(raw) === raw ? raw : undefined;
 }

--- a/packages/cursor/src/daemon.ts
+++ b/packages/cursor/src/daemon.ts
@@ -19,6 +19,7 @@ import { fileConfig } from "./config.ts";
 import { createCursorTelemetry, type CursorTelemetry } from "./telemetry.ts";
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -36,6 +37,7 @@ export function socketPath(): string {
   if (process.platform === "win32") {
     return `\\\\.\\pipe\\telemetry-dev-cursor-${userInfo().username}`;
   }
+
   return join(socketDir(), "d.sock");
 }
 
@@ -51,11 +53,14 @@ function socketDir(): string {
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   const stat = lstatSync(dir);
   const uid = process.getuid?.();
+
   if (!stat.isDirectory() || (uid !== undefined && stat.uid !== uid)) {
     throw new Error(`refusing unsafe socket directory ${dir}`);
   }
+
   // mkdirSync ignores mode for a pre-existing directory; tighten it ourselves.
   if ((stat.mode & 0o077) !== 0) chmodSync(dir, 0o700);
+
   return dir;
 }
 
@@ -66,16 +71,21 @@ function socketDir(): string {
 export async function runDaemon(): Promise<void> {
   const telemetry = createCursorTelemetry(fileConfig());
   let server: Server | undefined;
+
   const shutdown = (): void => {
     if (server) void stop(server, telemetry);
   };
+
   server = await listen(socketPath(), telemetry, shutdown);
+
   if (!server) {
     await telemetry.settle();
+
     return;
   }
 
   let idleTimer: NodeJS.Timeout | undefined;
+
   const touch = (): void => {
     clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
@@ -83,6 +93,7 @@ export async function runDaemon(): Promise<void> {
       else shutdown();
     }, IDLE_MS);
   };
+
   server.on("connection", touch);
   touch();
 
@@ -113,29 +124,39 @@ export async function listen(
       await bind(server, path);
     } catch (error) {
       const code = errorCode(error);
+
       if (code !== "EADDRINUSE") throw error;
+
       if (await alive(path)) return undefined;
       await bind(server, path);
     }
+
     return server;
   }
 
   const owner = lockRecovery(path);
+
   if (!owner) return undefined;
+
   try {
     try {
       await bind(server, path);
     } catch (error) {
       const code = errorCode(error);
+
       if (code !== "EADDRINUSE") throw error;
+
       if (await alive(path)) return undefined;
       const stale = lstatSync(path, { throwIfNoEntry: false });
+
       if (stale && !stale.isSocket()) {
         throw new Error(`refusing to replace non-socket ${path}`);
       }
+
       if (stale) unlinkSync(path);
       await bind(server, path);
     }
+
     return server;
   } finally {
     unlockRecovery(path, owner);
@@ -153,20 +174,27 @@ function lockRecovery(path: string): string | undefined {
   const pending = `${lock}.${owner}`;
   mkdirSync(pending, { mode: 0o700 });
   writeFileSync(join(pending, owner), "", { flag: "wx", mode: 0o600 });
+
   try {
     try {
       renameSync(pending, lock);
+
       return owner;
     } catch (error) {
       const code = errorCode(error);
+
       if (code !== "EEXIST" && code !== "ENOTEMPTY") throw error;
     }
+
     if (!clearStaleLock(lock)) return undefined;
+
     try {
       renameSync(pending, lock);
+
       return owner;
     } catch (error) {
       const code = errorCode(error);
+
       if (code === "EEXIST" || code === "ENOTEMPTY") return undefined;
       throw error;
     }
@@ -177,31 +205,40 @@ function lockRecovery(path: string): string | undefined {
 
 function clearStaleLock(lock: string): boolean {
   let entries: string[];
+
   try {
     entries = readdirSync(lock);
   } catch (error) {
     return errorCode(error) === "ENOENT";
   }
+
   if (entries.length > 1) return false;
+
   if (entries.length === 1) {
     const entry = entries[0];
+
     if (!entry) return false;
     const held = join(lock, entry);
     let mtimeMs: number;
+
     try {
       mtimeMs = lstatSync(held).mtimeMs;
     } catch (error) {
       return errorCode(error) === "ENOENT";
     }
+
     if (Date.now() - mtimeMs <= LOCK_STALE_MS) return false;
+
     try {
       unlinkSync(held);
     } catch (error) {
       return errorCode(error) === "ENOENT";
     }
   }
+
   try {
     rmdirSync(lock);
+
     return true;
   } catch (error) {
     return errorCode(error) === "ENOENT";
@@ -210,20 +247,24 @@ function clearStaleLock(lock: string): boolean {
 
 function unlockRecovery(path: string, owner: string): void {
   const lock = `${path}.lock`;
+
   try {
     unlinkSync(join(lock, owner));
   } catch {
     return;
   }
+
   try {
     rmdirSync(lock);
   } catch {
     // The directory is already gone or belongs to a new owner.
   }
 }
+
 function errorCode<T>(error: T): string | undefined {
   if (error === null || error instanceof Function || Object(error) !== error) return undefined;
   const value = error as T & { code?: JsonValue };
+
   return "code" in value ? readString(value.code) : undefined;
 }
 
@@ -234,6 +275,7 @@ function bind(server: Server, path: string): Promise<void> {
     server.removeListener("error", reject);
     resolve();
   });
+
   return promise;
 }
 
@@ -245,6 +287,7 @@ function alive(path: string): Promise<boolean> {
     resolve(true);
   });
   probe.once("error", () => resolve(false));
+
   return promise;
 }
 
@@ -260,14 +303,18 @@ function serve(
   socket.on("data", (chunk: string) => {
     buffer += chunk;
     let index = buffer.indexOf("\n");
+
     while (index >= 0) {
       const line = buffer.slice(0, index);
       buffer = buffer.slice(index + 1);
       index = buffer.indexOf("\n");
+
       if (line.trim().length === 0) continue;
       let shutdown = false;
+
       try {
         const parsed = JSON.parse(line) as JsonRecord;
+
         if (parsed.telemetry_dev_control === "shutdown") {
           // Sent by install/uninstall so the next hook restarts the daemon
           // with the new configuration.
@@ -278,7 +325,9 @@ function serve(
       } catch {
         // Malformed line from a mismatched forwarder version; drop it.
       }
+
       socket.write("ok\n");
+
       if (shutdown) onShutdown();
     }
   });
@@ -293,16 +342,21 @@ function serve(
 function replayed(event: JsonRecord, seenIds: Set<string>): boolean {
   const id = readString(event.hook_delivery_id);
   delete event.hook_delivery_id;
+
   if (id === undefined) return false;
+
   if (seenIds.has(id)) return true;
   seenIds.add(id);
+
   if (seenIds.size > SEEN_IDS_MAX) {
     seenIds.delete(seenIds.values().next().value as string);
   }
+
   return false;
 }
 
 function readString<T>(value: T): string | undefined {
   const raw: unknown = value;
+
   return String(raw) === raw ? raw : undefined;
 }

--- a/packages/cursor/src/hook.ts
+++ b/packages/cursor/src/hook.ts
@@ -6,6 +6,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { socketPath } from "./daemon.ts";
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -26,10 +27,12 @@ const DELIVER_DEADLINE_MS = 10_000;
 export async function runHook(cliPath: string): Promise<void> {
   try {
     const payload = await readStdin();
+
     if (payload.trim().length > 0) await deliver(payload, cliPath);
   } catch {
     // Fail open.
   }
+
   process.exitCode = 0;
   process.stdout.write("{}\n");
 }
@@ -41,23 +44,29 @@ function readStdin(): Promise<string> {
   process.stdin.on("data", (chunk: string) => (data += chunk));
   process.stdin.on("end", () => resolve(data));
   process.stdin.on("error", () => resolve(data));
+
   return promise;
 }
 
 async function deliver(payload: string, cliPath: string): Promise<void> {
   const line = frame(payload);
   const deadline = Date.now() + DELIVER_DEADLINE_MS;
+
   try {
     await send(line, deadline);
+
     return;
   } catch {
     spawnDaemon(cliPath);
   }
+
   // The daemon needs a moment to bind its socket after spawn.
   while (Date.now() < deadline) {
     await sleep(100);
+
     try {
       await send(line, deadline);
+
       return;
     } catch {
       continue;
@@ -74,13 +83,16 @@ function frame(payload: string): string {
   try {
     const parsed: unknown = JSON.parse(payload);
     const record = asRecord(parsed);
+
     if (record) {
       record.hook_delivery_id = randomUUID();
+
       return `${JSON.stringify(record)}\n`;
     }
   } catch {
     // Not JSON; forward as-is (the daemon drops undecodable lines).
   }
+
   return `${payload.replaceAll("\n", " ")}\n`;
 }
 
@@ -90,6 +102,7 @@ function spawnDaemon(cliPath: string): void {
     stdio: "ignore",
     env: process.env,
   });
+
   // A spawn failure (missing binary, fork limit) emits an async error event;
   // unhandled it would crash the hook before its fail-open `{}` output.
   child.once("error", () => {});
@@ -98,13 +111,16 @@ function spawnDaemon(cliPath: string): void {
 
 function send(line: string, deadline: number): Promise<void> {
   const budget = Math.min(ACK_TIMEOUT_MS, deadline - Date.now());
+
   if (budget <= 0) return Promise.reject(new Error("delivery deadline exceeded"));
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   const socket: Socket = createConnection(socketPath());
+
   const timer = setTimeout(() => {
     socket.destroy();
     reject(new Error("ack timeout"));
   }, budget);
+
   socket.once("error", (error) => {
     clearTimeout(timer);
     reject(error);
@@ -115,6 +131,7 @@ function send(line: string, deadline: number): Promise<void> {
     socket.end();
     resolve();
   });
+
   return promise;
 }
 

--- a/packages/cursor/src/index.ts
+++ b/packages/cursor/src/index.ts
@@ -1,3 +1,5 @@
 export { type ClientOverrides, type TelemetryDevCursorOptions } from "./config.ts";
+
 export { socketPath } from "./daemon.ts";
+
 export { createCursorTelemetry, type CursorTelemetry, HOOK_EVENTS } from "./telemetry.ts";

--- a/packages/cursor/src/install.ts
+++ b/packages/cursor/src/install.ts
@@ -19,6 +19,7 @@ import { socketPath } from "./daemon.ts";
 import { HOOK_EVENTS } from "./telemetry.ts";
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -34,6 +35,7 @@ interface HookEntry extends JsonRecord {
  */
 export async function runInstall(cliPath: string, args: string[]): Promise<void> {
   const apiKey = flag(args, "--api-key") ?? process.env.TELEMETRY_DEV_API_KEY;
+
   if (!apiKey) {
     process.stderr.write(
       "Missing api key. Pass --api-key td_live_… or set TELEMETRY_DEV_API_KEY.\n",
@@ -43,8 +45,10 @@ export async function runInstall(cliPath: string, args: string[]): Promise<void>
 
   const config = Object.fromEntries([["apiKey", apiKey]]);
   const baseUrl = flag(args, "--base-url") ?? process.env.TELEMETRY_DEV_BASE_URL;
+
   if (baseUrl) config.baseUrl = baseUrl;
   const environment = flag(args, "--environment") ?? process.env.TELEMETRY_DEV_ENVIRONMENT;
+
   if (environment) config.environment = environment;
   const file = configPath();
   writeSecretJson(file, config);
@@ -53,11 +57,13 @@ export async function runInstall(cliPath: string, args: string[]): Promise<void>
   const hooks = readJson(hooksPath);
   const command = hookCommand(cliPath);
   const table = (hooks.hooks ?? {}) as Record<string, HookEntry[]>;
+
   for (const event of HOOK_EVENTS) {
     const kept = (table[event] ?? []).filter((entry) => entry.telemetryDev !== true);
     kept.push({ command, telemetryDev: true });
     table[event] = kept;
   }
+
   writeJson(hooksPath, { version: 1, ...hooks, hooks: table });
   // A running daemon read the old config at startup; stop it so the next hook
   // restarts it with the new settings.
@@ -72,10 +78,13 @@ export async function runUninstall(): Promise<void> {
   const hooksPath = join(homedir(), ".cursor", "hooks.json");
   const hooks = readJson(hooksPath);
   const table = (hooks.hooks ?? {}) as Record<string, HookEntry[]>;
+
   for (const [event, entries] of Object.entries(table)) {
     table[event] = entries.filter((entry) => entry.telemetryDev !== true);
+
     if (table[event].length === 0) delete table[event];
   }
+
   writeJson(hooksPath, { ...hooks, hooks: table });
   await stopDaemon();
   process.stdout.write(`Removed telemetry-dev hooks from ${hooksPath}.\n`);
@@ -85,12 +94,15 @@ export async function runUninstall(): Promise<void> {
 function stopDaemon(): Promise<void> {
   const { promise, resolve } = Promise.withResolvers<void>();
   let socket: Socket | undefined;
+
   const finish = (): void => {
     clearTimeout(timer);
     socket?.destroy();
     resolve();
   };
+
   const timer = setTimeout(() => finish(), 2000);
+
   try {
     socket = createConnection(socketPath());
     socket.once("error", finish);
@@ -99,17 +111,21 @@ function stopDaemon(): Promise<void> {
   } catch {
     finish();
   }
+
   return promise;
 }
 
 function flag(args: string[], name: string): string | undefined {
   const index = args.indexOf(name);
+
   if (index < 0) return undefined;
   const value = args[index + 1];
+
   if (value === undefined || value.startsWith("--")) {
     process.stderr.write(`Missing value for ${name}.\n`);
     process.exit(1);
   }
+
   return value;
 }
 
@@ -119,22 +135,27 @@ function hookCommand(cliPath: string): string {
     const cli = cliPath.replaceAll("'", "''");
     const script = `& '${exe}' '${cli}' hook`;
     const encoded = Buffer.from(script, "utf16le").toString("base64");
+
     return `powershell.exe -NoProfile -NonInteractive -EncodedCommand ${encoded}`;
   }
+
   const exe = `'${process.execPath.replaceAll("'", "'\\''")}'`;
   const cli = `'${cliPath.replaceAll("'", "'\\''")}'`;
+
   return `${exe} ${cli} hook`;
 }
 
 function readJson(path: string): JsonRecord {
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+
     if (parsed !== null && !(parsed instanceof Function) && Object(parsed) === parsed) {
       return parsed as JsonRecord;
     }
   } catch {
     // Missing or invalid file; start fresh.
   }
+
   return {};
 }
 
@@ -142,12 +163,14 @@ function writeSecretJson<T>(path: string, value: T): void {
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true });
   const current = lstatSync(path, { throwIfNoEntry: false });
+
   if (current && !current.isFile()) {
     throw new Error(`refusing to replace non-regular file ${path}`);
   }
 
   const temp = join(dir, `.${basename(path)}.${process.pid}.${randomUUID()}`);
   let handle: number | undefined;
+
   try {
     handle = openSync(temp, "wx", 0o600);
     fchmodSync(handle, 0o600);

--- a/packages/cursor/src/telemetry.ts
+++ b/packages/cursor/src/telemetry.ts
@@ -3,7 +3,8 @@ import { flush, log, startSpan, type LogLevel, type SpanHandle } from "@telemetr
 import { ensureInit, type ClientOverrides, type TelemetryDevCursorOptions } from "./config.ts";
 import { createTitleLookup } from "./titles.ts";
 
-type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+type JsonValue = string | number | boolean | null | undefined | Date | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -91,6 +92,7 @@ function asRecord<T>(value: T): JsonRecord | undefined {
 
 function readString<T>(value: T): string | undefined {
   const raw: unknown = value;
+
   return String(raw) === raw ? raw : undefined;
 }
 
@@ -101,6 +103,7 @@ function str(record: JsonRecord, key: string): string | undefined {
 function num(record: JsonRecord, key: string): number | undefined {
   const raw = record[key];
   const value = Number(raw);
+
   return value === raw && Number.isFinite(value) ? value : undefined;
 }
 
@@ -112,19 +115,23 @@ function asError<T>(cause: T): Error {
 function failureError(name: string, message: string | undefined): Error {
   const error = new Error(message ?? name);
   error.name = name;
+
   return error;
 }
 
 /** First line of the prompt or task, shortened to a span-name-sized label. */
 function shortName(text: string | undefined): string | undefined {
   const line = text?.trim().split("\n", 1)[0];
+
   if (!line) return undefined;
+
   return line.length > 60 ? `${line.slice(0, 59)}\u2026` : line;
 }
 
 /** `tool_output` arrives JSON-stringified; keep the string when it is not JSON. */
 function parseMaybeJson(value: string | undefined): JsonValue {
   if (value === undefined) return undefined;
+
   try {
     return JSON.parse(value) as JsonValue;
   } catch {
@@ -145,6 +152,7 @@ export function createCursorTelemetry(
   overrides?: ClientOverrides,
 ): CursorTelemetry {
   const onError = options.onError;
+
   try {
     ensureInit(options, overrides);
   } catch (error) {
@@ -161,14 +169,19 @@ export function createCursorTelemetry(
   function baseAttributes(event: JsonRecord) {
     const attributes: Record<string, string> = {};
     const conversationId = str(event, "conversation_id");
+
     if (conversationId) attributes["gen_ai.conversation.id"] = conversationId;
     const generationId = str(event, "generation_id");
+
     if (generationId) attributes["cursor.generation_id"] = generationId;
     const email = str(event, "user_email");
+
     if (email) attributes["cursor.user_email"] = email;
     const roots = event.workspace_roots;
     const workspace = Array.isArray(roots) ? readString(roots[0]) : undefined;
+
     if (workspace !== undefined) attributes["cursor.workspace"] = workspace;
+
     return attributes;
   }
 
@@ -187,18 +200,24 @@ export function createCursorTelemetry(
 
   function endTurn(conversationId: string, fields: Parameters<SpanHandle["end"]>[0]): void {
     const turn = turns.get(conversationId);
+
     if (!turn) return;
     turns.delete(conversationId);
+
     // Purge per-turn state so a later event or conversation cannot pick up
     // stale tool timings or claim a Task wait from this ended turn.
     for (const key of pendingTools.keys()) {
       if (key.startsWith(`${conversationId}:`)) pendingTools.delete(key);
     }
+
     for (let i = taskWaits.length - 1; i >= 0; i--) {
       if (taskWaits[i]!.parent === conversationId) taskWaits.splice(i, 1);
     }
+
     const link = subagents.get(conversationId);
+
     if (link) link.closed = true;
+
     // A parent that ends leaves no close signal for its open subagent turns;
     // end them at their own last activity.
     for (const [childId, childLink] of subagents) {
@@ -206,6 +225,7 @@ export function createCursorTelemetry(
       const child = turns.get(childId);
       endTurn(childId, { finishReason: "incomplete", endTime: child?.lastEvent });
     }
+
     turn.span.end({ name: titleFor(conversationId) ?? turn.fallbackName, ...fields });
   }
 
@@ -229,10 +249,13 @@ export function createCursorTelemetry(
     priorGenerations?: Set<string>,
   ): Turn | undefined {
     const conversationId = str(event, "conversation_id");
+
     if (!conversationId) return undefined;
     const existing = turns.get(conversationId);
+
     if (existing) return existing;
     let link = subagents.get(conversationId);
+
     if (
       !link &&
       !userPrompt &&
@@ -240,14 +263,17 @@ export function createCursorTelemetry(
       str(event, "generation_id") === conversationId
     ) {
       const wait = taskWaits.find((w) => !w.claimedBy && w.parent !== conversationId);
+
       if (wait) {
         wait.claimedBy = conversationId;
         link = { parent: wait.parent, type: wait.type, task: wait.task, closed: false };
         subagents.set(conversationId, link);
       }
     }
+
     const agentName = link ? (link.type ?? "subagent") : "cursor";
     const promptOrTask = readString(input) ?? link?.task;
+
     const turn: Turn = {
       span: startSpan(`invoke_agent ${agentName}`, {
         type: "agent",
@@ -264,7 +290,9 @@ export function createCursorTelemetry(
       generations: new Set(str(event, "generation_id") ? [str(event, "generation_id")!] : []),
       priorGenerations,
     };
+
     turns.set(conversationId, turn);
+
     return turn;
   }
 
@@ -274,14 +302,19 @@ export function createCursorTelemetry(
     // checked first: a nested child's stop can be delivered in its subagent
     // parent's context, where conversation_id names the parent, not the child.
     const transcript = str(event, "agent_transcript_path");
+
     if (transcript) {
       const parts = transcript.split(/[\\/]+/);
+
       for (const id of subagents.keys()) {
         if (parts.includes(id)) return id;
       }
     }
+
     const conversationId = str(event, "conversation_id");
+
     if (conversationId && subagents.has(conversationId)) return conversationId;
+
     return undefined;
   }
 
@@ -290,27 +323,34 @@ export function createCursorTelemetry(
     // A terminal event without a conversation_id still closes the sole open
     // turn, so a harness that omits the field cannot leak an open span.
     const soleTurn = turns.size === 1 ? [...turns.keys()][0] : undefined;
+
     const conversationId =
       str(event, "conversation_id") ??
       (name === "stop" || name === "sessionEnd" ? soleTurn : undefined);
+
     const now = Date.now();
     const generationId = str(event, "generation_id");
     // A stop can arrive late, after beforeSubmitPrompt already closed its turn
     // and opened the next one; matching it to the closed turn's generations
     // keeps it from prematurely closing the fresh turn.
     let staleStop = false;
+
     if (conversationId) {
       const active = turns.get(conversationId);
+
       if (active) {
         staleStop =
           name === "stop" &&
           generationId !== undefined &&
           !active.generations.has(generationId) &&
           active.priorGenerations?.has(generationId) === true;
+
         if (!staleStop) {
           active.lastEvent = now;
+
           if (generationId) active.generations.add(generationId);
           const sessionId = str(event, "session_id");
+
           if (sessionId) active.sessionId = sessionId;
         }
       }
@@ -319,11 +359,13 @@ export function createCursorTelemetry(
     switch (name) {
       case "sessionStart": {
         const sessionId = str(event, "session_id");
+
         if (sessionId) sessions.add(sessionId);
         emit(event, "info", "Session started", {
           "cursor.composer_mode": str(event, "composer_mode"),
           "cursor.is_background_agent": event.is_background_agent === true,
         });
+
         return;
       }
 
@@ -334,15 +376,20 @@ export function createCursorTelemetry(
           "cursor.error.message": str(event, "error_message"),
         });
         const sessionId = str(event, "session_id");
+
         if (sessionId) sessions.delete(sessionId);
+
         if (conversationId) sessions.delete(conversationId);
         const targets = new Set<string>();
+
         if (conversationId) targets.add(conversationId);
+
         if (sessionId) {
           for (const [id, turn] of turns) {
             if (turn.sessionId === sessionId) targets.add(id);
           }
         }
+
         for (const id of targets) {
           endTurn(id, {
             error:
@@ -352,35 +399,45 @@ export function createCursorTelemetry(
             finishReason: reason === "error" ? undefined : (reason ?? "incomplete"),
           });
         }
+
         void flush().catch((error) => onError?.(asError(error)));
+
         return;
       }
 
       case "beforeSubmitPrompt": {
         let priorGenerations: Set<string> | undefined;
+
         if (conversationId) {
           const prior = turns.get(conversationId);
+
           if (prior) {
             priorGenerations = new Set(prior.priorGenerations);
+
             for (const generation of prior.generations) {
               priorGenerations.add(generation);
             }
           }
+
           endTurn(conversationId, { finishReason: "incomplete" });
         }
+
         ensureTurn(event, str(event, "prompt"), true, priorGenerations);
+
         return;
       }
 
       case "preToolUse": {
         ensureTurn(event);
         const callId = str(event, "tool_use_id");
+
         if (callId && conversationId) {
           pendingTools.set(`${conversationId}:${callId}`, {
             startedAt: now,
             input: event.tool_input,
           });
         }
+
         // A Task call spawns a subagent conversation; the next unknown
         // conversation claims this wait (see ensureTurn).
         if (conversationId && str(event, "tool_name") === "Task") {
@@ -392,6 +449,7 @@ export function createCursorTelemetry(
             task: str(record, "prompt") ?? str(record, "description"),
           });
         }
+
         return;
       }
 
@@ -401,8 +459,10 @@ export function createCursorTelemetry(
         const tool = str(event, "tool_name") ?? "unknown";
         const callId = str(event, "tool_use_id");
         const pending = callId ? pendingTools.get(`${conversationId}:${callId}`) : undefined;
+
         if (callId) pendingTools.delete(`${conversationId}:${callId}`);
         const duration = num(event, "duration");
+
         const span = startSpan(`execute_tool ${tool}`, {
           type: "tool",
           parent: turn?.span,
@@ -414,6 +474,7 @@ export function createCursorTelemetry(
           output: parseMaybeJson(str(event, "tool_output")),
           attributes: baseAttributes(event),
         });
+
         span.end({
           error:
             name === "postToolUseFailure"
@@ -423,6 +484,7 @@ export function createCursorTelemetry(
                 )
               : undefined,
         });
+
         // The Task tool result closes the subagent conversations it spawned.
         // Parallel workers share one tool_use_id, so one result can close
         // several claimed waits.
@@ -430,10 +492,13 @@ export function createCursorTelemetry(
           const matches = taskWaits.filter(
             (w) => w.parent === conversationId && (callId ? w.callId === callId : true),
           );
+
           for (const wait of matches) {
             const index = taskWaits.indexOf(wait);
+
             if (index >= 0) taskWaits.splice(index, 1);
             const child = wait.claimedBy;
+
             if (!child || !turns.has(child)) continue;
             const failed = name === "postToolUseFailure";
             const childTurn = turns.get(child);
@@ -450,12 +515,14 @@ export function createCursorTelemetry(
             });
           }
         }
+
         return;
       }
 
       case "subagentStart": {
         const parent = str(event, "parent_conversation_id") ?? conversationId;
         const subagentId = str(event, "subagent_id");
+
         if (parent) {
           const link: SubagentLink = {
             parent,
@@ -464,38 +531,48 @@ export function createCursorTelemetry(
             task: str(event, "task"),
             closed: false,
           };
+
           if (subagentId) subagents.set(subagentId, link);
           // When the Task preToolUse already registered a wait, enrich it so a
           // conversation claiming it inherits the subagent type and model.
           const toolCallId = str(event, "tool_call_id");
+
           const wait = taskWaits.find(
             (w) => w.parent === parent && (toolCallId ? w.callId === toolCallId : !w.claimedBy),
           );
+
           if (wait) {
             wait.type ??= link.type;
             wait.task ??= link.task;
           }
+
           // Some payloads deliver the subagent's own conversation_id here.
           if (conversationId && conversationId !== parent) subagents.set(conversationId, link);
           // Open the parent turn so the subagent's spans have a trace to nest in.
           ensureTurn({ ...event, conversation_id: parent });
         }
+
         emit(event, "info", "Subagent started", {
           "cursor.subagent_id": subagentId,
           "cursor.subagent_type": str(event, "subagent_type"),
           "cursor.subagent_model": str(event, "subagent_model"),
         });
+
         return;
       }
 
       case "subagentStop": {
         const status = str(event, "status");
+
         const error =
           status === "error" ? failureError("SubagentError", str(event, "task")) : undefined;
+
         const subagentId = resolveSubagent(event);
         const link = subagentId ? subagents.get(subagentId) : undefined;
+
         if (subagentId && link) {
           const child = turns.get(subagentId);
+
           if (child) {
             child.span.update({
               output: str(event, "summary"),
@@ -503,16 +580,20 @@ export function createCursorTelemetry(
             });
             endTurn(subagentId, { error, finishReason: status === "error" ? undefined : status });
           }
+
           for (const [id, other] of subagents) {
             if (other === link) subagents.delete(id);
           }
+
           // The subagent's own events already produced its turn span; only a
           // link that never opened (and never closed) a turn needs the
           // synthetic span below.
           if (child || link.closed) return;
         }
+
         const turn = link ? turns.get(link.parent) : ensureTurn(event);
         const duration = num(event, "duration_ms") ?? 0;
+
         const span = startSpan(`invoke_agent ${str(event, "subagent_type") ?? "subagent"}`, {
           type: "agent",
           parent: turn?.span,
@@ -525,7 +606,9 @@ export function createCursorTelemetry(
             "cursor.subagent_status": status ?? "unknown",
           },
         });
+
         span.end({ error, finishReason: status === "error" ? undefined : status });
+
         return;
       }
 
@@ -536,6 +619,7 @@ export function createCursorTelemetry(
           "cursor.file_path": str(event, "file_path"),
           "cursor.edit_count": Array.isArray(edits) ? edits.length : 0,
         });
+
         return;
       }
 
@@ -549,12 +633,14 @@ export function createCursorTelemetry(
           output: str(event, "text"),
           attributes: baseAttributes(event),
         }).end();
+
         return;
       }
 
       case "afterAgentResponse": {
         const turn = ensureTurn(event);
         const model = str(event, "model_id") ?? str(event, "model");
+
         const span = startSpan(`chat ${model ?? "unknown"}`, {
           type: "generation",
           parent: turn?.span,
@@ -564,11 +650,14 @@ export function createCursorTelemetry(
           output: str(event, "text"),
           attributes: baseAttributes(event),
         });
+
         span.end();
+
         if (turn) {
           turn.lastBoundary = now;
           turn.span.update({ output: str(event, "text") });
         }
+
         return;
       }
 
@@ -579,19 +668,23 @@ export function createCursorTelemetry(
           "cursor.context_tokens": num(event, "context_tokens"),
           "cursor.messages_to_compact": num(event, "messages_to_compact"),
         });
+
         return;
       }
 
       case "stop": {
         if (staleStop) return;
         const status = str(event, "status");
+
         if (conversationId) {
           endTurn(conversationId, {
             error: status === "error" ? failureError("AgentError", "agent loop failed") : undefined,
             finishReason: status === "error" ? undefined : status,
           });
         }
+
         void flush().catch((error) => onError?.(asError(error)));
+
         return;
       }
     }
@@ -613,6 +706,7 @@ export function createCursorTelemetry(
         for (const [conversationId, turn] of turns) {
           endTurn(conversationId, { finishReason: "incomplete", endTime: turn.lastEvent });
         }
+
         pendingTools.clear();
         subagents.clear();
         taskWaits.length = 0;

--- a/packages/cursor/src/titles.ts
+++ b/packages/cursor/src/titles.ts
@@ -11,6 +11,7 @@ export function createTitleLookup(
   chatsDir = join(homedir(), ".cursor", "chats"),
 ): (conversationId: string) => string | undefined {
   const cache = new Map<string, string>();
+
   return (conversationId) => {
     if (
       conversationId === "." ||
@@ -20,34 +21,44 @@ export function createTitleLookup(
     ) {
       return undefined;
     }
+
     const cached = cache.get(conversationId);
+
     if (cached !== undefined) return cached;
     let hashes: string[];
+
     try {
       hashes = readdirSync(chatsDir);
     } catch {
       // Missing chats dir (tests, CI) means no titles; telemetry keeps default names.
       return undefined;
     }
+
     for (const hash of hashes) {
       let raw: string;
+
       try {
         raw = readFileSync(join(chatsDir, hash, conversationId, "meta.json"), "utf8");
       } catch {
         continue;
       }
+
       try {
         const meta = JSON.parse(raw) as { title?: unknown };
         const title = meta.title;
+
         if (String(title) === title && title.length > 0) {
           cache.set(conversationId, title);
+
           return title;
         }
       } catch {
         // Malformed meta must never break telemetry.
       }
+
       return undefined;
     }
+
     return undefined;
   };
 }

--- a/packages/cursor/tests/cursor.test.ts
+++ b/packages/cursor/tests/cursor.test.ts
@@ -27,6 +27,7 @@ import { createCursorTelemetry, type CursorTelemetry } from "../src/telemetry.ts
 import { createTitleLookup } from "../src/titles.ts";
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
@@ -45,6 +46,7 @@ function makeHarness(options: TelemetryDevCursorOptions = {}): Harness {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
   const overrides: ClientOverrides = { spanExporter: spans, logRecordExporter: logs };
+
   const telemetry = createCursorTelemetry(
     {
       apiKey,
@@ -57,6 +59,7 @@ function makeHarness(options: TelemetryDevCursorOptions = {}): Harness {
     },
     overrides,
   );
+
   return { spans, logs, telemetry };
 }
 
@@ -71,9 +74,11 @@ function setHome(home: string): () => void {
     USERPROFILE: process.env.USERPROFILE,
     XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR,
   };
+
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   process.env.XDG_RUNTIME_DIR = home;
+
   return () => {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];
@@ -308,6 +313,7 @@ describe("subagents", () => {
     // Task call can fan out parallel workers with the same tool_use_id.
     const { spans, telemetry } = makeHarness();
     telemetry.handle(event("beforeSubmitPrompt", { prompt: "explore" }));
+
     for (let i = 0; i < 2; i++) {
       telemetry.handle(
         event("preToolUse", {
@@ -317,6 +323,7 @@ describe("subagents", () => {
         }),
       );
     }
+
     for (const sub of ["sub-a", "sub-b"]) {
       telemetry.handle(
         event("preToolUse", {
@@ -337,6 +344,7 @@ describe("subagents", () => {
         }),
       );
     }
+
     telemetry.handle(
       event("postToolUse", {
         tool_name: "Task",
@@ -350,6 +358,7 @@ describe("subagents", () => {
     const parent = agentSpans(spans, "cursor")[0]!;
     const subs = agentSpans(spans, "code-explorer");
     expect(subs).toHaveLength(2);
+
     for (const sub of subs) {
       expect(sub.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
       expect(sub.attributes["gen_ai.response.finish_reasons"]).toEqual(["completed"]);
@@ -502,6 +511,7 @@ describe("subagents", () => {
         span.attributes["gen_ai.conversation.id"] === "conv-2" &&
         span.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     expect(other!.attributes["gen_ai.agent.name"]).toBe("cursor");
     const session = sessionSpanContext(apiKey, "conv-2");
     expect(other!.spanContext().traceId).toBe(session.traceId);
@@ -558,6 +568,7 @@ describe("subagents", () => {
         span.attributes["gen_ai.conversation.id"] === "headless-2" &&
         span.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     expect(headless!.attributes["gen_ai.agent.name"]).toBe("cursor");
     const session = sessionSpanContext(apiKey, "headless-2");
     expect(headless!.spanContext().traceId).toBe(session.traceId);
@@ -611,10 +622,12 @@ describe("subagents", () => {
     const parent = agentSpans(spans, "cursor")[0]!;
     const subA = agentSpans(spans, "explore")[0]!;
     const subB = agentSpans(spans, "shell")[0]!;
+
     for (const sub of [subA, subB]) {
       expect(sub.spanContext().traceId).toBe(parent.spanContext().traceId);
       expect(sub.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
     }
+
     expect(subA.attributes["gen_ai.output.messages"]).toContain("done a");
     expect(subB.attributes["gen_ai.output.messages"]).toContain("done b");
   });
@@ -731,6 +744,7 @@ describe("subagents", () => {
   test("subagent transcript paths match complete path segments", async () => {
     const { spans, telemetry } = makeHarness();
     telemetry.handle(event("beforeSubmitPrompt", { prompt: "explore" }));
+
     for (const subagentId of ["sub-1", "sub-10"]) {
       telemetry.handle(
         event("subagentStart", {
@@ -744,6 +758,7 @@ describe("subagents", () => {
         event("afterAgentResponse", { conversation_id: subagentId, text: `${subagentId} done` }),
       );
     }
+
     telemetry.handle(
       event("subagentStop", {
         conversation_id: "conv-1",
@@ -761,11 +776,13 @@ describe("subagents", () => {
         span.attributes["gen_ai.conversation.id"] === "sub-1" &&
         span.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     const sub10 = finished(spans).find(
       (span) =>
         span.attributes["gen_ai.conversation.id"] === "sub-10" &&
         span.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     expect(sub1!.attributes["gen_ai.response.finish_reasons"]).toEqual(["incomplete"]);
     expect(sub10!.attributes["gen_ai.response.finish_reasons"]).toEqual(["completed"]);
   });
@@ -785,6 +802,7 @@ describe("titles", () => {
       JSON.stringify({ schemaVersion: 1, title: "Subagent title from metadata" }),
     );
     const { spans, telemetry } = makeHarness({ chatsDir: chats });
+
     try {
       telemetry.handle(event("beforeSubmitPrompt", { prompt: "fix login" }));
       telemetry.handle(
@@ -818,6 +836,7 @@ describe("titles", () => {
   test("a missing title falls back to the prompt as the span name", async () => {
     const chats = mkdtempSync(join(tmpdir(), "cursor-chats-"));
     const { spans, telemetry } = makeHarness({ chatsDir: chats });
+
     try {
       telemetry.handle(event("beforeSubmitPrompt", { prompt: "x" }));
       telemetry.handle(event("stop", { status: "completed" }));
@@ -835,12 +854,14 @@ describe("titles", () => {
       { conversationId: "../outside", metaDir: ["outside"] },
       { conversationId: "bad\\id", metaDir: ["hash1", "bad\\id"] },
     ];
+
     for (const { conversationId, metaDir } of cases) {
       const chats = mkdtempSync(join(tmpdir(), "cursor-chats-"));
       mkdirSync(join(chats, "hash1"), { recursive: true });
       const titleDir = join(chats, ...metaDir);
       mkdirSync(titleDir, { recursive: true });
       writeFileSync(join(titleDir, "meta.json"), JSON.stringify({ title: "Outside title" }));
+
       try {
         expect(createTitleLookup(chats)(conversationId)).toBeUndefined();
       } finally {
@@ -864,10 +885,12 @@ describe("lifecycle logs", () => {
     const records = logs.getFinishedLogRecords();
     const names = records.map((r) => r.eventName);
     expect(names).toEqual(["sessionStart", "afterFileEdit", "preCompact", "sessionEnd"]);
+
     for (const record of records) {
       expect(record.attributes["gen_ai.conversation.id"]).toBe("conv-1");
       expect(record.attributes["gen_ai.agent.name"]).toBe("cursor");
     }
+
     const edit = records.find((r) => r.eventName === "afterFileEdit");
     expect(edit!.attributes["cursor.file_path"]).toBe("/tmp/project/a.ts");
     expect(edit!.attributes["cursor.edit_count"]).toBe(2);
@@ -910,10 +933,12 @@ describe("settle", () => {
 
   test("malformed events never throw", () => {
     const { telemetry } = makeHarness();
+
     const eventRecord = {
       hook_event_name: "unknownEvent",
       nested: { arbitrary: new Date() },
     };
+
     expectTypeOf<CursorTelemetry["handle"]>().parameter(0).toEqualTypeOf<Record<string, unknown>>();
     telemetry.handle({});
     telemetry.handle({ hook_event_name: "postToolUse" });
@@ -929,6 +954,7 @@ describe("fileConfig", () => {
     mkdirSync(join(home, ".cursor"));
     writeFileSync(join(home, ".cursor", "telemetry-dev.json"), "{not json");
     const restoreHome = setHome(home);
+
     try {
       expect(fileConfig()).toEqual({});
     } finally {
@@ -961,6 +987,7 @@ describe("stale state across turns", () => {
     const { spans, telemetry } = makeHarness();
     telemetry.handle(event("beforeSubmitPrompt", { prompt: "first", generation_id: "gen-1" }));
     telemetry.handle(event("beforeSubmitPrompt", { prompt: "second", generation_id: "gen-2" }));
+
     for (let index = 0; index < 100; index++) {
       const id = `other-${index}`;
       telemetry.handle(
@@ -981,6 +1008,7 @@ describe("stale state across turns", () => {
         span.attributes["gen_ai.conversation.id"] === "conv-1" &&
         span.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     expect(agents).toHaveLength(2);
     expect(agents[0]!.attributes["gen_ai.response.finish_reasons"]).toEqual(["incomplete"]);
     expect(agents[1]!.attributes["gen_ai.response.finish_reasons"]).toEqual(["completed"]);
@@ -1014,6 +1042,7 @@ describe("stale state across turns", () => {
         s.attributes["gen_ai.conversation.id"] === "conv-9" &&
         s.attributes["gen_ai.operation.name"] === "invoke_agent",
     );
+
     expect(later).toBeDefined();
     expect(later!.attributes["gen_ai.agent.name"]).toBe("cursor");
     const session = sessionSpanContext(apiKey, "conv-9");
@@ -1109,6 +1138,7 @@ describe.skipIf(process.platform === "win32")("daemon socket protocol", () => {
       socket.setEncoding("utf8");
       socket.on("data", (chunk: string) => {
         seen += chunk.split("\n").filter((l) => l.length > 0).length;
+
         if (seen >= acks) {
           socket.end();
           resolve();
@@ -1126,7 +1156,9 @@ describe.skipIf(process.platform === "win32")("daemon socket protocol", () => {
     const dir = mkdtempSync(join(tmpdir(), "tdc-sock-"));
     const path = join(dir, "d.sock");
     const server = await listen(path, telemetry);
+
     if (!server) throw new Error("failed to start test daemon");
+
     try {
       const post = {
         ...event("postToolUse", {
@@ -1137,6 +1169,7 @@ describe.skipIf(process.platform === "win32")("daemon socket protocol", () => {
         }),
         hook_delivery_id: "d-1",
       };
+
       const lines = [
         { ...event("beforeSubmitPrompt", { prompt: "x" }), hook_delivery_id: "d-0" },
         post,
@@ -1145,6 +1178,7 @@ describe.skipIf(process.platform === "win32")("daemon socket protocol", () => {
       ]
         .map((l) => `${JSON.stringify(l)}\n`)
         .join("");
+
       // Split mid-line to exercise framing across chunk boundaries.
       await sendChunks(path, [lines.slice(0, 25), lines.slice(25)], 4);
       await flush();
@@ -1168,9 +1202,11 @@ describe.skipIf(process.platform === "win32")("daemon socket protocol", () => {
     mkdirSync(lock);
     writeFileSync(held, "");
     utimesSync(held, 0, 0);
+
     const servers = (await Promise.all([listen(path, telemetry), listen(path, telemetry)])).filter(
       (server) => server !== undefined,
     );
+
     try {
       expect(servers).toHaveLength(1);
     } finally {
@@ -1188,6 +1224,7 @@ describe("install and uninstall", () => {
     const home = mkdtempSync(join(tmpdir(), "cursor-home-"));
     const restoreHome = setHome(home);
     const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
     try {
       const hooksPath = join(home, ".cursor", "hooks.json");
       mkdirSync(join(home, ".cursor"), { recursive: true });
@@ -1203,6 +1240,7 @@ describe("install and uninstall", () => {
       const hooks = JSON.parse(readFileSync(hooksPath, "utf8")) as {
         hooks: Record<string, { command: string; telemetryDev?: boolean }[]>;
       };
+
       const stopHooks = hooks.hooks.stop!;
       expect(stopHooks.filter((h) => h.command === "my-other-hook")).toHaveLength(1);
       const oursEntries = stopHooks.filter((h) => h.telemetryDev === true);
@@ -1212,6 +1250,7 @@ describe("install and uninstall", () => {
       const config = JSON.parse(
         readFileSync(join(home, ".cursor", "telemetry-dev.json"), "utf8"),
       ) as { apiKey: string };
+
       expect(config.apiKey).toBe("td_live_test");
       expect(lstatSync(join(home, ".cursor", "telemetry-dev.json")).mode & 0o777).toBe(0o600);
     } finally {
@@ -1225,6 +1264,7 @@ describe("install and uninstall", () => {
     const home = mkdtempSync(join(tmpdir(), "cursor-home-"));
     const restoreHome = setHome(home);
     const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
     try {
       const hooksPath = join(home, ".cursor", "hooks.json");
       mkdirSync(join(home, ".cursor"), { recursive: true });
@@ -1247,6 +1287,7 @@ describe("install and uninstall", () => {
       const hooks = JSON.parse(readFileSync(hooksPath, "utf8")) as {
         hooks: Record<string, { command: string }[]>;
       };
+
       expect(hooks.hooks.stop).toEqual([
         { command: "my-other-hook" },
         { command: "my-telemetry-dev-cursor-backup" },
@@ -1265,6 +1306,7 @@ describe("install and uninstall", () => {
       const home = mkdtempSync(join(tmpdir(), "cursor-home-"));
       const restoreHome = setHome(home);
       const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
       try {
         const cliDir = join(home, "cli '$HOME' `tick`");
         const cliPath = join(cliDir, "hook.mjs");
@@ -1275,6 +1317,7 @@ describe("install and uninstall", () => {
         const hooks = JSON.parse(readFileSync(join(home, ".cursor", "hooks.json"), "utf8")) as {
           hooks: Record<string, { command: string }[]>;
         };
+
         const command = hooks.hooks.stop![0]!.command;
         const output = execFileSync("/bin/sh", ["-c", command], { encoding: "utf8" });
         expect(JSON.parse(output)).toEqual(["hook"]);
@@ -1291,6 +1334,7 @@ describe("install and uninstall", () => {
     async () => {
       const home = mkdtempSync(join(tmpdir(), "cursor-home-"));
       const restoreHome = setHome(home);
+
       try {
         const cursorDir = join(home, ".cursor");
         const target = join(home, "target.json");
@@ -1313,10 +1357,13 @@ describe("install and uninstall", () => {
   test("an option flag without a value aborts instead of consuming the next flag", async () => {
     const home = mkdtempSync(join(tmpdir(), "cursor-home-"));
     const restoreHome = setHome(home);
+
     const exit = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("exit(1)");
     }) as never);
+
     const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
     try {
       await expect(
         runInstall("/opt/telemetry/cli.js", ["--api-key", "--base-url", "https://example.test"]),

--- a/packages/eve/src/client.ts
+++ b/packages/eve/src/client.ts
@@ -26,6 +26,7 @@ export interface WrapEveClientOptions extends TelemetryDevEveOptions {
 }
 
 type EventRecord = { [key: string]: EventValue };
+
 type EventValue =
   | string
   | number
@@ -34,23 +35,28 @@ type EventValue =
   | undefined
   | readonly EventValue[]
   | EventRecord;
+
 function asRecord(value: EventValue): EventRecord | undefined {
   if (value === null || Array.isArray(value) || !(value instanceof Object)) return undefined;
+
   return value as EventRecord;
 }
 
 function stringField(record: EventRecord | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   return value?.constructor === String && value.length > 0 ? value : undefined;
 }
 
 function numberField(record: EventRecord | undefined, key: string): number | undefined {
   const value = record?.[key];
+
   return value?.constructor === Number ? value : undefined;
 }
 
 function eventData(event: MessageStreamEvent): EventRecord {
   if (!("data" in event)) return {};
+
   return asRecord(event.data as EventValue) ?? {};
 }
 
@@ -58,31 +64,38 @@ function eventAttributes(
   attributes: Record<string, string | number | boolean | undefined>,
 ): Attributes {
   const out: Attributes = {};
+
   for (const [key, value] of Object.entries(attributes)) {
     if (value !== undefined) out[key] = value;
   }
+
   return out;
 }
 
 function addUsage(usage: TokenUsage, key: keyof TokenUsage, value: number | undefined): boolean {
   if (value === undefined) return false;
   usage[key] = (usage[key] ?? 0) + value;
+
   return true;
 }
 
 function failureError(code: string | undefined, message: string | undefined): Error {
   const error = new Error(message ?? code ?? "error");
+
   if (code) error.name = code;
+
   return error;
 }
 
 function bindOrReturn<T extends object>(target: T, prop: string | symbol) {
   const value = target[prop as keyof T];
+
   return value instanceof Function ? value.bind(target) : value;
 }
 
 function addLifecycleEvent(span: SpanHandle, event: MessageStreamEvent): void {
   const data = eventData(event);
+
   switch (event.type) {
     case "subagent.called": {
       const remote = asRecord(data.remote);
@@ -97,21 +110,26 @@ function addLifecycleEvent(span: SpanHandle, event: MessageStreamEvent): void {
           "eve.remote.url": stringField(remote, "url"),
         }),
       );
+
       return;
     }
+
     case "input.requested": {
       const requests = Array.isArray(data.requests) ? data.requests : undefined;
       span.span.addEvent(
         event.type,
         eventAttributes({ "eve.input.request_count": requests?.length }),
       );
+
       return;
     }
+
     case "authorization.required":
       span.span.addEvent(
         event.type,
         eventAttributes({ "eve.authorization.name": stringField(data, "name") }),
       );
+
       return;
     default:
       return;
@@ -139,6 +157,7 @@ async function* instrumentedStream<TOutput>(
   const finish = (): void => {
     if (done) return;
     done = true;
+
     if (!sawTerminalEvent && error === undefined) {
       if (signal?.aborted) {
         error = failureError("cancelled", "cancelled");
@@ -148,6 +167,7 @@ async function* instrumentedStream<TOutput>(
         finishReason ??= "error";
       }
     }
+
     span.end({
       usage: sawUsage ? usage : undefined,
       finishReason,
@@ -164,17 +184,21 @@ async function* instrumentedStream<TOutput>(
   try {
     for await (const event of response) {
       const data = eventData(event);
+
       if (event.type === "turn.started") {
         const turnTrace = asRecord(data.trace);
         const traceId = stringField(turnTrace, "traceId");
         const spanId = stringField(turnTrace, "spanId");
         const turnId = stringField(data, "turnId");
+
         if (traceId && spanId && turnId) {
           span.span.setAttribute("td.eve.turn_root", `${traceId}/${spanId}`);
           span.span.setAttribute("eve.turn.id", turnId);
         }
       }
+
       if (isCurrentTurnBoundaryEvent(event)) sawTerminalEvent = true;
+
       if (
         timeToFirstChunkMs === undefined &&
         (event.type === "message.appended" || event.type === "reasoning.appended")
@@ -198,11 +222,13 @@ async function* instrumentedStream<TOutput>(
             numberField(eventUsage, "cacheWriteTokens"),
           ) || sawUsage;
         const stepCost = numberField(eventUsage, "costUsd");
+
         if (stepCost === undefined || !Number.isFinite(stepCost) || stepCost < 0) {
           allCostsKnown = false;
         } else {
           costUsd = (costUsd ?? 0) + stepCost;
         }
+
         finishReason = stringField(data, "finishReason") ?? finishReason;
       }
 
@@ -212,9 +238,11 @@ async function* instrumentedStream<TOutput>(
       ) {
         output = data.message;
       }
+
       if (event.type === "result.completed") {
         output = data.result;
       }
+
       if (
         event.type === "turn.failed" ||
         event.type === "session.failed" ||
@@ -223,10 +251,13 @@ async function* instrumentedStream<TOutput>(
         if (error === undefined) {
           const code = stringField(data, "code");
           error = failureError(code, stringField(data, "message"));
+
           if (code) span.span.setAttribute("error.code", code);
         }
+
         finishReason = "error";
       }
+
       if (event.type === "turn.cancelled") {
         error = failureError("cancelled", "cancelled");
         finishReason = "cancelled";
@@ -242,9 +273,11 @@ async function* instrumentedStream<TOutput>(
     } else {
       error = caught instanceof Error ? caught : new Error(String(caught));
     }
+
     throw caught;
   } finally {
     finish();
+
     if (endCancelled) signal?.removeEventListener("abort", endCancelled);
   }
 }
@@ -261,6 +294,7 @@ async function tracedTurn<TOutput>(
   const startTime = new Date();
   const start = performance.now();
   const signal = turnOptions?.signal;
+
   const spanFor = (sessionId: string | undefined) =>
     startSpan(options.spanName ?? "invoke_agent", {
       type: "agent",
@@ -269,31 +303,39 @@ async function tracedTurn<TOutput>(
       startTime,
       attributes: sessionId === undefined ? undefined : { "gen_ai.conversation.id": sessionId },
     });
+
   let response: MessageResponse<TOutput>;
+
   try {
     response = await send();
   } catch (error) {
     const span = spanFor(knownSessionId);
+
     if (signal?.aborted) {
       span.end({ error: failureError("cancelled", "cancelled"), finishReason: "cancelled" });
     } else {
       span.end({ error: error instanceof Error ? error : new Error(String(error)) });
     }
+
     throw error;
   }
+
   const span = spanFor(response.sessionId);
   let streamStarted = false;
   let endedBeforeStream = false;
+
   const endCancelled = () => {
     if (streamStarted) return;
     endedBeforeStream = true;
     span.end({ error: failureError("cancelled", "cancelled"), finishReason: "cancelled" });
   };
+
   if (signal?.aborted) {
     endCancelled();
   } else {
     signal?.addEventListener("abort", endCancelled, { once: true });
   }
+
   // MessageResponse's constructor is @internal in eve; re-wrapping the stream has no
   // public alternative. cancel() forwards to the original response, whose turn id
   // resolves because instrumentedStream consumes it.
@@ -301,11 +343,13 @@ async function tracedTurn<TOutput>(
     cancelTurn: () => response.cancel(),
     createStream: () => {
       streamStarted = true;
+
       // The span already ended on abort; hand back the raw stream instead of ending it twice.
       if (endedBeforeStream)
         return (async function* () {
           yield* response;
         })();
+
       return instrumentedStream(response, span, start, signal, endCancelled);
     },
     sessionId: response.sessionId,
@@ -320,15 +364,19 @@ function wrapSession(session: ClientSession, options: WrapEveClientOptions): Cli
           tracedTurn(options, message, turnOptions, target.state.sessionId, () =>
             target.send(message, turnOptions),
           );
+
         return send;
       }
+
       if (prop === "respond") {
         const respond: ClientSession["respond"] = (inputResponses, turnOptions) =>
           tracedTurn(options, inputResponses, turnOptions, target.state.sessionId, () =>
             target.respond(inputResponses, turnOptions),
           );
+
         return respond;
       }
+
       return bindOrReturn(target, prop);
     },
   });
@@ -342,20 +390,27 @@ function wrapSessions(sessions: ClientSessions, options: WrapEveClientOptions): 
           input: SendTurnInput<TOutput>,
         ) => {
           let session: ClientSession | undefined;
+
           const response = await tracedTurn(options, input.message, input, undefined, async () => {
             const created = await target.create(input);
             session = created.session;
+
             return created.response;
           });
+
           return { response, session: wrapSession(session!, options) };
         };
+
         return create;
       }
+
       if (prop === "attach") {
         const attach: ClientSessions["attach"] = (sessionId, attachOptions) =>
           wrapSession(target.attach(sessionId, attachOptions), options);
+
         return attach;
       }
+
       return bindOrReturn(target, prop);
     },
   });
@@ -369,9 +424,11 @@ export function wrapEveClient<C extends Client>(
   const { agentName: _agentName, spanName: _spanName, ...sdkOptions } = options;
   ensureInit(sdkOptions, overrides);
   const sessions = wrapSessions(client.sessions, options);
+
   return new Proxy(client, {
     get(target, prop) {
       if (prop === "sessions") return sessions;
+
       return bindOrReturn(target, prop);
     },
   }) as C;

--- a/packages/eve/src/config.ts
+++ b/packages/eve/src/config.ts
@@ -47,6 +47,7 @@ export function ensureInit(
       spanFilter: options.spanFilter ?? ((span) => isAiScope(span.instrumentationScope.name)),
       sessionRootOf: (name, attributes) => {
         const sessionId = attributes["eve.session.id"];
+
         return name === "ai.eve.turn" && typeof sessionId === "string" ? sessionId : undefined;
       },
     },

--- a/packages/eve/src/hook.ts
+++ b/packages/eve/src/hook.ts
@@ -5,31 +5,38 @@ import type { HookContext, HookDefinition } from "eve/hooks";
 import { ensureInit, type ClientOverrides, type TelemetryDevEveOptions } from "./config.ts";
 
 type Attrs = { [key: string]: Value };
+
 type Value = string | number | boolean | null | undefined | readonly Value[] | Attrs;
 
 function asRecord(value: Value): Attrs | undefined {
   if (value === null || Array.isArray(value) || !(value instanceof Object)) return undefined;
+
   return value as Attrs;
 }
 
 function eventData(event: MessageStreamEvent): Attrs {
   if (!("data" in event)) return {};
+
   return asRecord(event.data as Value) ?? {};
 }
 
 function stringField(record: Attrs | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   return value?.constructor === String && value.length > 0 ? value : undefined;
 }
 
 function numberField(record: Attrs | undefined, key: string): number | undefined {
   const value = record?.[key];
+
   return value?.constructor === Number ? value : undefined;
 }
 
 function jsonField(record: Attrs | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   if (value === undefined) return undefined;
+
   try {
     return JSON.stringify(value);
   } catch {
@@ -39,6 +46,7 @@ function jsonField(record: Attrs | undefined, key: string): string | undefined {
 
 function baseAttributes(event: MessageStreamEvent, ctx: HookContext) {
   const data = eventData(event);
+
   return {
     "gen_ai.conversation.id": ctx.session.id,
     "gen_ai.agent.name": ctx.agent.name,
@@ -52,6 +60,7 @@ function baseAttributes(event: MessageStreamEvent, ctx: HookContext) {
 function toolAttrs(result: Value) {
   const record = asRecord(result);
   const subagentName = stringField(record, "subagentName");
+
   return {
     "gen_ai.tool.name":
       stringField(record, "toolName") ??
@@ -60,6 +69,7 @@ function toolAttrs(result: Value) {
     "eve.subagent.name": subagentName,
   };
 }
+
 function reportError(onError: ((error: Error) => void) | undefined, error: Error): void {
   try {
     onError?.(error);
@@ -90,10 +100,12 @@ function stepCompletedMessage(data: Attrs): string {
   const usage = asRecord(data.usage);
   const inputTokens = numberField(usage, "inputTokens");
   const outputTokens = numberField(usage, "outputTokens");
+
   const suffix =
     inputTokens !== undefined && outputTokens !== undefined
       ? `: ${inputTokens} in / ${outputTokens} out tokens`
       : "";
+
   return `Step completed (${finishReason})${suffix}`;
 }
 
@@ -114,18 +126,23 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
         "eve.parent.turn_id": stringField(invocation, "parentTurnId"),
         "eve.subagent.name": stringField(invocation, "name"),
       });
+
       return;
     }
+
     case "turn.started":
       emit(event, ctx, "debug", "Turn started");
+
       return;
     case "message.received":
       emit(event, ctx, "debug", "User message received");
+
       return;
     case "step.started":
       emit(event, ctx, "debug", "Step started", {
         "gen_ai.request.model": stringField(data, "modelId"),
       });
+
       return;
     case "step.completed": {
       const usage = asRecord(data.usage);
@@ -135,16 +152,20 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
         "eve.usage.cache_read_tokens": numberField(usage, "cacheReadTokens"),
         "eve.usage.cache_write_tokens": numberField(usage, "cacheWriteTokens"),
       });
+
       return;
     }
+
     case "step.failed":
       emit(event, ctx, "error", `Step failed: ${stringField(data, "message") ?? ""}`, {
         "error.code": stringField(data, "code"),
         "eve.error.details": jsonField(data, "details"),
       });
+
       return;
     case "action.result": {
       const status = stringField(data, "status");
+
       if (status === "completed") return;
       const error = asRecord(data.error);
       emit(
@@ -157,19 +178,24 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
           ...toolAttrs(data.result),
         },
       );
+
       return;
     }
+
     case "input.requested": {
       const requests = Array.isArray(data.requests) ? data.requests : undefined;
       emit(event, ctx, "info", "Input requested (HITL)", {
         "eve.input.request_count": requests?.length,
       });
+
       return;
     }
+
     case "authorization.required":
       emit(event, ctx, "warn", `Authorization required: ${stringField(data, "name") ?? ""}`, {
         "eve.authorization.name": stringField(data, "name"),
       });
+
       return;
     case "authorization.completed": {
       const outcome = stringField(data, "outcome");
@@ -184,22 +210,27 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
           "eve.authorization.reason": stringField(data, "reason"),
         },
       );
+
       return;
     }
+
     case "subagent.started":
       emit(event, ctx, "info", "Subagent started", {
         "eve.subagent.name": stringField(data, "subagentName"),
         "gen_ai.tool.call.id": stringField(data, "callId"),
       });
+
       return;
     case "subagent.event": {
       const child = asRecord(data.event as Value);
       const childData = asRecord(child?.data);
       const childType = stringField(child, "type");
+
       const attrs = {
         "eve.subagent.name": stringField(data, "subagentName"),
         "gen_ai.tool.call.id": stringField(data, "callId"),
       };
+
       if (
         childType === "step.failed" ||
         childType === "turn.failed" ||
@@ -222,8 +253,10 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
           } as MessageStreamEvent,
         );
       }
+
       return;
     }
+
     case "subagent.called": {
       const remote = asRecord(data.remote);
       emit(event, ctx, "info", `Subagent called: ${stringField(data, "name") ?? ""}`, {
@@ -234,48 +267,59 @@ function logEvent(event: MessageStreamEvent, ctx: HookContext): void {
         "eve.workflow.id": stringField(data, "workflowId"),
         "eve.remote.url": stringField(remote, "url"),
       });
+
       return;
     }
+
     case "subagent.completed":
       emit(event, ctx, "info", "Subagent completed", {
         "eve.subagent.name": stringField(data, "subagentName"),
         "gen_ai.tool.call.id": stringField(data, "callId"),
       });
+
       return;
     case "compaction.requested":
       emit(event, ctx, "info", `Compaction requested (${stringField(data, "modelId") ?? ""})`, {
         "gen_ai.request.model": stringField(data, "modelId"),
         "gen_ai.usage.input_tokens": numberField(data, "usageInputTokens"),
       });
+
       return;
     case "compaction.completed":
       emit(event, ctx, "debug", "Compaction completed", {
         "gen_ai.request.model": stringField(data, "modelId"),
       });
+
       return;
     case "turn.completed":
       emit(event, ctx, "info", "Turn completed");
+
       return;
     case "turn.cancelled":
       emit(event, ctx, "warn", "Turn cancelled");
+
       return;
     case "turn.failed":
       emit(event, ctx, "error", `Turn failed: ${stringField(data, "message") ?? ""}`, {
         "error.code": stringField(data, "code"),
         "eve.error.details": jsonField(data, "details"),
       });
+
       return;
     case "session.waiting":
       emit(event, ctx, "debug", "Session waiting");
+
       return;
     case "session.completed":
       emit(event, ctx, "info", "Session completed");
+
       return;
     case "session.failed":
       emit(event, ctx, "error", `Session failed: ${stringField(data, "message") ?? ""}`, {
         "error.code": stringField(data, "code"),
         "eve.error.details": jsonField(data, "details"),
       });
+
       return;
     default:
       return;

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -1,8 +1,12 @@
 export { wrapEveClient, type WrapEveClientOptions } from "./client.ts";
+
 export type { TelemetryDevEveOptions } from "./config.ts";
+
 export { telemetryDevHook } from "./hook.ts";
+
 export {
   telemetryDevInstrumentation,
   type TelemetryDevInstrumentationOptions,
 } from "./instrumentation.ts";
+
 export { telemetryDevOtelIntegration, type TelemetryDevOtelIntegrationOptions } from "./otel.ts";

--- a/packages/eve/src/instrumentation.ts
+++ b/packages/eve/src/instrumentation.ts
@@ -21,6 +21,7 @@ export interface TelemetryDevInstrumentationOptions extends TelemetryDevEveOptio
 
 const envServiceName = (): string | undefined =>
   globalThis.process !== undefined ? process.env.OTEL_SERVICE_NAME : undefined;
+
 function reportError(onError: ((error: Error) => void) | undefined, error: Error): void {
   try {
     onError?.(error);
@@ -55,12 +56,15 @@ export function telemetryDevInstrumentation(
     events: {
       "step.started"(input) {
         const ctx = { ...runtimeContext } satisfies InstrumentationRuntimeContext;
+
         const userId =
           input.session.auth.initiator?.principalId ?? input.session.auth.current?.principalId;
+
         const runtimeContextWithUser = userId ? { ...ctx, "user.id": userId } : ctx;
 
         try {
           const userResult = stepStarted?.(input);
+
           if (userResult?.runtimeContext) {
             Object.assign(runtimeContextWithUser, userResult.runtimeContext);
           }
@@ -81,5 +85,6 @@ export function telemetryDevInstrumentation(
   if (functionId !== undefined) {
     return { ...definition, functionId };
   }
+
   return definition;
 }

--- a/packages/eve/src/otel.ts
+++ b/packages/eve/src/otel.ts
@@ -20,6 +20,7 @@ export function telemetryDevOtelIntegration(
   options: TelemetryDevOtelIntegrationOptions = {},
 ): OtelIntegration {
   const { recordInputs, recordOutputs, ...processorOptions } = options;
+
   return otelIntegration({
     recordInputs,
     recordOutputs,

--- a/packages/eve/tests/eve.test.ts
+++ b/packages/eve/tests/eve.test.ts
@@ -46,6 +46,7 @@ interface Exporters extends ClientOverrides {
 function makeExporters(): Exporters {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
+
   return { logRecordExporter: logs, logs, spanExporter: spans, spans };
 }
 
@@ -65,6 +66,7 @@ function setupInstrumentation(
 ): InstrumentationDefinition {
   const definition = telemetryDevInstrumentation(telemetryOptions(options), overrides);
   definition.setup?.({ agentName: "agent-from-setup" });
+
   return definition;
 }
 
@@ -74,6 +76,7 @@ async function exportedServiceName(
   agentName: string,
 ): Promise<ExportedServiceName> {
   await resetForTesting();
+
   if (envServiceName === undefined) {
     delete process.env.OTEL_SERVICE_NAME;
   } else {
@@ -81,11 +84,13 @@ async function exportedServiceName(
   }
 
   const exporters = makeExporters();
+
   try {
     const definition = telemetryDevInstrumentation(telemetryOptions(options), exporters);
     definition.setup?.({ agentName });
     trace.getTracer("eve").startSpan(`service-${agentName}`).end();
     await flush();
+
     return exporters.spans.getFinishedSpans()[0]?.resource.attributes["service.name"];
   } finally {
     await resetForTesting();
@@ -97,6 +102,7 @@ function stepInput(auth?: {
   initiator?: string;
 }): InstrumentationStepStartedEventInput {
   const channel = { kind: "unit" } as never;
+
   return {
     channel,
     modelInput: { instructions: undefined, messages: [] },
@@ -158,11 +164,14 @@ function event<TType extends MessageStreamEvent["type"]>(
   ...args: EventPayload<TType> extends never ? [] : [data: EventPayload<TType>]
 ): Extract<MessageStreamEvent, { type: TType }> {
   const [data] = args;
+
   const result = {
     meta: { at: "2026-01-02T03:04:05.000Z", id: `evt_${type}` },
     type,
   };
+
   if (data !== undefined) Object.assign(result, { data });
+
   return result as Extract<MessageStreamEvent, { type: TType }>;
 }
 
@@ -189,14 +198,17 @@ function textResponse(body: string, status: number): Response {
 
 function ndjsonResponse(events: readonly MessageStreamEvent[]): Response {
   const encoder = new TextEncoder();
+
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       for (const item of events) {
         controller.enqueue(encoder.encode(`${JSON.stringify(item)}\n`));
       }
+
       controller.close();
     },
   });
+
   return new Response(body, {
     headers: {
       "content-type": "application/x-ndjson; charset=utf-8",
@@ -208,19 +220,26 @@ function ndjsonResponse(events: readonly MessageStreamEvent[]): Response {
 
 function stubFetchSequence(responses: Response[]) {
   const requests: Array<Parameters<typeof fetch>> = [];
+
   const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
     requests.push(args);
     const response = responses.shift();
+
     if (!response) throw new Error("unexpected fetch");
+
     return response;
   });
+
   vi.stubGlobal("fetch", fetchMock);
+
   return { requests };
 }
 
 function requestUrl(input: Parameters<typeof fetch>[0]): string {
   if (input instanceof URL) return input.href;
+
   if (input instanceof Request) return input.url;
+
   return String(input);
 }
 
@@ -278,23 +297,27 @@ function successfulTurnEvents(): MessageStreamEvent[] {
 function onlySpan(exporters: Exporters): ReadableSpan {
   const spans = exporters.spans.getFinishedSpans();
   expect(spans).toHaveLength(1);
+
   return spans[0]!;
 }
 
 function onlyLog(exporters: Exporters) {
   const records = exporters.logs.getFinishedLogRecords();
   expect(records).toHaveLength(1);
+
   return records[0]!;
 }
 
 afterEach(async () => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+
   if (originalOtelServiceName === undefined) {
     delete process.env.OTEL_SERVICE_NAME;
   } else {
     process.env.OTEL_SERVICE_NAME = originalOtelServiceName;
   }
+
   await resetForTesting();
 });
 
@@ -351,15 +374,18 @@ test("instrumentation puts every ai.eve.turn of a session in the session trace",
   for (const turnId of ["turn_0", "turn_1"]) {
     // eve runs each turn inside a workflow-engine span that starts its own trace.
     const engine = trace.getTracer("workflow").startSpan("workflow.execute");
+
     const turn = eve.startSpan(
       "ai.eve.turn",
       { attributes: { "eve.session.id": "session-1", "eve.turn.id": turnId } },
       trace.setSpan(apiContext.active(), engine),
     );
+
     genAi.startSpan("ai.streamText", {}, trace.setSpan(apiContext.active(), turn)).end();
     turn.end();
     engine.end();
   }
+
   await flush();
 
   // sha256("td_live_test\0session-1"): trace id = digest[0:16], session parent = digest[16:24]
@@ -370,9 +396,11 @@ test("instrumentation puts every ai.eve.turn of a session in the session trace",
     "ai.streamText",
     "ai.eve.turn",
   ]);
+
   for (const span of spans) {
     expect(span.spanContext().traceId).toBe("1382eccf84291f6161a535bdd642e06c");
   }
+
   for (const span of spans.filter((span) => span.name === "ai.eve.turn")) {
     expect(span.parentSpanContext?.spanId).toBe("da259c4698ed3d9f");
   }
@@ -419,6 +447,7 @@ test.each([
   "provider integration applies the $name filter to actual exports",
   async ({ options, httpExports, totalExports }) => {
     const requests: string[] = [];
+
     const integration = telemetryDevOtelIntegration({
       apiKey: "td_live_test",
       baseUrl: "https://ingest.test",
@@ -426,15 +455,18 @@ test.each([
       metrics: false,
       fetch: async (input) => {
         requests.push(requestUrl(input));
+
         return new Response(null, { status: 200 });
       },
       ...options,
     });
+
     const provider = new BasicTracerProvider({
       spanProcessors: integration.spanProcessors.filter(
         (processor) => typeof processor !== "string",
       ),
     });
+
     try {
       provider.getTracer("unrelated-http").startSpan("GET /health").end();
       await provider.forceFlush();
@@ -487,6 +519,7 @@ test("step.started returns undefined when no context is available", () => {
 test("step.started swallows user callback errors and reports them", () => {
   const onError = vi.fn();
   const thrown = new Error("callback failed");
+
   const definition = telemetryDevInstrumentation(
     telemetryOptions({
       onError,
@@ -798,10 +831,13 @@ test("hook ignores message.appended and malformed event data does not throw", as
 test("hook swallows event processing errors even when onError throws", async () => {
   const exporters = makeExporters();
   const thrown = new Error("event data failed");
+
   const onError = vi.fn(() => {
     throw new Error("onError failed");
   });
+
   const hook = telemetryDevHook(telemetryOptions({ onError }), exporters);
+
   const brokenEvent = {
     get data() {
       throw thrown;
@@ -838,6 +874,7 @@ test("wrapped eve client streams a successful turn and records usage on the turn
 
   const { response } = await client.sessions.create({ message: "hello" });
   const seen: string[] = [];
+
   for await (const item of response) seen.push(item.type);
   await flush();
 
@@ -934,6 +971,7 @@ test("wrapped eve client puts every turn of one session in the session trace", a
   const spans = exporters.spans.getFinishedSpans();
   expect(spans.map((s) => s.name)).toEqual(["invoke_agent", "invoke_agent"]);
   const ms = ([sec, nano]: [number, number]) => sec * 1000 + nano / 1e6;
+
   for (const span of spans) {
     expect(span.spanContext().traceId).toBe(expected.traceId);
     expect(span.parentSpanContext?.spanId).toBe(expected.spanId);
@@ -966,6 +1004,7 @@ test("wrapped eve client marks streams without terminal events as errored spans"
       streamReconnectPolicy: { reconnect: false },
     })
   ).response.result();
+
   await flush();
 
   expect(result.status).toBe("completed");
@@ -977,12 +1016,14 @@ test("wrapped eve client marks streams without terminal events as errored spans"
 
 test("wrapped eve client result() aggregates output, message, input requests, and status", async () => {
   const exporters = makeExporters();
+
   const inputRequest = {
     action: { callId: "call-approval", input: {}, kind: "tool-call" as const, toolName: "approve" },
     kind: "tool-approval" as const,
     prompt: "Approve?",
     requestId: "approval-1",
   };
+
   stubFetchSequence([
     jsonResponse({ sessionId: "session-2" }),
     ndjsonResponse([
@@ -1013,6 +1054,7 @@ test("wrapped eve client result() aggregates output, message, input requests, an
   const result = await (
     await client.sessions.create({ message: "approve this" })
   ).response.result();
+
   await flush();
 
   expect(result).toMatchObject({
@@ -1092,9 +1134,11 @@ test("wrapped eve client marks aborted streams as cancelled spans", async () => 
     "fetch",
     vi.fn(async (...args: Parameters<typeof fetch>) => {
       requests.push(args);
+
       if (requests.length === 1) return jsonResponse({ sessionId: "session-4" });
       controller.abort();
       const abortError = new DOMException("The operation was aborted.", "AbortError");
+
       return new Response(
         new ReadableStream<Uint8Array>({
           start(streamController) {
@@ -1110,6 +1154,7 @@ test("wrapped eve client marks aborted streams as cancelled spans", async () => 
   const result = await (
     await client.sessions.create({ message: "cancel", signal: controller.signal })
   ).response.result();
+
   expect(result.events).toEqual([]);
   await flush();
 
@@ -1124,12 +1169,14 @@ test.each(["create", "send", "respond"] as const)(
   async (method) => {
     const exporters = makeExporters();
     const controller = new AbortController();
+
     const inputRequest = {
       action: { callId: "call-1", input: {}, kind: "tool-call" as const, toolName: "approve" },
       kind: "tool-approval" as const,
       prompt: "Approve?",
       requestId: "approval-1",
     };
+
     stubFetchSequence([
       ...(method === "create" ? [] : [jsonResponse({ sessionId: "session-abort" })]),
       jsonResponse({ sessionId: "session-abort" }),
@@ -1140,12 +1187,14 @@ test.each(["create", "send", "respond"] as const)(
       await client.sessions.create({ message: "hello", signal: controller.signal });
     } else {
       const session = client.sessions.attach("session-abort");
+
       if (method === "send") {
         await session.send("hello", { signal: controller.signal });
       } else {
         await session.respond([inputRequest], { signal: controller.signal });
       }
     }
+
     controller.abort();
     await flush();
 
@@ -1179,8 +1228,10 @@ test("wrapped eve client keeps completed streams successful when abort races aft
     "fetch",
     vi.fn(async (...args: Parameters<typeof fetch>) => {
       requests.push(args);
+
       if (requests.length === 1) return jsonResponse({ sessionId: "session-4b" });
       controller.abort();
+
       return ndjsonResponse([event("session.completed")]);
     }),
   );
@@ -1189,6 +1240,7 @@ test("wrapped eve client keeps completed streams successful when abort races aft
   const result = await (
     await client.sessions.create({ message: "complete despite abort", signal: controller.signal })
   ).response.result();
+
   await flush();
 
   expect(result.status).toBe("completed");
@@ -1241,9 +1293,11 @@ test("wrapped eve client rethrows POST 500 errors and records the failed send", 
 
 test("wrapped eve client binds private-field methods for health and session state", async () => {
   const exporters = makeExporters();
+
   const { requests } = stubFetchSequence([
     jsonResponse({ ok: true, status: "ready", workflowId: "wf-1" }),
   ]);
+
   const client = wrapClient(exporters);
 
   await expect(client.health()).resolves.toEqual({ ok: true, status: "ready", workflowId: "wf-1" });

--- a/packages/google-genai/src/index.ts
+++ b/packages/google-genai/src/index.ts
@@ -11,16 +11,22 @@ import type { AsyncLocalStorage } from "node:async_hooks";
 import { startSpan, type SpanFields, type SpanHandle } from "@telemetry-dev/sdk";
 
 type AttributeValue = NonNullable<SpanFields["attributes"]>[string];
+
 type AlsConstructor = new <T>() => AsyncLocalStorage<T>;
+
 type AsyncHooksModule = { AsyncLocalStorage?: AlsConstructor };
 
 function loadAls(): AlsConstructor | undefined {
   const globals = globalThis as { AsyncLocalStorage?: AlsConstructor };
+
   if (globals.AsyncLocalStorage) return globals.AsyncLocalStorage;
   const proc = globalThis.process as { getBuiltinModule?: (id: string) => unknown } | undefined;
+
   if (typeof proc?.getBuiltinModule !== "function") return undefined;
+
   try {
     const mod = proc.getBuiltinModule("node:async_hooks") as AsyncHooksModule | undefined;
+
     return mod?.AsyncLocalStorage;
   } catch {
     return undefined;
@@ -32,16 +38,20 @@ const ORIGINAL = Symbol("telemetry.dev.google-genai.original");
 const wrappedClients = new WeakSet<object>();
 const usageCollectorModels = new WeakSet<object>();
 const AlsCtor = loadAls();
+
 const afcUsageStore = AlsCtor
   ? new AlsCtor<{ usage?: SpanFields["usage"]; toolUsePromptTokens?: number }>()
   : undefined;
-
-type UnknownRecord = Record<string, unknown>;
 
 type WrappedFunction = ((...args: unknown[]) => unknown) & {
   [WRAPPED]?: true;
   [ORIGINAL]?: (...args: unknown[]) => unknown;
 };
+
+interface UnknownRecord {
+  // oxlint-disable-next-line anti-slop/no-unsafe-dictionary-type -- Google returns versioned external payloads; every consumed field is narrowed after this boundary.
+  [key: string]: unknown;
+}
 
 interface RequestMapping {
   name: string;
@@ -85,11 +95,13 @@ function readNumber(value: unknown): number | undefined {
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   if (value === null || typeof value !== "object" || !("then" in value)) return false;
+
   return typeof value.then === "function";
 }
 
 function compactUsage(usage: SpanFields["usage"]): SpanFields["usage"] {
   if (!usage) return undefined;
+
   return Object.values(usage).some((value) => value !== undefined) ? usage : undefined;
 }
 
@@ -107,19 +119,23 @@ function setJsonAttribute(
   value: unknown,
 ): void {
   const serialized = jsonStringify(value);
+
   if (serialized !== undefined) attributes[key] = serialized;
 }
 
 function stopSequences(value: unknown): string[] | undefined {
   const arr = asArray(value);
+
   if (!arr) return undefined;
   const strings = arr.filter((item): item is string => typeof item === "string");
+
   return strings.length > 0 ? strings : undefined;
 }
 
 function outputTypeFromConfig(config: UnknownRecord | undefined): string | undefined {
   if (!config) return undefined;
   const mime = readString(config.responseMimeType);
+
   if (
     mime === "application/json" ||
     config.responseSchema !== undefined ||
@@ -127,60 +143,84 @@ function outputTypeFromConfig(config: UnknownRecord | undefined): string | undef
   ) {
     return "json";
   }
+
   if (mime === "text/plain") return "text";
+
   return undefined;
 }
 
 function mapToolDefinitions(tools: unknown): unknown[] | undefined {
   const toolArray = asArray(tools);
+
   if (!toolArray) return undefined;
   const definitions: unknown[] = [];
+
   for (const tool of toolArray) {
     const record = asRecord(tool);
+
     if (!record) continue;
+
     if (typeof record.callTool === "function") {
       const name = readString(record.name);
+
       if (name) definitions.push({ type: "function", name });
       continue;
     }
+
     for (const declaration of asArray(record.functionDeclarations) ?? []) {
       const fn = asRecord(declaration);
+
       if (!fn) continue;
       const definition = { type: "function", name: fn.name };
+
       if (fn.description !== undefined) Object.assign(definition, { description: fn.description });
+
       if (fn.parameters !== undefined) Object.assign(definition, { parameters: fn.parameters });
       definitions.push(definition);
     }
+
     for (const key of BUILTIN_TOOL_KEYS) {
       if (record[key] !== undefined) definitions.push({ type: key });
     }
   }
+
   return definitions.length > 0 ? definitions : undefined;
 }
 
 function requestAttributesFromConfig(config: UnknownRecord | undefined) {
   const attributes: Record<string, AttributeValue> = {};
+
   if (!config) return attributes;
   const toolDefs = mapToolDefinitions(config.tools);
+
   if (toolDefs) {
     const serialized = jsonStringify(toolDefs);
+
     if (serialized !== undefined) attributes["gen_ai.tool.definitions"] = serialized;
   }
+
   const candidateCount = readNumber(config.candidateCount);
+
   if (candidateCount !== undefined) attributes["gen_ai.request.choice.count"] = candidateCount;
+
   if (config.toolConfig !== undefined)
     setJsonAttribute(attributes, "google_genai.request.tool_config", config.toolConfig);
+
   if (config.safetySettings !== undefined) {
     setJsonAttribute(attributes, "google_genai.request.safety_settings", config.safetySettings);
   }
+
   if (config.thinkingConfig !== undefined) {
     setJsonAttribute(attributes, "google_genai.request.thinking_config", config.thinkingConfig);
   }
+
   if (config.labels !== undefined)
     setJsonAttribute(attributes, "google_genai.request.labels", config.labels);
   const cachedContent = readString(config.cachedContent);
+
   if (cachedContent !== undefined)
     attributes["google_genai.request.cached_content"] = cachedContent;
+
   if (config.responseModalities !== undefined) {
     setJsonAttribute(
       attributes,
@@ -188,12 +228,15 @@ function requestAttributesFromConfig(config: UnknownRecord | undefined) {
       config.responseModalities,
     );
   }
+
   return attributes;
 }
 
 function usageFromMetadata(usage: unknown): SpanFields["usage"] {
   const metadata = asRecord(usage);
+
   if (!metadata) return undefined;
+
   return compactUsage({
     inputTokens: readNumber(metadata.promptTokenCount),
     outputTokens: readNumber(metadata.candidatesTokenCount),
@@ -205,18 +248,23 @@ function usageFromMetadata(usage: unknown): SpanFields["usage"] {
 
 function candidateOutput(response: UnknownRecord): unknown[] | undefined {
   const candidates = asArray(response.candidates);
+
   if (!candidates || candidates.length === 0) return undefined;
+
   const output = candidates
     .map((candidate) => {
       const record = asRecord(candidate);
       const content = asRecord(record?.content);
+
       if (!content) return undefined;
+
       return {
         role: readString(content.role) ?? "model",
         parts: asArray(content.parts) ?? [],
       };
     })
     .filter((entry) => entry !== undefined);
+
   return output.length > 0 ? output : undefined;
 }
 
@@ -225,11 +273,14 @@ function responseAttributes(response: UnknownRecord) {
   const candidates = asArray(response.candidates) ?? [];
   const promptFeedback = asRecord(response.promptFeedback);
   const blockReason = readString(promptFeedback?.blockReason);
+
   if (blockReason) attributes["google_genai.response.block_reason"] = blockReason;
   const blockReasonMessage = readString(promptFeedback?.blockReasonMessage);
+
   if (blockReasonMessage)
     attributes["google_genai.response.block_reason_message"] = blockReasonMessage;
   const promptSafetyRatings = asArray(promptFeedback?.safetyRatings);
+
   if (promptSafetyRatings && promptSafetyRatings.length > 0) {
     setJsonAttribute(
       attributes,
@@ -241,10 +292,12 @@ function responseAttributes(response: UnknownRecord) {
   const finishReasons = candidates
     .map((candidate) => readString(asRecord(candidate)?.finishReason))
     .filter((reason): reason is string => reason !== undefined);
+
   if (finishReasons.length > 1) attributes["gen_ai.response.finish_reasons"] = finishReasons;
 
   const usageMetadata = asRecord(response.usageMetadata);
   const toolUsePromptTokens = readNumber(usageMetadata?.toolUsePromptTokenCount);
+
   if (toolUsePromptTokens !== undefined) {
     attributes["google_genai.usage.tool_use_prompt_tokens"] = toolUsePromptTokens;
   }
@@ -253,15 +306,19 @@ function responseAttributes(response: UnknownRecord) {
     .map((candidate, index) => {
       const record = asRecord(candidate);
       const ratings = asArray(record?.safetyRatings);
+
       if (!ratings || ratings.length === 0) return undefined;
+
       return { candidateIndex: readNumber(record?.index) ?? index, ratings };
     })
     .filter((entry) => entry !== undefined);
+
   if (safetyEntries.length > 0) {
     setJsonAttribute(attributes, "google_genai.response.safety_ratings", safetyEntries);
   }
 
   const firstCandidate = asRecord(candidates[0]);
+
   if (firstCandidate?.groundingMetadata !== undefined) {
     setJsonAttribute(
       attributes,
@@ -269,6 +326,7 @@ function responseAttributes(response: UnknownRecord) {
       firstCandidate.groundingMetadata,
     );
   }
+
   if (firstCandidate?.urlContextMetadata !== undefined) {
     setJsonAttribute(
       attributes,
@@ -278,6 +336,7 @@ function responseAttributes(response: UnknownRecord) {
   }
 
   const afcHistory = asArray(response.automaticFunctionCallingHistory);
+
   if (afcHistory && afcHistory.length > 0)
     attributes["google_genai.automatic_function_calling"] = true;
 
@@ -288,6 +347,7 @@ function generateRequestFields(params: UnknownRecord): RequestMapping {
   const model = readString(params.model);
   const config = asRecord(params.config);
   const attributes = requestAttributesFromConfig(config);
+
   const fields: RequestMapping["fields"] = {
     type: "generation",
     model,
@@ -303,18 +363,23 @@ function generateRequestFields(params: UnknownRecord): RequestMapping {
     presencePenalty: readNumber(config?.presencePenalty),
     outputType: outputTypeFromConfig(config),
   };
+
   if (Object.keys(attributes).length > 0) fields.attributes = attributes;
+
   return { name: `chat ${model ?? "unknown"}`, fields };
 }
 
 function generateResponseFields(response: unknown): SpanFields {
   const record = asRecord(response) ?? {};
   const candidates = asArray(record.candidates) ?? [];
+
   const finishReasons = candidates
     .map((candidate) => readString(asRecord(candidate)?.finishReason))
     .filter((reason): reason is string => reason !== undefined);
+
   const attributes = responseAttributes(record);
   const afcHistory = asArray(record.automaticFunctionCallingHistory);
+
   const fields: SpanFields = {
     responseModel: readString(record.modelVersion),
     responseId: readString(record.responseId),
@@ -322,12 +387,16 @@ function generateResponseFields(response: unknown): SpanFields {
     output: candidateOutput(record),
     usage: usageFromMetadata(record.usageMetadata),
   };
+
   if (Object.keys(attributes).length > 0) fields.attributes = attributes;
+
   if (afcHistory && afcHistory.length > 0) fields.input = afcHistory;
+
   if (readString(asRecord(record.promptFeedback)?.blockReason)) {
     delete fields.output;
     delete fields.finishReason;
   }
+
   return fields;
 }
 
@@ -336,13 +405,18 @@ function embedRequestFields(params: UnknownRecord): RequestMapping {
   const config = asRecord(params.config);
   const attributes: Record<string, AttributeValue> = {};
   const taskType = readString(config?.taskType);
+
   if (taskType) attributes["google_genai.request.task_type"] = taskType;
   const outputDimensionality = readNumber(config?.outputDimensionality);
+
   if (outputDimensionality !== undefined) {
     attributes["google_genai.request.output_dimensionality"] = outputDimensionality;
   }
+
   const fields: RequestMapping["fields"] = { type: "embedding", model, input: params.contents };
+
   if (Object.keys(attributes).length > 0) fields.attributes = attributes;
+
   return { name: `embeddings ${model ?? "unknown"}`, fields };
 }
 
@@ -350,30 +424,39 @@ function embedResponseFields(response: unknown): SpanFields {
   const record = asRecord(response) ?? {};
   const embeddings = asArray(record.embeddings) ?? [];
   const attributes: Record<string, AttributeValue> = {};
+
   if (embeddings.length > 0)
     attributes["google_genai.response.embedding_count"] = embeddings.length;
   const firstValues = asArray(asRecord(embeddings[0])?.values);
+
   if (firstValues) attributes["google_genai.response.embedding_dimensions"] = firstValues.length;
   let inputTokens = 0;
   let sawTokens = false;
+
   for (const embedding of embeddings) {
     const tokenCount = readNumber(asRecord(asRecord(embedding)?.statistics)?.tokenCount);
+
     if (tokenCount !== undefined) {
       sawTokens = true;
       inputTokens += tokenCount;
     }
   }
+
   const metadata = asRecord(record.metadata);
   const billableCharacters = readNumber(metadata?.billableCharacterCount);
+
   if (billableCharacters !== undefined) {
     attributes["google_genai.usage.billable_characters"] = billableCharacters;
   }
+
   const fields: SpanFields = { usage: sawTokens ? compactUsage({ inputTokens }) : undefined };
+
   if (Object.keys(attributes).length > 0) fields.attributes = attributes;
+
   return fields;
 }
 
-function isWrapped(fn: unknown): fn is WrappedFunction {
+function isWrapped<T>(fn: T): fn is T & WrappedFunction {
   return typeof fn === "function" && (fn as WrappedFunction)[WRAPPED] === true;
 }
 
@@ -383,11 +466,13 @@ function markWrapped<T extends WrappedFunction>(
 ): T {
   Object.defineProperty(fn, WRAPPED, { value: true });
   Object.defineProperty(fn, ORIGINAL, { value: original });
+
   return fn;
 }
 
 function endOnce(span: SpanHandle): (fields?: SpanFields) => void {
   let ended = false;
+
   return (fields?: SpanFields) => {
     if (ended) return;
     ended = true;
@@ -409,11 +494,13 @@ function safeRequestMapping(
     return mapRequest(params);
   } catch {
     let model: string | undefined;
+
     try {
       model = readString(params.model);
     } catch {
       model = undefined;
     }
+
     return {
       name: `${fallback.namePrefix} ${model ?? "unknown"}`,
       fields: { type: fallback.type, model },
@@ -436,8 +523,10 @@ function shouldAggregateAfcUsage(params: UnknownRecord): boolean {
   try {
     const config = asRecord(params.config);
     const tools = asArray(config?.tools) ?? [];
+
     if (!tools.some((tool) => typeof asRecord(tool)?.callTool === "function")) return false;
     const automaticFunctionCalling = asRecord(config?.automaticFunctionCalling);
+
     return (
       automaticFunctionCalling?.disable !== true &&
       readNumber(automaticFunctionCalling?.maximumRemoteCalls) !== 0
@@ -450,16 +539,20 @@ function shouldAggregateAfcUsage(params: UnknownRecord): boolean {
 function installInternalUsageCollector(models: UnknownRecord | undefined): void {
   if (!models || usageCollectorModels.has(models)) return;
   const original = models.generateContentInternal;
+
   if (typeof original !== "function") return;
   models.generateContentInternal = function (this: unknown, ...args: unknown[]) {
     const result = original.apply(this, args);
+
     const recordUsage = (response: unknown) => {
       try {
         const store = afcUsageStore?.getStore();
         const usageMetadata = asRecord(response)?.usageMetadata;
+
         if (store) {
           store.usage = sumUsage(store.usage, usageFromMetadata(asRecord(usageMetadata)));
           const toolUsePromptTokens = readNumber(asRecord(usageMetadata)?.toolUsePromptTokenCount);
+
           if (toolUsePromptTokens !== undefined) {
             store.toolUsePromptTokens =
               (readNumber(store.toolUsePromptTokens) ?? 0) + toolUsePromptTokens;
@@ -468,10 +561,13 @@ function installInternalUsageCollector(models: UnknownRecord | undefined): void 
       } catch {
         // Telemetry-only AFC usage collection must fail open.
       }
+
       return response;
     };
+
     return isThenable(result) ? result.then(recordUsage) : recordUsage(result);
   };
+
   usageCollectorModels.add(models);
 }
 
@@ -484,33 +580,43 @@ function wrapUnary(
   models?: UnknownRecord,
 ): WrappedFunction {
   if (isWrapped(original)) return original;
+
   const wrapped = function (this: unknown, ...args: unknown[]) {
     const params = asRecord(args[0]) ?? {};
     const request = safeRequestMapping(params, mapRequest, fallback);
     const span = startSpan(request.name, { ...request.fields, provider });
     const end = endOnce(span);
     const usageStore = afcUsageStore;
+
     const internalUsage: { usage?: SpanFields["usage"]; toolUsePromptTokens?: number } | undefined =
       usageStore && shouldAggregateAfcUsage(params) ? {} : undefined;
+
     if (internalUsage) installInternalUsageCollector(models);
+
     const finishResponse = (response: unknown) => {
       const fields = safeResponseFields(mapResponse, response);
+
       if (internalUsage?.usage) fields.usage = internalUsage.usage;
       const toolUsePromptTokens = readNumber(internalUsage?.toolUsePromptTokens);
+
       if (toolUsePromptTokens !== undefined) {
         fields.attributes = {
           ...fields.attributes,
           "google_genai.usage.tool_use_prompt_tokens": toolUsePromptTokens,
         };
       }
+
       end(fields);
+
       return response;
     };
+
     try {
       const result =
         usageStore && internalUsage
           ? usageStore.run(internalUsage, () => original.call(this, ...args))
           : original.call(this, ...args);
+
       if (isThenable(result)) {
         return result.then(
           (response) => finishResponse(response),
@@ -520,12 +626,14 @@ function wrapUnary(
           },
         );
       }
+
       return finishResponse(result);
     } catch (error) {
       end({ error });
       throw error;
     }
   };
+
   return markWrapped(wrapped as WrappedFunction, original);
 }
 
@@ -537,6 +645,7 @@ interface CandidateAggregate {
 
 function appendPart(parts: UnknownRecord[], incoming: UnknownRecord): void {
   const last = parts[parts.length - 1];
+
   if (
     last &&
     typeof last.text === "string" &&
@@ -544,8 +653,10 @@ function appendPart(parts: UnknownRecord[], incoming: UnknownRecord): void {
     last.thought === incoming.thought
   ) {
     last.text += incoming.text;
+
     return;
   }
+
   parts.push({ ...incoming });
 }
 
@@ -554,9 +665,12 @@ function sumUsage(
   right: SpanFields["usage"] | undefined,
 ): SpanFields["usage"] {
   if (!left) return right;
+
   if (!right) return left;
+
   const add = (a: number | undefined, b: number | undefined) =>
     a === undefined && b === undefined ? undefined : (a ?? 0) + (b ?? 0);
+
   return compactUsage({
     inputTokens: add(left.inputTokens, right.inputTokens),
     outputTokens: add(left.outputTokens, right.outputTokens),
@@ -571,6 +685,7 @@ function copyContent(content: UnknownRecord) {
     role: readString(content.role) ?? "model",
     parts: (asArray(content.parts) ?? []).flatMap((part) => {
       const record = asRecord(part);
+
       return record ? [{ ...record }] : [];
     }),
   };
@@ -578,32 +693,40 @@ function copyContent(content: UnknownRecord) {
 
 function normalizeContentInput(input: unknown): unknown[] {
   if (input === undefined) return [];
+
   if (typeof input === "string") return [{ role: "user", parts: [{ text: input }] }];
   const items = asArray(input);
+
   if (items) {
     if (items.some((item) => readString(asRecord(item)?.role) || asArray(asRecord(item)?.parts))) {
       return [...items];
     }
+
     return [
       {
         role: "user",
         parts: items.flatMap((item) => {
           if (typeof item === "string") return [{ text: item }];
           const record = asRecord(item);
+
           return record ? [{ ...record }] : [];
         }),
       },
     ];
   }
+
   const record = asRecord(input);
+
   if (record && !readString(record.role) && !asArray(record.parts)) {
     return [{ role: "user", parts: [{ ...record }] }];
   }
+
   return [input];
 }
 
 function hasFunctionResponse(content: UnknownRecord | undefined): boolean {
   if (readString(content?.role) !== "user") return false;
+
   return (asArray(content?.parts) ?? []).some(
     (part) => asRecord(part)?.functionResponse !== undefined,
   );
@@ -638,15 +761,18 @@ class StreamAggregator {
     if (!this.afcHistory) {
       this.afcHistory = normalizeContentInput(this.requestInput);
     }
+
     return this.afcHistory;
   }
 
   private foldTurn(toAfcHistory: boolean): void {
     const output = this.currentOutput();
+
     if (output.length > 0) {
       if (toAfcHistory) this.ensureAfcHistory().push(...output);
       else this.priorOutput.push(...output);
     }
+
     this.committedUsage = sumUsage(this.committedUsage, this.usage);
     this.candidates.clear();
     this.usage = undefined;
@@ -655,41 +781,56 @@ class StreamAggregator {
   recordChunk(chunk: unknown): void {
     const record = asRecord(chunk) ?? {};
     const nextResponseId = readString(record.responseId);
+
     if (nextResponseId && this.responseId && nextResponseId !== this.responseId) {
       this.foldTurn(false);
     }
+
     if (nextResponseId) this.responseId = nextResponseId;
     const nextResponseModel = readString(record.modelVersion);
+
     if (nextResponseModel) this.responseModel = nextResponseModel;
 
     for (const candidate of asArray(record.candidates) ?? []) {
       const candidateRecord = asRecord(candidate) ?? {};
       const content = asRecord(candidateRecord.content);
+
       if (content && hasFunctionResponse(content)) {
         this.foldTurn(true);
         this.ensureAfcHistory().push(copyContent(content));
         continue;
       }
+
       const index = readNumber(candidateRecord.index) ?? 0;
       let state = this.candidates.get(index);
+
       if (!state) {
         state = { role: "model", parts: [] };
         this.candidates.set(index, state);
       }
+
       if (content) {
         const role = readString(content.role);
+
         if (role) state.role = role;
+
         for (const part of asArray(content.parts) ?? []) {
           const partRecord = asRecord(part);
+
           if (partRecord) appendPart(state.parts, partRecord);
         }
       }
+
       const finishReason = readString(candidateRecord.finishReason);
+
       if (finishReason) state.finishReason = finishReason;
     }
+
     const chunkUsage = usageFromMetadata(record.usageMetadata);
+
     if (chunkUsage) this.usage = chunkUsage;
     const afcHistory = asArray(record.automaticFunctionCallingHistory);
+
     if (afcHistory && afcHistory.length > 0) this.afcHistory = [...afcHistory];
     const chunkAttributes = responseAttributes(record);
     Object.assign(this.attributes, chunkAttributes);
@@ -700,7 +841,9 @@ class StreamAggregator {
       this.afcHistory && this.afcHistory.length > 0
         ? this.currentOutput()
         : [...this.priorOutput, ...this.currentOutput()];
+
     const finishReasons = this.finishReasons();
+
     const fields: SpanFields = {
       responseId: this.responseId,
       responseModel: this.responseModel,
@@ -708,17 +851,23 @@ class StreamAggregator {
       usage: sumUsage(this.committedUsage, this.usage),
       finishReason: finishReasons[0],
     };
+
     const attributes = { ...this.attributes };
+
     if (this.afcHistory && this.afcHistory.length > 0) {
       fields.input = this.afcHistory;
       attributes["google_genai.automatic_function_calling"] = true;
     }
+
     if (finishReasons.length > 1) attributes["gen_ai.response.finish_reasons"] = finishReasons;
+
     if (Object.keys(attributes).length > 0) fields.attributes = attributes;
+
     if (attributes["google_genai.response.block_reason"]) {
       delete fields.output;
       delete fields.finishReason;
     }
+
     return fields;
   }
 }
@@ -747,6 +896,7 @@ function createObservedStream(
         responseModel: readString(record.modelVersion),
       });
     }
+
     try {
       aggregator.recordChunk(chunk);
     } catch {
@@ -758,11 +908,13 @@ function createObservedStream(
     if (ended) return;
     ended = true;
     let finalFields: SpanFields = {};
+
     try {
       finalFields = aggregator.finish();
     } catch {
       finalFields = {};
     }
+
     if (error !== undefined) finalFields.error = error;
     end(finalFields);
   };
@@ -775,8 +927,10 @@ function createObservedStream(
       try {
         const step = await iterator.next(value);
         const receivedAt = performance.now();
+
         if (step.done) finish();
         else recordChunk(step.value, receivedAt);
+
         return step;
       } catch (error) {
         finish(error);
@@ -791,9 +945,12 @@ function createObservedStream(
 
           if (!step.done) recordChunk(step.value, receivedAt);
           else finish();
+
           return step;
         }
+
         finish();
+
         return { done: true, value };
       } catch (error) {
         finish(error);
@@ -805,11 +962,14 @@ function createObservedStream(
         finish(error);
         throw error;
       }
+
       try {
         const step = await iterator.throw(error);
         const receivedAt = performance.now();
+
         if (step.done) finish();
         else recordChunk(step.value, receivedAt);
+
         return step;
       } catch (thrown) {
         finish(thrown);
@@ -864,14 +1024,17 @@ function wrapStream(
   fallback: RequestFallback,
 ): WrappedFunction {
   if (isWrapped(original)) return original;
+
   const wrapped = function (this: unknown, ...args: unknown[]) {
     const params = asRecord(args[0]) ?? {};
     const request = safeRequestMapping(params, mapRequest, fallback);
     const span = startSpan(request.name, { ...request.fields, provider });
     const end = endOnce(span);
     const startedAt = Date.now();
+
     try {
       const result = original.call(this, ...args);
+
       return Promise.resolve(result).then(
         (generator) =>
           createObservedStream(
@@ -891,6 +1054,7 @@ function wrapStream(
       throw error;
     }
   };
+
   return markWrapped(wrapped as WrappedFunction, original);
 }
 
@@ -904,8 +1068,10 @@ function patchModelsMethod(
   streaming = false,
 ): void {
   const current = models[key];
+
   if (isWrapped(current) && Object.prototype.hasOwnProperty.call(models, key)) return;
   const original = isWrapped(current) ? current[ORIGINAL] : current;
+
   if (typeof original !== "function") return;
   const bound = original.bind(models) as (...args: unknown[]) => unknown;
   models[key] = streaming
@@ -946,5 +1112,6 @@ export function wrapGoogleGenAI<T extends GoogleGenAIClientLike>(client: T): T {
     type: "embedding",
   });
   wrappedClients.add(client);
+
   return client;
 }

--- a/packages/google-genai/src/index.ts
+++ b/packages/google-genai/src/index.ts
@@ -735,7 +735,9 @@ function createObservedStream(
   let sawFirst = false;
   let ended = false;
 
-  const recordChunk = (chunk: unknown): void => {
+  const recordChunk = (chunk: unknown, receivedAt: number): void => {
+    if (chunkHasOutput(chunk)) span.recordOutputChunk?.(receivedAt);
+
     if (!sawFirst) {
       sawFirst = true;
       const record = asRecord(chunk) ?? {};
@@ -772,8 +774,9 @@ function createObservedStream(
     async next(value?: unknown) {
       try {
         const step = await iterator.next(value);
+        const receivedAt = performance.now();
         if (step.done) finish();
-        else recordChunk(step.value);
+        else recordChunk(step.value, receivedAt);
         return step;
       } catch (error) {
         finish(error);
@@ -784,7 +787,9 @@ function createObservedStream(
       try {
         if (iterator.return) {
           const step = await iterator.return(value);
-          if (!step.done) recordChunk(step.value);
+          const receivedAt = performance.now();
+
+          if (!step.done) recordChunk(step.value, receivedAt);
           else finish();
           return step;
         }
@@ -802,8 +807,9 @@ function createObservedStream(
       }
       try {
         const step = await iterator.throw(error);
+        const receivedAt = performance.now();
         if (step.done) finish();
-        else recordChunk(step.value);
+        else recordChunk(step.value, receivedAt);
         return step;
       } catch (thrown) {
         finish(thrown);
@@ -814,6 +820,41 @@ function createObservedStream(
       await this.return(undefined);
     },
   };
+}
+
+function chunkHasOutput(chunk: unknown): boolean {
+  return (asArray(asRecord(chunk)?.candidates) ?? []).some((candidate) =>
+    (asArray(asRecord(asRecord(candidate)?.content)?.parts) ?? []).some((part) => {
+      const value = asRecord(part);
+      const inlineData = asRecord(value?.inlineData ?? value?.inline_data);
+      const functionCall = asRecord(value?.functionCall ?? value?.function_call);
+      const args = asRecord(functionCall?.args);
+      const partialArgs = asArray(functionCall?.partialArgs ?? functionCall?.partial_args) ?? [];
+
+      return (
+        (typeof value?.text === "string" && value.text.length > 0) ||
+        (args !== undefined && Object.keys(args).length > 0) ||
+        partialArgs.some((partialArg) => {
+          const partial = asRecord(partialArg);
+          const stringValue = partial?.stringValue ?? partial?.string_value;
+
+          return (
+            typeof partial?.boolValue === "boolean" ||
+            typeof partial?.bool_value === "boolean" ||
+            typeof partial?.numberValue === "number" ||
+            typeof partial?.number_value === "number" ||
+            (typeof stringValue === "string" && stringValue.length > 0) ||
+            partial?.nullValue === "NULL_VALUE" ||
+            partial?.null_value === "NULL_VALUE"
+          );
+        }) ||
+        (typeof inlineData?.mimeType === "string" &&
+          inlineData.mimeType.startsWith("audio/") &&
+          typeof inlineData.data === "string" &&
+          inlineData.data.length > 0)
+      );
+    }),
+  );
 }
 
 function wrapStream(

--- a/packages/google-genai/tests/google-genai.test.ts
+++ b/packages/google-genai/tests/google-genai.test.ts
@@ -1,4 +1,10 @@
 import { InMemorySpanExporter, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  AggregationTemporality,
+  DataPointType,
+  type PushMetricExporter,
+  type ResourceMetrics,
+} from "@opentelemetry/sdk-metrics";
 import { flush, init, shutdown } from "@telemetry-dev/sdk";
 import {
   FunctionCallingConfigMode,
@@ -45,14 +51,16 @@ function sseResponse(chunks: JsonValue[]): Response {
   });
 }
 
-function erroringSseResponse(chunk: JsonValue, error: Error): Response {
+function erroringSseResponse(chunks: JsonValue | JsonValue[], error: Error): Response {
   const encoder = new TextEncoder();
-  let sent = false;
+  const pending = Array.isArray(chunks) ? [...chunks] : [chunks];
+
   const body = new ReadableStream<Uint8Array>(
     {
       pull(controller) {
-        if (!sent) {
-          sent = true;
+        const chunk = pending.shift();
+
+        if (chunk !== undefined) {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
           return;
         }
@@ -103,6 +111,53 @@ function setupSpans(): InMemorySpanExporter {
   return spanExporter;
 }
 
+function setupSpansAndMetrics() {
+  const spanExporter = new InMemorySpanExporter();
+  const metricBatches: ResourceMetrics[] = [];
+
+  const metricExporter: PushMetricExporter = {
+    export: (resourceMetrics, resultCallback) => {
+      metricBatches.push(resourceMetrics);
+      resultCallback({ code: 0 });
+    },
+    selectAggregationTemporality: () => AggregationTemporality.DELTA,
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+
+  init(
+    {
+      apiKey: "td_live_test",
+      serviceName: "google-genai-tests",
+      environment: "test",
+      exportMode: "immediate",
+      logLevel: "silent",
+      fetch: async () => new Response(null, { status: 200 }),
+    },
+    { spanExporter, metricExporter },
+  );
+
+  return { spanExporter, metricBatches };
+}
+
+function outputChunkIntervalCount(metricBatches: ResourceMetrics[]): number {
+  let count = 0;
+
+  for (const batch of metricBatches) {
+    for (const scope of batch.scopeMetrics) {
+      for (const metric of scope.metrics) {
+        if (metric.descriptor.name !== "gen_ai.client.operation.time_per_output_chunk") continue;
+
+        if (metric.dataPointType !== DataPointType.HISTOGRAM) throw new Error("expected histogram");
+
+        for (const point of metric.dataPoints) count += point.value.count;
+      }
+    }
+  }
+
+  return count;
+}
+
 function clientWith(): GoogleGenAI {
   return wrapGoogleGenAI(new GoogleGenAI({ apiKey: "test" }));
 }
@@ -140,6 +195,7 @@ function messagesAttr(span: ReadableSpan, key: "gen_ai.input.messages" | "gen_ai
 afterEach(async () => {
   vi.unstubAllGlobals();
   await shutdown();
+  vi.restoreAllMocks();
 });
 
 test("generateContent maps request, response, usage, finish reason, provider, and sampling attributes", async () => {
@@ -703,6 +759,229 @@ test("streaming mid-stream error records error status with partial output", asyn
     { role: "model", parts: [{ text: "partial" }] },
   ]);
 });
+
+test.each<{ partialArgs: JsonValue[] }>([
+  { partialArgs: [{ jsonPath: "$.enabled", boolValue: false }] },
+  { partialArgs: [{ jsonPath: "$.retries", numberValue: 0 }] },
+  {
+    partialArgs: [
+      { jsonPath: "$.enabled", boolValue: false },
+      { jsonPath: "$.retries", numberValue: 0 },
+    ],
+  },
+])("Vertex streaming counts partial values once but not shells: %j", async ({ partialArgs }) => {
+  const { spanExporter, metricBatches } = setupSpansAndMetrics();
+
+  const chunks: JsonValue[] = [
+    {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "set_flags",
+                  partialArgs: [
+                    { jsonPath: "$.enabled", willContinue: true },
+                    { jsonPath: "$.label", stringValue: "" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "set_flags",
+                  partialArgs,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "set_flags",
+                  partialArgs: [{ jsonPath: "$.fallback", nullValue: "NULL_VALUE" }],
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+  ];
+
+  const fake = createFakeFetch(sseResponse(chunks));
+  vi.stubGlobal("fetch", fake.fetch);
+  const client = wrapGoogleGenAI(new GoogleGenAI({ vertexai: true, apiKey: "test" }));
+
+  const stream = await client.models.generateContentStream({
+    model: "gemini-2.5-flash",
+    contents: "Set flags",
+  });
+
+  const received = [];
+
+  for await (const chunk of stream) received.push(chunk);
+
+  expect(received).toHaveLength(3);
+  expect(received[1]!.candidates?.[0]?.content?.parts?.[0]?.functionCall?.partialArgs).toEqual(
+    partialArgs,
+  );
+  await exportedSpan(spanExporter);
+  await flush();
+  expect(outputChunkIntervalCount(metricBatches)).toBe(1);
+});
+
+test("Vertex streaming retains partial argument chunk intervals when interrupted", async () => {
+  const { spanExporter, metricBatches } = setupSpansAndMetrics();
+
+  const first = {
+    candidates: [
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: "lookup",
+                partialArgs: [{ jsonPath: "$.query", stringValue: "north" }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const second = {
+    candidates: [
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: "lookup",
+                partialArgs: [{ jsonPath: "$.limit", numberValue: 0 }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const fake = createFakeFetch(
+    erroringSseResponse([first, second], new Error("stream interrupted")),
+  );
+
+  vi.stubGlobal("fetch", fake.fetch);
+  const client = wrapGoogleGenAI(new GoogleGenAI({ vertexai: true, apiKey: "test" }));
+
+  const stream = await client.models.generateContentStream({
+    model: "gemini-2.5-flash",
+    contents: "Lookup",
+  });
+
+  const iterator = stream[Symbol.asyncIterator]();
+  expect(
+    (await iterator.next()).value.candidates[0].content.parts[0].functionCall.partialArgs,
+  ).toEqual([{ jsonPath: "$.query", stringValue: "north" }]);
+  expect(
+    (await iterator.next()).value.candidates[0].content.parts[0].functionCall.partialArgs,
+  ).toEqual([{ jsonPath: "$.limit", numberValue: 0 }]);
+  await expect(iterator.next()).rejects.toThrow("stream interrupted");
+
+  const span = await exportedSpan(spanExporter);
+  expect(span.status.code).toBe(SPAN_STATUS_ERROR);
+  await flush();
+  expect(outputChunkIntervalCount(metricBatches)).toBe(1);
+});
+
+test.each(["next", "return", "throw"] as const)(
+  "streaming %s timestamps precede telemetry classification",
+  async (method) => {
+    const spans = setupSpans();
+    let now = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+
+    const timings = [
+      [100, 30],
+      [240, 90],
+    ] as const;
+
+    let index = 0;
+
+    const pull = async () => {
+      const timing = timings[index++];
+
+      if (!timing) return { done: true as const, value: undefined };
+      const [receivedAt, mappingMs] = timing;
+      now = receivedAt;
+
+      return {
+        done: false as const,
+        value: {
+          get candidates() {
+            now = receivedAt + mappingMs;
+
+            return [{ content: { role: "model", parts: [{ text: "A" }] } }];
+          },
+        },
+      };
+    };
+
+    const source = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: pull,
+      return: pull,
+      throw: pull,
+    };
+
+    const client = wrapGoogleGenAI({
+      models: { generateContentStream: async (_params: unknown) => source },
+    });
+
+    const stream = await client.models.generateContentStream({
+      model: "gemini-2.5-flash",
+      contents: "Hi",
+    });
+
+    expect((await stream.next()).done).toBe(false);
+    expect((await stream[method]()).done).toBe(false);
+    expect((await stream.return()).done).toBe(true);
+    expect(await exportedSpan(spans)).toMatchObject({
+      [Symbol.for("telemetry.dev.outputChunkHistogram")]: {
+        count: 1,
+        sum: 0.14,
+        min: 0.14,
+        max: 0.14,
+      },
+    });
+  },
+);
 
 test("streaming early break ends span with partial aggregate", async () => {
   const spans = setupSpans();

--- a/packages/google-genai/tests/google-genai.test.ts
+++ b/packages/google-genai/tests/google-genai.test.ts
@@ -45,6 +45,7 @@ function jsonErrorResponse(status: number, message: string): Response {
 
 function sseResponse(chunks: JsonValue[]): Response {
   const body = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("");
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -62,13 +63,16 @@ function erroringSseResponse(chunks: JsonValue | JsonValue[], error: Error): Res
 
         if (chunk !== undefined) {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+
           return;
         }
+
         controller.error(error);
       },
     },
     { highWaterMark: 0 },
   );
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -77,21 +81,24 @@ function erroringSseResponse(chunks: JsonValue | JsonValue[], error: Error): Res
 
 function createFakeFetch(...responses: Response[]) {
   const requests: CapturedRequest[] = [];
+
   const fetchImpl: typeof fetch = async (input, init) => {
     const url = input instanceof Request ? input.url : String(input);
-    const bodyText =
-      Object.prototype.toString.call(init?.body) === "[object String]"
-        ? String(init?.body)
-        : undefined;
+
+    const bodyText = typeof init?.body === "string" ? init.body : undefined;
+
     requests.push({
       method: init?.method,
       path: new URL(url).pathname + new URL(url).search,
       body: bodyText ? JSON.parse(bodyText) : undefined,
     });
     const response = responses.shift();
+
     if (!response) throw new Error(`unexpected request to ${url}`);
+
     return response;
   };
+
   return { fetch: fetchImpl, requests };
 }
 
@@ -108,6 +115,7 @@ function setupSpans(): InMemorySpanExporter {
     },
     { spanExporter },
   );
+
   return spanExporter;
 }
 
@@ -169,22 +177,28 @@ async function finishedSpans(
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await flush();
     const spans = exporter.getFinishedSpans();
+
     if (spans.length === expectedCount) return spans;
+
     if (spans.length > expectedCount) expect(spans).toHaveLength(expectedCount);
     await Promise.resolve();
   }
+
   expect(exporter.getFinishedSpans()).toHaveLength(expectedCount);
+
   return exporter.getFinishedSpans();
 }
 
 async function exportedSpan(exporter: InMemorySpanExporter): Promise<ReadableSpan> {
   const spans = await finishedSpans(exporter, 1);
+
   return spans[0]!;
 }
 
 function jsonAttr<T>(span: ReadableSpan, key: string): T {
   const value = span.attributes[key];
   expect(Object.prototype.toString.call(value)).toBe("[object String]");
+
   return JSON.parse(String(value)) as T;
 }
 
@@ -200,6 +214,7 @@ afterEach(async () => {
 
 test("generateContent maps request, response, usage, finish reason, provider, and sampling attributes", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [
@@ -220,8 +235,10 @@ test("generateContent maps request, response, usage, finish reason, provider, an
       },
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const response = await client.models.generateContent({
     model: "gemini-2.5-flash",
     contents: [{ role: "user", parts: [{ text: "Say hello" }] }],
@@ -235,6 +252,7 @@ test("generateContent maps request, response, usage, finish reason, provider, an
       seed: 42,
     },
   });
+
   expect(response.text).toBe("Hello there");
   const span = await exportedSpan(spans);
   expect(span.name).toBe("chat gemini-2.5-flash");
@@ -267,13 +285,16 @@ test("generateContent maps request, response, usage, finish reason, provider, an
 
 test("generateContent normalizes part-array input before recording", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [{ content: { role: "model", parts: [{ text: "An image." }] } }],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const contents = [
     { text: "Describe this image" },
     { inlineData: { mimeType: "image/png", data: "abc123" } },
@@ -287,6 +308,7 @@ test("generateContent normalizes part-array input before recording", async () =>
 
 test("structured output records json output type", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [
@@ -297,6 +319,7 @@ test("structured output records json output type", async () => {
       ],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
   await client.models.generateContent({
@@ -316,6 +339,7 @@ test("structured output records json output type", async () => {
 
 test("function tools map definitions, toolConfig, and functionCall output", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [
@@ -329,6 +353,7 @@ test("function tools map definitions, toolConfig, and functionCall output", asyn
       ],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
   await client.models.generateContent({
@@ -370,6 +395,7 @@ test("function tools map definitions, toolConfig, and functionCall output", asyn
 
 test("generateContent automatic function calls sum usage from internal generateContent calls", async () => {
   const spans = setupSpans();
+
   const callableTool = {
     name: "get_weather",
     async tool(): Promise<Tool> {
@@ -394,6 +420,7 @@ test("generateContent automatic function calls sum usage from internal generateC
       ];
     },
   };
+
   const functionCallResponse = {
     responseId: "afc_1",
     candidates: [
@@ -412,6 +439,7 @@ test("generateContent automatic function calls sum usage from internal generateC
       toolUsePromptTokenCount: 2,
     },
   };
+
   const finalResponse = {
     responseId: "afc_2",
     candidates: [
@@ -427,6 +455,7 @@ test("generateContent automatic function calls sum usage from internal generateC
       toolUsePromptTokenCount: 3,
     },
   };
+
   const fake = createFakeFetch(jsonResponse(functionCallResponse), jsonResponse(finalResponse));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
@@ -466,6 +495,7 @@ test("generateContent automatic function calls sum usage from internal generateC
 
 test("built-in tools map every SDK marker to tool definitions", async () => {
   const spans = setupSpans();
+
   const client = wrapGoogleGenAI({
     models: {
       generateContent(_params: any) {
@@ -473,6 +503,7 @@ test("built-in tools map every SDK marker to tool definitions", async () => {
       },
     },
   });
+
   client.models.generateContent({
     model: "gemini-2.5-flash",
     contents: "Use tools",
@@ -512,6 +543,7 @@ test("built-in tools map every SDK marker to tool definitions", async () => {
 
 test("multi-candidate responses capture choice count and finish reasons", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [
@@ -528,6 +560,7 @@ test("multi-candidate responses capture choice count and finish reasons", async 
       ],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
   await client.models.generateContent({
@@ -543,14 +576,17 @@ test("multi-candidate responses capture choice count and finish reasons", async 
 
 test("streaming aggregates chunks, preserves passthrough, and records time to first chunk", async () => {
   const spans = setupSpans();
+
   const chunk1 = {
     candidates: [{ content: { role: "model", parts: [{ text: "Hel" }] } }],
     responseId: "stream_1",
     modelVersion: "gemini-2.5-flash-stream",
   };
+
   const chunk2 = {
     candidates: [{ content: { role: "model", parts: [{ text: "lo" }] } }],
   };
+
   const chunk3 = {
     candidates: [{ content: { role: "model", parts: [{ text: "!" }] }, finishReason: "STOP" }],
     usageMetadata: {
@@ -559,19 +595,25 @@ test("streaming aggregates chunks, preserves passthrough, and records time to fi
       totalTokenCount: 5,
     },
   };
+
   const fake = createFakeFetch(sseResponse([chunk1, chunk2, chunk3]));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
   });
+
   const stripTransport = (value: any) => {
     const copy = JSON.parse(JSON.stringify(value)) as { [key: string]: JsonValue };
     delete copy.sdkHttpResponse;
+
     return copy;
   };
+
   const seen: object[] = [];
+
   for await (const chunk of stream) seen.push(stripTransport(chunk));
   expect(seen).toEqual([chunk1, chunk2, chunk3]);
   const span = await exportedSpan(spans);
@@ -586,6 +628,7 @@ test("streaming aggregates chunks, preserves passthrough, and records time to fi
 test("streaming automatic function calls keep tool turns out of final output", async () => {
   const spans = setupSpans();
   const requestContents = [{ role: "user", parts: [{ text: "Weather?" }] }];
+
   const expectedInput = [
     { role: "user", parts: [{ text: "Weather?" }] },
     {
@@ -597,6 +640,7 @@ test("streaming automatic function calls keep tool turns out of final output", a
       parts: [{ functionResponse: { name: "get_weather", response: { temperature: 21 } } }],
     },
   ];
+
   const functionCallChunk = {
     responseId: "afc_1",
     candidates: [
@@ -609,6 +653,7 @@ test("streaming automatic function calls keep tool turns out of final output", a
     ],
     usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, totalTokenCount: 12 },
   };
+
   const functionResponseChunk = {
     candidates: [
       {
@@ -619,6 +664,7 @@ test("streaming automatic function calls keep tool turns out of final output", a
       },
     ],
   };
+
   const finalChunk = {
     responseId: "afc_2",
     candidates: [
@@ -629,15 +675,19 @@ test("streaming automatic function calls keep tool turns out of final output", a
     ],
     usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 3, totalTokenCount: 7 },
   };
+
   const fake = createFakeFetch(sseResponse([functionCallChunk, functionResponseChunk, finalChunk]));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: requestContents,
   });
+
   for await (const _chunk of stream) {
   }
+
   const span = await exportedSpan(spans);
   expect(requestContents).toEqual([{ role: "user", parts: [{ text: "Weather?" }] }]);
   expect(messagesAttr(span, "gen_ai.input.messages")).toEqual(expectedInput);
@@ -653,6 +703,7 @@ test("streaming automatic function calls keep tool turns out of final output", a
 
 test("streaming automatic function history excludes prior synthetic output", async () => {
   const spans = setupSpans();
+
   const functionCallChunk = {
     responseId: "afc_1",
     candidates: [
@@ -664,6 +715,7 @@ test("streaming automatic function history excludes prior synthetic output", asy
       },
     ],
   };
+
   const finalChunk = {
     responseId: "afc_2",
     candidates: [
@@ -684,6 +736,7 @@ test("streaming automatic function history excludes prior synthetic output", asy
       },
     ],
   };
+
   const client = wrapGoogleGenAI({
     models: {
       async *generateContentStream(_params: any) {
@@ -692,6 +745,7 @@ test("streaming automatic function history excludes prior synthetic output", asy
       },
     },
   });
+
   const stream = await (client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: [{ role: "user", parts: [{ text: "Weather?" }] }],
@@ -711,25 +765,32 @@ test("streaming automatic function history excludes prior synthetic output", asy
 
 test("streaming keeps thought parts separate from plain text parts", async () => {
   const spans = setupSpans();
+
   const chunk1 = {
     candidates: [{ content: { role: "model", parts: [{ text: "thinking", thought: true }] } }],
   };
+
   const chunk2 = {
     candidates: [{ content: { role: "model", parts: [{ text: "answer" }] } }],
   };
+
   const chunk3 = {
     candidates: [{ finishReason: "STOP" }],
     usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
   };
+
   const fake = createFakeFetch(sseResponse([chunk1, chunk2, chunk3]));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Think",
   });
+
   for await (const _chunk of stream) {
   }
+
   const span = await exportedSpan(spans);
   expect(messagesAttr(span, "gen_ai.output.messages")[0]).toEqual({
     role: "model",
@@ -739,16 +800,20 @@ test("streaming keeps thought parts separate from plain text parts", async () =>
 
 test("streaming mid-stream error records error status with partial output", async () => {
   const spans = setupSpans();
+
   const chunk = {
     candidates: [{ content: { role: "model", parts: [{ text: "partial" }] } }],
   };
+
   const fake = createFakeFetch(erroringSseResponse(chunk, new Error("stream failed")));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
   });
+
   await expect(async () => {
     for await (const _chunk of stream) {
     }
@@ -985,19 +1050,24 @@ test.each(["next", "return", "throw"] as const)(
 
 test("streaming early break ends span with partial aggregate", async () => {
   const spans = setupSpans();
+
   const chunk1 = {
     candidates: [{ content: { role: "model", parts: [{ text: "first" }] } }],
   };
+
   const chunk2 = {
     candidates: [{ content: { role: "model", parts: [{ text: "second" }] } }],
   };
+
   const fake = createFakeFetch(sseResponse([chunk1, chunk2]));
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
   });
+
   for await (const _chunk of stream) break;
   const span = await exportedSpan(spans);
   expect(messagesAttr(span, "gen_ai.output.messages")).toEqual([
@@ -1008,6 +1078,7 @@ test("streaming early break ends span with partial aggregate", async () => {
 test("streaming return before first chunk ends span", async () => {
   const spans = setupSpans();
   let returned = false;
+
   const source = {
     [Symbol.asyncIterator]() {
       return {
@@ -1019,11 +1090,13 @@ test("streaming return before first chunk ends span", async () => {
         },
         async return() {
           returned = true;
+
           return { done: true as const, value: undefined };
         },
       };
     },
   };
+
   const client = wrapGoogleGenAI({
     models: {
       generateContentStream(_params: any) {
@@ -1031,10 +1104,12 @@ test("streaming return before first chunk ends span", async () => {
       },
     },
   });
+
   const stream = await (client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
   }) as any);
+
   await stream.return(undefined);
   expect(returned).toBe(true);
   const span = await exportedSpan(spans);
@@ -1044,6 +1119,7 @@ test("streaming return before first chunk ends span", async () => {
 
 test("streaming return forwards the source iterator result", async () => {
   const spans = setupSpans();
+
   const returnChunk = {
     candidates: [
       {
@@ -1053,13 +1129,16 @@ test("streaming return forwards the source iterator result", async () => {
     ],
     usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 2, totalTokenCount: 3 },
   };
+
   const source = {
     [Symbol.asyncIterator]() {
       let done = false;
+
       return {
         async next() {
           if (done) return { done: true as const, value: undefined };
           done = true;
+
           return {
             done: false as const,
             value: {
@@ -1074,6 +1153,7 @@ test("streaming return forwards the source iterator result", async () => {
       };
     },
   };
+
   const client = wrapGoogleGenAI({
     models: {
       generateContentStream(_params: any) {
@@ -1081,6 +1161,7 @@ test("streaming return forwards the source iterator result", async () => {
       },
     },
   });
+
   const stream = await (client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
@@ -1102,11 +1183,13 @@ test("streaming return forwards the source iterator result", async () => {
 test("streaming next forwards values to the source iterator", async () => {
   const spans = setupSpans();
   const seen: object[] = [];
+
   const source = {
     [Symbol.asyncIterator]() {
       return {
         async next(value?: any) {
           seen.push(value);
+
           return {
             done: false as const,
             value: {
@@ -1120,6 +1203,7 @@ test("streaming next forwards values to the source iterator", async () => {
       };
     },
   };
+
   const client = wrapGoogleGenAI({
     models: {
       generateContentStream(_params: any) {
@@ -1127,6 +1211,7 @@ test("streaming next forwards values to the source iterator", async () => {
       },
     },
   });
+
   const stream = await (client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
@@ -1144,6 +1229,7 @@ test("streaming next forwards values to the source iterator", async () => {
 test("streaming return failure records a non-Error rejection", async () => {
   const spans = setupSpans();
   const cleanupFailure = "cleanup failed";
+
   const source = {
     [Symbol.asyncIterator]() {
       return {
@@ -1156,6 +1242,7 @@ test("streaming return failure records a non-Error rejection", async () => {
       };
     },
   };
+
   const client = wrapGoogleGenAI({
     models: {
       generateContentStream<T>(_params: T) {
@@ -1163,11 +1250,14 @@ test("streaming return failure records a non-Error rejection", async () => {
       },
     },
   });
+
   const stream = await client.models.generateContentStream({
     model: "gemini-2.5-flash",
     contents: "Stream",
   });
+
   const iterator = stream[Symbol.asyncIterator]();
+
   if (!iterator.return) throw new Error("stream iterator does not support return");
 
   await expect(iterator.return()).rejects.toBe(cleanupFailure);
@@ -1194,6 +1284,7 @@ test("API error 400 rethrows ApiError and records error span", async () => {
 test("non-Error unary failures end spans and preserve the thrown values", async () => {
   const spans = setupSpans();
   const rejected = "unary rejected";
+
   const rejecting = wrapGoogleGenAI({
     models: {
       generateContent<T>(_params: T) {
@@ -1201,11 +1292,13 @@ test("non-Error unary failures end spans and preserve the thrown values", async 
       },
     },
   });
+
   await expect(
     rejecting.models.generateContent({ model: "gemini-2.5-flash", contents: "fail" }),
   ).rejects.toBe(rejected);
 
   const thrown = { message: "unary threw" };
+
   const throwing = wrapGoogleGenAI({
     models: {
       generateContent<T>(_params: T) {
@@ -1213,13 +1306,16 @@ test("non-Error unary failures end spans and preserve the thrown values", async 
       },
     },
   });
+
   let caught = false;
+
   try {
     throwing.models.generateContent({ model: "gemini-2.5-flash", contents: "fail" });
   } catch (error) {
     caught = true;
     expect(error).toBe(thrown);
   }
+
   expect(caught).toBe(true);
 
   const finished = await finishedSpans(spans, 2);
@@ -1235,6 +1331,7 @@ test("non-Error unary failures end spans and preserve the thrown values", async 
 test("non-Error stream setup failures end spans and preserve the thrown values", async () => {
   const spans = setupSpans();
   const rejected = "stream setup rejected";
+
   const rejecting = wrapGoogleGenAI({
     models: {
       generateContentStream<T>(_params: T) {
@@ -1242,11 +1339,13 @@ test("non-Error stream setup failures end spans and preserve the thrown values",
       },
     },
   });
+
   await expect(
     rejecting.models.generateContentStream({ model: "gemini-2.5-flash", contents: "fail" }),
   ).rejects.toBe(rejected);
 
   const thrown = { message: "stream setup threw" };
+
   const throwing = wrapGoogleGenAI({
     models: {
       generateContentStream<T>(_params: T) {
@@ -1254,13 +1353,16 @@ test("non-Error stream setup failures end spans and preserve the thrown values",
       },
     },
   });
+
   let caught = false;
+
   try {
     throwing.models.generateContentStream({ model: "gemini-2.5-flash", contents: "fail" });
   } catch (error) {
     caught = true;
     expect(error).toBe(thrown);
   }
+
   expect(caught).toBe(true);
 
   const finished = await finishedSpans(spans, 2);
@@ -1275,6 +1377,7 @@ test("non-Error stream setup failures end spans and preserve the thrown values",
 
 test("blocked prompt records block attrs without output", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       promptFeedback: {
@@ -1284,6 +1387,7 @@ test("blocked prompt records block attrs without output", async () => {
       },
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
   await client.models.generateContent({ model: "gemini-2.5-flash", contents: "blocked" });
@@ -1299,6 +1403,7 @@ test("blocked prompt records block attrs without output", async () => {
 
 test("embedContent maps embedding span fields without output", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       embeddings: [
@@ -1308,6 +1413,7 @@ test("embedContent maps embedding span fields without output", async () => {
       metadata: { billableCharacterCount: 42 },
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = clientWith();
   await client.models.embedContent({
@@ -1336,15 +1442,18 @@ test("chats sendMessage emits span input with history for wrap-before-create and
       },
     ],
   };
+
   const history = [{ role: "user", parts: [{ text: "Hi" }] }];
   const spans = setupSpans();
   const fakeBefore = createFakeFetch(jsonResponse(responseBody), jsonResponse(responseBody));
   vi.stubGlobal("fetch", fakeBefore.fetch);
   const wrappedFirst = clientWith();
+
   const chatBefore = wrappedFirst.chats.create({
     model: "gemini-2.5-flash",
     history,
   });
+
   await chatBefore.sendMessage({ message: "Again" });
   const spanBefore = (await finishedSpans(spans, 1))[0]!;
   expect(messagesAttr(spanBefore, "gen_ai.input.messages")).toEqual([
@@ -1369,11 +1478,13 @@ test("chats sendMessage emits span input with history for wrap-before-create and
 
 test("vertex clients report gcp.vertex_ai provider", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [{ content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" }],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = wrapGoogleGenAI(new GoogleGenAI({ vertexai: true, apiKey: "test" }));
   await client.models.generateContent({ model: "gemini-2.5-flash", contents: "hi" });
@@ -1383,6 +1494,7 @@ test("vertex clients report gcp.vertex_ai provider", async () => {
 
 test("double wrapGoogleGenAI emits one span per call", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       candidates: [{ content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" }],
@@ -1391,6 +1503,7 @@ test("double wrapGoogleGenAI emits one span per call", async () => {
       candidates: [{ content: { role: "model", parts: [{ text: "ok2" }] }, finishReason: "STOP" }],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const once = wrapGoogleGenAI(new GoogleGenAI({ apiKey: "test" }));
   const twice = wrapGoogleGenAI(once);
@@ -1401,12 +1514,14 @@ test("double wrapGoogleGenAI emits one span per call", async () => {
 
 test("wrapped calls fail open when telemetry mapping throws", async () => {
   const spans = setupSpans();
+
   const response = {
     text: "ok",
     get candidates() {
       throw new Error("response mapper failed");
     },
   };
+
   const client = wrapGoogleGenAI({
     models: {
       generateContent(_params: any) {
@@ -1414,6 +1529,7 @@ test("wrapped calls fail open when telemetry mapping throws", async () => {
       },
     },
   });
+
   const params = {
     model: "gemini-2.5-flash",
     contents: "hi",
@@ -1421,6 +1537,7 @@ test("wrapped calls fail open when telemetry mapping throws", async () => {
       throw new Error("request mapper failed");
     },
   };
+
   const result = client.models.generateContent(params);
   expect(result).toBe(response);
   const span = await exportedSpan(spans);
@@ -1434,11 +1551,14 @@ test("wrapped calls fail open when telemetry is not initialized", async () => {
       candidates: [{ content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" }],
     }),
   );
+
   vi.stubGlobal("fetch", fake.fetch);
   const client = wrapGoogleGenAI(new GoogleGenAI({ apiKey: "test" }));
+
   const response = await client.models.generateContent({
     model: "gemini-2.5-flash",
     contents: "hi",
   });
+
   expect(response.text).toBe("ok");
 });

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,11 +23,18 @@ export interface InstrumentMcpTransportOptions {
 }
 
 type JsonRpcId = string | number;
-type JsonRecord = Record<string, unknown>;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonRecord;
+
+interface JsonRecord {
+  [key: string]: JsonValue | undefined;
+}
+
 type MessageHandler = (message: unknown, extra?: unknown) => void;
+
 type Send = (message: unknown, options?: unknown) => Promise<void>;
 
-interface SendOptions extends JsonRecord {
+interface SendOptions {
   requestSignal?: AbortSignal;
   onRequestStreamEnd?: () => void;
   resumptionToken?: string;
@@ -81,8 +88,10 @@ function asRecord(value: unknown): JsonRecord | undefined {
 
 function parseMessage(value: unknown): ParsedMessage | undefined {
   const message = asRecord(value);
+
   if (message === undefined) return undefined;
   const params = asRecord(message.params);
+
   return {
     message,
     method: requestMethod(message),
@@ -95,6 +104,7 @@ function parseMessage(value: unknown): ParsedMessage | undefined {
 function requestId(message: JsonRecord): JsonRpcId | undefined {
   if (!("id" in message)) return undefined;
   const id = message.id;
+
   return typeof id === "string" || typeof id === "number" ? id : undefined;
 }
 
@@ -114,6 +124,7 @@ function isRequest(
 
 function targetFor(method: string, params: JsonRecord | undefined): string | undefined {
   if (method !== "tools/call" && method !== "prompts/get") return undefined;
+
   return typeof params?.name === "string" ? params.name : undefined;
 }
 
@@ -126,11 +137,13 @@ function resourceUri(method: string, params: JsonRecord | undefined): string | u
   ) {
     return undefined;
   }
+
   return typeof params?.uri === "string" ? params.uri : undefined;
 }
 
 function metaProtocolVersion(meta: JsonRecord | undefined): string | undefined {
   const version = meta?.[PROTOCOL_VERSION_META_KEY];
+
   return typeof version === "string" ? version : undefined;
 }
 
@@ -139,11 +152,15 @@ function protocolVersion(
   message: ParsedMessage,
 ): string | undefined {
   const modern = metaProtocolVersion(message.meta);
+
   if (modern !== undefined) return modern;
+
   if (message.method === "initialize" && typeof message.params?.protocolVersion === "string") {
     PROTOCOL_VERSIONS.set(transport, message.params.protocolVersion);
+
     return message.params.protocolVersion;
   }
+
   return PROTOCOL_VERSIONS.get(transport) ?? transport.protocolVersion;
 }
 
@@ -153,12 +170,16 @@ function responseProtocolVersion(
   message: ParsedMessage,
 ): string | undefined {
   const modern = metaProtocolVersion(message.meta);
+
   if (modern !== undefined) return modern;
   const result = asRecord(message.message.result);
+
   if (method === "initialize" && typeof result?.protocolVersion === "string") {
     PROTOCOL_VERSIONS.set(transport, result.protocolVersion);
+
     return result.protocolVersion;
   }
+
   return PROTOCOL_VERSIONS.get(transport) ?? transport.protocolVersion;
 }
 
@@ -167,21 +188,29 @@ function requestAttributes(
   message: ParsedMessage,
 ): RequestSpanAttributes {
   const method = message.method!;
+
   const attributes: RequestSpanAttributes = {
     "gen_ai.operation.name": method === "tools/call" ? "execute_tool" : "mcp",
     "mcp.method.name": method,
   };
+
   if (message.id !== undefined) {
     attributes["jsonrpc.request.id"] = String(message.id);
   }
+
   if (typeof transport.sessionId === "string") attributes["mcp.session.id"] = transport.sessionId;
   const version = protocolVersion(transport, message);
+
   if (version !== undefined) attributes["mcp.protocol.version"] = version;
   const target = targetFor(method, message.params);
+
   if (method === "tools/call" && target !== undefined) attributes["gen_ai.tool.name"] = target;
+
   if (method === "prompts/get" && target !== undefined) attributes["gen_ai.prompt.name"] = target;
   const uri = resourceUri(method, message.params);
+
   if (uri !== undefined) attributes["mcp.resource.uri"] = uri;
+
   return attributes;
 }
 
@@ -193,21 +222,26 @@ function startRequest(
   propagateBaggage: boolean,
 ): PendingRequest | undefined {
   const method = message.method;
+
   if (method === undefined) return undefined;
   const target = targetFor(method, message.params);
   const ambient = activeContext();
+
   const extracted = receiver
     ? extractW3cContext(message.meta ?? {}, { includeBaggage: propagateBaggage })
     : undefined;
+
   const ambientSpan = trace.getSpanContext(ambient);
   const remoteSpan = extracted === undefined ? undefined : trace.getSpanContext(extracted);
   const remoteIsValid = remoteSpan !== undefined && trace.isSpanContextValid(remoteSpan);
   const remoteBaggage = extracted === undefined ? undefined : propagation.getBaggage(extracted);
+
   const parent = remoteIsValid
     ? extracted
     : remoteBaggage === undefined
       ? undefined
       : propagation.setBaggage(ambient, remoteBaggage);
+
   const links =
     ambientSpan !== undefined &&
     trace.isSpanContextValid(ambientSpan) &&
@@ -215,6 +249,7 @@ function startRequest(
     (ambientSpan.traceId !== remoteSpan.traceId || ambientSpan.spanId !== remoteSpan.spanId)
       ? [{ context: ambientSpan }]
       : undefined;
+
   const handle = startSpan(target === undefined ? method : `${method} ${target}`, {
     type: method === "tools/call" ? "tool" : "span",
     kind: receiver ? SpanKind.SERVER : SpanKind.CLIENT,
@@ -223,6 +258,7 @@ function startRequest(
     attributes: requestAttributes(transport, message),
     input: capturePayloads && method === "tools/call" ? message.params?.arguments : undefined,
   });
+
   return { handle, method, receiver, capturePayloads, completed: false };
 }
 
@@ -232,8 +268,10 @@ function updateObservableAttributes(
   message: ParsedMessage,
 ): void {
   const attributes: Record<string, string> = {};
+
   if (typeof transport.sessionId === "string") attributes["mcp.session.id"] = transport.sessionId;
   const version = responseProtocolVersion(transport, pending.method, message);
+
   if (version !== undefined) attributes["mcp.protocol.version"] = version;
   pending.handle.update({ attributes });
 }
@@ -250,18 +288,22 @@ function finishResponse(
 ): void {
   updateObservableAttributes(transport, pending, message);
   const error = asRecord(message.message.error);
+
   if (error !== undefined) {
     const code = typeof error.code === "number" ? error.code : undefined;
     const codeText = code === undefined ? "_OTHER" : String(code);
     pending.handle.span.setAttribute("rpc.response.status_code", codeText);
+
     if (!pending.receiver || code === undefined || !CALLER_ERROR_CODES.has(code)) {
       setFailure(pending, codeText, typeof error.message === "string" ? error.message : undefined);
     }
   } else {
     const result = asRecord(message.message.result);
+
     if (pending.method === "tools/call" && result?.isError === true) {
       setFailure(pending, "tool_error");
     }
+
     if (pending.capturePayloads && pending.method === "tools/call" && result?.isError !== true) {
       pending.handle.update({ output: message.message.result });
     }
@@ -276,11 +318,14 @@ function completePending(
 ): void {
   if (pending.completed) return;
   pending.completed = true;
+
   if (requests.get(key) === pending) requests.delete(key);
   pending.removeAbortListener?.();
+
   try {
     update?.();
   } catch {}
+
   try {
     pending.handle.end();
   } catch {}
@@ -292,6 +337,7 @@ function completeAs(
   type: "cancelled" | "connection_error",
 ): void {
   const pending = requests.get(id);
+
   if (pending !== undefined) {
     completePending(requests, id, pending, () => setFailure(pending, type));
   }
@@ -299,8 +345,10 @@ function completeAs(
 
 function cancellationId(message: ParsedMessage): JsonRpcId | undefined {
   if (message.method !== "notifications/cancelled") return undefined;
+
   if (message.params === undefined || !("requestId" in message.params)) return undefined;
   const id = message.params.requestId;
+
   return typeof id === "string" || typeof id === "number" ? id : undefined;
 }
 
@@ -308,6 +356,7 @@ function prepareInjectedRequest(message: ParsedMessage) {
   const params = { ...message.params };
   const meta = { ...message.meta };
   params._meta = meta;
+
   return { message: { ...message.message, params }, meta };
 }
 
@@ -328,17 +377,21 @@ export function instrumentMcpTransport<T extends McpTransport>(
   const capturePayloads = options.capturePayloads === true;
   const propagateBaggage = options.propagateBaggage === true;
   let onmessage = target.onmessage;
+
   const wrapClose = (handler: (() => void) | undefined) =>
     function () {
       for (const [key, pending] of outgoing) {
         completePending(outgoing, key, pending, () => setFailure(pending, "connection_error"));
       }
+
       for (const [key, pending] of incoming) {
         if (sendingResponses.has(pending)) continue;
         completePending(incoming, key, pending, () => setFailure(pending, "connection_error"));
       }
+
       handler?.call(target);
     };
+
   let onclose = wrapClose(target.onclose);
 
   target.send = async (value, sendOptions) => {
@@ -357,12 +410,15 @@ export function instrumentMcpTransport<T extends McpTransport>(
       );
       const rawOptions = asRecord(sendOptions) as SendOptions | undefined;
       const copiedOptions = rawOptions === undefined ? undefined : { ...rawOptions };
+
       const resumeOnly =
         typeof copiedOptions?.resumptionToken === "string" &&
         copiedOptions.resumptionToken.length > 0;
+
       requestSignal = copiedOptions?.requestSignal;
       const originalStreamEnd = copiedOptions?.onRequestStreamEnd;
       const requestCounts = new Map<JsonRpcId, number>();
+
       if (!resumeOnly) {
         for (const message of messages) {
           if (!isRequest(message)) continue;
@@ -372,6 +428,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
       }
 
       const transformed = [...values];
+
       const prepared: Array<{
         index: number;
         key: JsonRpcId;
@@ -379,17 +436,23 @@ export function instrumentMcpTransport<T extends McpTransport>(
         message: InjectedRequest;
         meta: JsonRecord;
       }> = [];
+
       const cancelledKeys = new Set<JsonRpcId>();
+
       for (const [index, message] of messages.entries()) {
         const cancelled = cancellations[index];
+
         if (cancelled !== undefined) {
           cancelledKeys.add(cancelled);
         }
+
         if (!isRequest(message) || resumeOnly) continue;
         const key = message.id;
+
         if (requestCounts.get(key) !== 1 || (outgoing.has(key) && !cancelledKeys.has(key))) {
           continue;
         }
+
         const injected = prepareInjectedRequest(message);
         prepared.push({ index, key, parsed: message, ...injected });
       }
@@ -402,6 +465,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
           capturePayloads,
           propagateBaggage,
         );
+
         if (pending !== undefined) {
           started.push({ index: request.index, key: request.key, pending });
           injectW3cContext(pending.handle.context, request.meta, {
@@ -412,6 +476,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
       }
 
       if (started.length > 0) sent = Array.isArray(value) ? transformed : transformed[0];
+
       if (started.length > 0 && copiedOptions !== undefined) {
         forwardedOptions = {
           ...copiedOptions,
@@ -434,6 +499,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
           pending.handle.end();
         } catch {}
       }
+
       messages = [];
       cancellations = [];
       started = [];
@@ -444,24 +510,31 @@ export function instrumentMcpTransport<T extends McpTransport>(
 
     const startedByIndex = new Map(started.map((request) => [request.index, request]));
     const signal = requestSignal;
+
     for (const [index, cancelled] of cancellations.entries()) {
       if (cancelled !== undefined) completeAs(outgoing, cancelled, "cancelled");
       const request = startedByIndex.get(index);
+
       if (request !== undefined) {
         const { key, pending } = request;
+
         if (outgoing.has(key)) {
           completePending(outgoing, key, pending, () =>
             setFailure(pending, "duplicate_request_id"),
           );
           continue;
         }
+
         outgoing.set(key, pending);
+
         if (signal !== undefined) {
           const onAbort = () =>
             completePending(outgoing, key, pending, () => setFailure(pending, "cancelled"));
+
           try {
             signal.addEventListener("abort", onAbort, { once: true });
             pending.removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+
             if (signal.aborted) onAbort();
           } catch {}
         }
@@ -470,11 +543,13 @@ export function instrumentMcpTransport<T extends McpTransport>(
 
     const responses: Array<{ key: JsonRpcId; pending: PendingRequest; message: ParsedMessage }> =
       [];
+
     for (const message of messages) {
       if (message === undefined || message.method !== undefined || message.id === undefined)
         continue;
       const key = message.id;
       const pending = incoming.get(key);
+
       if (pending === undefined || sendingResponses.has(pending)) continue;
       sendingResponses.add(pending);
       responses.push({ key, pending, message });
@@ -487,9 +562,11 @@ export function instrumentMcpTransport<T extends McpTransport>(
         for (const { key, pending } of started) {
           completePending(outgoing, key, pending, () => pending.handle.update({ error }));
         }
+
         for (const { key, pending } of responses) {
           completePending(incoming, key, pending, () => pending.handle.update({ error }));
         }
+
         throw error;
       }
 
@@ -520,23 +597,31 @@ export function instrumentMcpTransport<T extends McpTransport>(
           ? undefined
           : function (value, extra) {
               const object = value !== null && typeof value === "object" ? value : undefined;
+
               if (object !== undefined && dispatching.has(object)) {
                 handler.call(target, value, extra);
+
                 return;
               }
+
               if (object !== undefined) dispatching.add(object);
 
               let invoked = false;
+
               const invoke = () => {
                 invoked = true;
+
                 return handler.call(target, value, extra);
               };
+
               const received: Array<{ key: JsonRpcId; pending: PendingRequest }> = [];
+
               const completeFailure = (error: unknown) => {
                 for (const { key, pending } of received) {
                   completePending(incoming, key, pending, () => pending.handle.update({ error }));
                 }
               };
+
               const completeAsyncFailure = (result: unknown): unknown => {
                 if (
                   result === null ||
@@ -546,6 +631,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
                 ) {
                   return result;
                 }
+
                 return Promise.resolve(result).catch((error: unknown) => {
                   completeFailure(error);
                   throw error;
@@ -557,6 +643,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
                   const values = Array.isArray(value) ? value : [value];
                   const messages = values.map(parseMessage);
                   const requestCounts = new Map<JsonRpcId, number>();
+
                   for (const message of messages) {
                     if (!isRequest(message)) continue;
                     const key = message.id;
@@ -566,11 +653,14 @@ export function instrumentMcpTransport<T extends McpTransport>(
                   for (const message of messages) {
                     if (message === undefined) continue;
                     const cancelled = cancellationId(message);
+
                     if (cancelled !== undefined) completeAs(incoming, cancelled, "cancelled");
 
                     if (isRequest(message)) {
                       const key = message.id;
+
                       if (requestCounts.get(key) !== 1 || incoming.has(key)) continue;
+
                       const pending = startRequest(
                         target,
                         message,
@@ -578,6 +668,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
                         capturePayloads,
                         propagateBaggage,
                       );
+
                       if (pending !== undefined) {
                         incoming.set(key, pending);
                         received.push({ key, pending });
@@ -585,6 +676,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
                     } else if (message.method === undefined && message.id !== undefined) {
                       const key = message.id;
                       const pending = outgoing.get(key);
+
                       if (pending !== undefined) {
                         completePending(outgoing, key, pending, () =>
                           finishResponse(target, pending, message),
@@ -596,11 +688,13 @@ export function instrumentMcpTransport<T extends McpTransport>(
                   for (const { key, pending } of received) {
                     completePending(incoming, key, pending);
                   }
+
                   received.length = 0;
                 }
 
                 const requestContext =
                   received.length === 1 ? received[0]?.pending.handle.context : undefined;
+
                 try {
                   return completeAsyncFailure(
                     requestContext === undefined ? invoke() : withContext(requestContext, invoke),
@@ -614,6 +708,7 @@ export function instrumentMcpTransport<T extends McpTransport>(
                       throw handlerError;
                     }
                   }
+
                   completeFailure(error);
                   throw error;
                 }
@@ -634,5 +729,6 @@ export function instrumentMcpTransport<T extends McpTransport>(
   });
 
   if (onmessage !== undefined) target.onmessage = onmessage;
+
   return transport;
 }

--- a/packages/mcp/tests/mcp.test.ts
+++ b/packages/mcp/tests/mcp.test.ts
@@ -29,6 +29,12 @@ interface TestTransport {
   setProtocolVersion?: (version: string) => void;
 }
 
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonRecord;
+
+interface JsonRecord {
+  [key: string]: JsonValue | undefined;
+}
+
 function setup(): InMemorySpanExporter {
   const spans = new InMemorySpanExporter();
   init(
@@ -42,16 +48,20 @@ function setup(): InMemorySpanExporter {
     },
     { spanExporter: spans },
   );
+
   return spans;
 }
 
 async function exported(spans: InMemorySpanExporter, count: number): Promise<ReadableSpan[]> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await flush();
+
     if (spans.getFinishedSpans().length === count) return spans.getFinishedSpans();
     await Promise.resolve();
   }
+
   expect(spans.getFinishedSpans()).toHaveLength(count);
+
   return spans.getFinishedSpans();
 }
 
@@ -67,9 +77,9 @@ test("instruments both v2 transport directions with propagation and opt-in paylo
   expect(instrumentMcpTransport(client)).toBe(clientRaw);
 
   client.onmessage = () => undefined;
-  let receivedMeta: Record<string, unknown> | undefined;
+  let receivedMeta: JsonRecord | undefined;
   server.onmessage = (message) => {
-    receivedMeta = (message as { params?: { _meta?: Record<string, unknown> } }).params?._meta;
+    receivedMeta = (message as { params?: { _meta?: JsonRecord } }).params?._meta;
     startSpan("handler-work").end();
     void server.send({
       jsonrpc: "2.0",
@@ -78,6 +88,7 @@ test("instruments both v2 transport directions with propagation and opt-in paylo
     });
     void message;
   };
+
   await client.start();
   await server.start();
 
@@ -94,6 +105,7 @@ test("instruments both v2 transport directions with propagation and opt-in paylo
       },
     },
   } satisfies JSONRPCMessage;
+
   const baggage = propagation.createBaggage({ tenant: { value: "acme" } });
   await withContext(propagation.setBaggage(activeContext(), baggage), () => client.send(request));
 
@@ -125,6 +137,7 @@ test("instruments both v2 transport directions with propagation and opt-in paylo
 test("propagates baggage only when enabled", async () => {
   const spans = setup();
   let sent: unknown;
+
   const transport = instrumentMcpTransport<TestTransport>(
     {
       send: async (message: unknown) => {
@@ -133,6 +146,7 @@ test("propagates baggage only when enabled", async () => {
     },
     { propagateBaggage: true },
   );
+
   transport.onmessage = () => undefined;
 
   const baggage = propagation.createBaggage({ tenant: { value: "acme" } });
@@ -140,7 +154,7 @@ test("propagates baggage only when enabled", async () => {
     transport.send({ jsonrpc: "2.0", id: 2, method: "ping" } as never),
   );
 
-  const meta = (sent as { params?: { _meta?: Record<string, unknown> } }).params?._meta;
+  const meta = (sent as { params?: { _meta?: JsonRecord } }).params?._meta;
   expect(meta?.traceparent).toBeTypeOf("string");
   expect(meta?.baggage).toBe("tenant=acme");
   transport.onmessage?.({ jsonrpc: "2.0", id: 2, result: {} } as never);
@@ -155,8 +169,10 @@ test("works through the official v2 client and server connection lifecycle", asy
   let preexistingCalls = 0;
   serverRaw.onmessage = function (message) {
     expect(this).toBe(serverRaw);
+
     if ("method" in message && message.method === "tools/call") preexistingCalls += 1;
   };
+
   server.registerTool("weather", { description: "Get the weather" }, async () => ({
     content: [{ type: "text", text: "sunny" }],
   }));
@@ -169,6 +185,7 @@ test("works through the official v2 client and server connection lifecycle", asy
   const toolSpans = spans
     .getFinishedSpans()
     .filter((span) => span.attributes["mcp.method.name"] === "tools/call");
+
   expect(toolSpans).toHaveLength(2);
   expect(toolSpans.map((span) => span.kind)).toContain(SpanKind.CLIENT);
   expect(toolSpans.map((span) => span.kind)).toContain(SpanKind.SERVER);
@@ -183,6 +200,7 @@ test("works through the official v2 client and server connection lifecycle", asy
 
 test("completes responses before a per-request HTTP transport closes", async () => {
   const spans = setup();
+
   const handler = createMcpHandler(
     () => {
       const server = new McpServer({ name: "test-server", version: "1.0.0" });
@@ -191,10 +209,12 @@ test("completes responses before a per-request HTTP transport closes", async () 
       }));
       const connect = server.connect.bind(server);
       server.connect = (transport) => connect(instrumentMcpTransport(transport));
+
       return server;
     },
     { legacy: "reject" },
   );
+
   const response = await handler.fetch(
     new Request("https://mcp.example.test", {
       method: "POST",
@@ -233,9 +253,11 @@ test("completes responses before a per-request HTTP transport closes", async () 
 
 test("applies asymmetric JSON-RPC error status rules", async () => {
   const spans = setup();
+
   const [client, server] = InMemoryTransport.createLinkedPair().map((transport) =>
     instrumentMcpTransport(transport),
   );
+
   client.onmessage = () => undefined;
   server.onmessage = () => {
     void server.send({
@@ -244,6 +266,7 @@ test("applies asymmetric JSON-RPC error status rules", async () => {
       error: { code: -32602, message: "Invalid params" },
     });
   };
+
   await client.start();
   await server.start();
   await client.send({ jsonrpc: "2.0", id: 7, method: "prompts/get", params: { name: "review" } });
@@ -263,9 +286,11 @@ test.each([-32021, -32022])(
   "treats MCP v2 caller error %i as a client failure only",
   async (code) => {
     const spans = setup();
+
     const [client, server] = InMemoryTransport.createLinkedPair().map((transport) =>
       instrumentMcpTransport(transport),
     );
+
     client.onmessage = () => undefined;
     server.onmessage = () => {
       void server.send({
@@ -274,6 +299,7 @@ test.each([-32021, -32022])(
         error: { code, message: "Client compatibility error" },
       });
     };
+
     await client.start();
     await server.start();
     await client.send({ jsonrpc: "2.0", id: 8, method: "ping" });
@@ -290,9 +316,11 @@ test.each([-32021, -32022])(
 
 test("marks CallToolResult errors and closes pending requests", async () => {
   const spans = setup();
+
   const [client, server] = InMemoryTransport.createLinkedPair().map((transport) =>
     instrumentMcpTransport(transport),
   );
+
   client.onmessage = () => undefined;
   server.onmessage = () => {
     void server.send({
@@ -301,6 +329,7 @@ test("marks CallToolResult errors and closes pending requests", async () => {
       result: { content: [{ type: "text", text: "failed" }], isError: true },
     });
   };
+
   await client.start();
   await server.start();
   await client.send({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "broken" } });
@@ -311,11 +340,13 @@ test("marks CallToolResult errors and closes pending requests", async () => {
 
   await shutdown();
   const closeSpans = setup();
+
   const rawTransport: TestTransport = {
     send: async (_message: unknown) => undefined,
     onmessage: undefined,
     onclose: undefined,
   };
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onclose = () => undefined;
   await transport.send({ jsonrpc: "2.0", id: 10, method: "ping" } as never);
@@ -327,11 +358,13 @@ test("marks CallToolResult errors and closes pending requests", async () => {
 
 test("ends an outgoing request span when send fails", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport({
     send: async (_message: unknown) => {
       throw new TypeError("disconnected");
     },
   });
+
   await expect(
     transport.send({ jsonrpc: "2.0", id: 11, method: "resources/list" } as never),
   ).rejects.toThrow("disconnected");
@@ -342,12 +375,14 @@ test("ends an outgoing request span when send fails", async () => {
 
 test("records response send failures that race with transport close", async () => {
   const spans = setup();
+
   const rawTransport: TestTransport = {
     send: async (_message: unknown) => {
       rawTransport.onclose?.();
       throw new TypeError("response disconnected");
     },
   };
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onmessage = () => undefined;
   transport.onmessage({ jsonrpc: "2.0", id: 14, method: "resources/list" } as never);
@@ -362,9 +397,11 @@ test("records response send failures that race with transport close", async () =
 
 test("ends an incoming request span when its handler throws", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (_message: unknown) => undefined,
   });
+
   transport.onmessage = () => {
     throw new TypeError("handler failed");
   };
@@ -379,9 +416,11 @@ test("ends an incoming request span when its handler throws", async () => {
 
 test("ends an incoming request span when its async handler rejects", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (_message: unknown) => undefined,
   });
+
   transport.onmessage = async () => {
     await Promise.resolve();
     throw new TypeError("async handler failed");
@@ -392,6 +431,7 @@ test("ends an incoming request span when its async handler rejects", async () =>
     id: 13,
     method: "resources/list",
   } as never) as unknown;
+
   await expect(result).rejects.toThrow("async handler failed");
   const [span] = await exported(spans, 1);
   expect(span?.attributes["error.type"]).toBe("TypeError");
@@ -401,10 +441,12 @@ test("ends an incoming request span when its async handler rejects", async () =>
 test("observes protocol versions without owning transport negotiation", async () => {
   const spans = setup();
   const setProtocolVersion = vi.fn();
+
   const rawTransport: TestTransport = {
     send: async (_message: unknown) => undefined,
     setProtocolVersion,
   };
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onmessage = () => undefined;
 
@@ -428,25 +470,38 @@ test("observes protocol versions without owning transport negotiation", async ()
   Object.defineProperty(transport, "protocolVersion", { value: "stale", configurable: true });
   await transport.send({ jsonrpc: "2.0", id: 21, method: "ping" } as never);
   transport.onmessage?.({ jsonrpc: "2.0", id: 21, result: {} } as never);
+
   const versions = (await exported(spans, 2)).map(
     (finished) => finished.attributes["mcp.protocol.version"],
   );
+
   expect(versions).toContain("2025-03-26");
   expect(setProtocolVersion).toHaveBeenCalledOnce();
 });
 
 test("completes pending spans exactly once on abort, cancellation, and stream end", async () => {
   const spans = setup();
-  const sentOptions = new Map<number, Record<string, unknown>>();
+
+  const sentOptions = new Map<
+    number,
+    { requestSignal?: AbortSignal; onRequestStreamEnd?: () => void }
+  >();
+
   const originalStreamEnd = vi.fn();
+
   const rawTransport: TestTransport = {
     send: async (message: unknown, options?: unknown) => {
       const id = (message as { id?: unknown }).id;
+
       if (typeof id === "number" && options !== undefined) {
-        sentOptions.set(id, options as Record<string, unknown>);
+        sentOptions.set(
+          id,
+          options as { requestSignal?: AbortSignal; onRequestStreamEnd?: () => void },
+        );
       }
     },
   };
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onmessage = () => undefined;
 
@@ -493,14 +548,17 @@ test("completes pending spans exactly once on abort, cancellation, and stream en
 test("stale stream callbacks cannot complete a newer request with a reused id", async () => {
   const spans = setup();
   let firstStreamEnd: (() => void) | undefined;
+
   const rawTransport: TestTransport = {
     send: async (message: unknown, options?: unknown) => {
       const id = (message as { id?: unknown }).id;
+
       if (id === 34 && firstStreamEnd === undefined) {
         firstStreamEnd = (options as { onRequestStreamEnd?: () => void }).onRequestStreamEnd;
       }
     },
   };
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onmessage = () => undefined;
 
@@ -518,6 +576,7 @@ test("stale stream callbacks cannot complete a newer request with a reused id", 
 test("instruments mixed batched requests without mutating untouched messages", async () => {
   const spans = setup();
   let sent: unknown;
+
   const transport = instrumentMcpTransport<TestTransport>(
     {
       send: async (message: unknown) => {
@@ -526,31 +585,36 @@ test("instruments mixed batched requests without mutating untouched messages", a
     },
     { capturePayloads: true },
   );
+
   transport.onmessage = () => undefined;
+
   const first = {
     jsonrpc: "2.0",
     id: 60,
     method: "tools/call",
     params: { name: "weather", arguments: { city: "Paris" }, _meta: { existing: "kept" } },
   };
+
   const notification = {
     jsonrpc: "2.0",
     method: "notifications/progress",
     params: { progressToken: "one", progress: 1 },
   };
+
   const second = {
     jsonrpc: "2.0",
     id: "61",
     method: "prompts/get",
     params: { name: "review" },
   };
+
   const batch = [first, notification, second];
 
   await transport.send(batch as never);
 
-  const sentBatch = sent as Array<Record<string, unknown>>;
-  const firstParams = sentBatch[0]?.params as { _meta?: Record<string, unknown> } | undefined;
-  const secondParams = sentBatch[2]?.params as { _meta?: Record<string, unknown> } | undefined;
+  const sentBatch = sent as JsonRecord[];
+  const firstParams = sentBatch[0]?.params as { _meta?: JsonRecord } | undefined;
+  const secondParams = sentBatch[2]?.params as { _meta?: JsonRecord } | undefined;
   const firstMeta = firstParams?._meta;
   const secondMeta = secondParams?._meta;
   expect(sentBatch).not.toBe(batch);
@@ -599,11 +663,14 @@ test("instruments both directions when a transport delivers batches intact", asy
   const client = instrumentMcpTransport(clientRaw);
   const server = instrumentMcpTransport(serverRaw);
   client.onmessage = () => undefined;
+
   const serverHandler = vi.fn((message: unknown) => {
     const requests = message as Array<{ id: string | number }>;
     void server.send(requests.map((request) => ({ jsonrpc: "2.0", id: request.id, result: {} })));
   });
+
   server.onmessage = serverHandler;
+
   const batch = [
     { jsonrpc: "2.0", id: 71, method: "ping" },
     { jsonrpc: "2.0", id: "72", method: "tools/list" },
@@ -614,6 +681,7 @@ test("instruments both directions when a transport delivers batches intact", asy
   const finished = await exported(spans, 4);
   expect(serverHandler).toHaveBeenCalledOnce();
   expect(serverHandler.mock.calls[0]?.[0]).toBeInstanceOf(Array);
+
   for (const id of ["71", "72"]) {
     const matching = finished.filter((span) => span.attributes["jsonrpc.request.id"] === id);
     const clientSpan = matching.find((span) => span.kind === SpanKind.CLIENT);
@@ -626,11 +694,13 @@ test("instruments both directions when a transport delivers batches intact", asy
 test("skips duplicate batch ids while distinguishing numeric and string ids", async () => {
   const spans = setup();
   let sent: unknown;
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (message: unknown) => {
       sent = message;
     },
   });
+
   transport.onmessage = () => undefined;
   const first = { jsonrpc: "2.0", id: 62, method: "ping" };
   const duplicate = { jsonrpc: "2.0", id: 62, method: "tools/list" };
@@ -639,11 +709,11 @@ test("skips duplicate batch ids while distinguishing numeric and string ids", as
 
   await transport.send(batch as never);
 
-  const sentBatch = sent as Array<Record<string, unknown>>;
+  const sentBatch = sent as JsonRecord[];
   expect(sentBatch[0]).toBe(first);
   expect(sentBatch[1]).toBe(duplicate);
   expect(sentBatch[2]).not.toBe(distinct);
-  const distinctParams = sentBatch[2]?.params as { _meta?: Record<string, unknown> } | undefined;
+  const distinctParams = sentBatch[2]?.params as { _meta?: JsonRecord } | undefined;
   expect(distinctParams?._meta?.traceparent).toBeTypeOf("string");
   transport.onmessage?.({ jsonrpc: "2.0", id: 62, result: {} });
   expect(spans.getFinishedSpans()).toHaveLength(0);
@@ -656,23 +726,27 @@ test("skips duplicate batch ids while distinguishing numeric and string ids", as
 test("applies batched cancellations in message order", async () => {
   const spans = setup();
   let sent: unknown;
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (message: unknown) => {
       sent = message;
     },
   });
+
   transport.onmessage = () => undefined;
   await transport.send({ jsonrpc: "2.0", id: 63, method: "ping" } as never);
+
   const cancellation = {
     jsonrpc: "2.0",
     method: "notifications/cancelled",
     params: { requestId: 63 },
   };
+
   const replacement = { jsonrpc: "2.0", id: 63, method: "tools/list" };
 
   await transport.send([cancellation, replacement] as never);
 
-  const sentBatch = sent as Array<Record<string, unknown>>;
+  const sentBatch = sent as JsonRecord[];
   expect(sentBatch[0]).toBe(cancellation);
   expect(sentBatch[1]).not.toBe(replacement);
   transport.onmessage?.({ jsonrpc: "2.0", id: 63, result: {} });
@@ -695,6 +769,7 @@ test.each([73, 74])("does not trace id-bearing cancellation controls with id %i"
   const transport = instrumentMcpTransport<TestTransport>({ send: originalSend });
   transport.onmessage = () => undefined;
   await transport.send({ jsonrpc: "2.0", id: 73, method: "ping" } as never);
+
   const cancellation = {
     jsonrpc: "2.0",
     id,
@@ -715,9 +790,11 @@ test.each([75, 76])(
   "does not trace received id-bearing cancellation controls with id %i",
   async (id) => {
     const spans = setup();
+
     const transport = instrumentMcpTransport<TestTransport>({
       send: async (_message: unknown) => undefined,
     });
+
     transport.onmessage = () => undefined;
     transport.onmessage?.({ jsonrpc: "2.0", id: 75, method: "ping" });
     transport.onmessage?.({
@@ -736,6 +813,7 @@ test.each([75, 76])(
 
 test("completes every batched request when send fails", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (_message: unknown) => {
       throw new TypeError("batch disconnected");
@@ -788,6 +866,7 @@ test("completes incoming requests from a batched response send", async () => {
   transport.onmessage = () => undefined;
   transport.onmessage?.({ jsonrpc: "2.0", id: 69, method: "ping" });
   transport.onmessage?.({ jsonrpc: "2.0", id: 70, method: "tools/list" });
+
   const responses = [
     { jsonrpc: "2.0", id: 70, result: { tools: [] } },
     { jsonrpc: "2.0", id: 69, result: {} },
@@ -803,13 +882,16 @@ test("completes incoming requests from a batched response send", async () => {
 
 test("does not trace resume-only Streamable HTTP sends", async () => {
   const spans = setup();
+
   const fetch = vi.fn(
     async (_input: RequestInfo | URL, _init?: RequestInit) =>
       new Response(null, { status: 405, statusText: "Method Not Allowed" }),
   );
+
   const rawTransport = new StreamableHTTPClientTransport(new URL("https://mcp.example.test"), {
     fetch,
   });
+
   const transport = instrumentMcpTransport(rawTransport);
   transport.onerror = () => undefined;
   await transport.start();
@@ -836,6 +918,7 @@ test("parents inbound work to remote context and links a distinct ambient span",
       result: {},
     } as never);
   };
+
   const remoteTraceId = "0af7651916cd43dd8448eb211c80319c";
   const remoteSpanId = "b7ad6b7169203331";
 
@@ -859,9 +942,11 @@ test("parents inbound work to remote context and links a distinct ambient span",
 
 test("parents unpropagated inbound work to the ambient context", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (_message: unknown) => undefined,
   });
+
   transport.onmessage = (message: unknown) => {
     void transport.send({
       jsonrpc: "2.0",
@@ -917,9 +1002,11 @@ test("does not instrument null ids outside the MCP v2 RequestId contract", async
 
 test("closes pending spans even when no onclose handler was assigned", async () => {
   const spans = setup();
+
   const transport = instrumentMcpTransport<TestTransport>({
     send: async (_message: unknown) => undefined,
   });
+
   await transport.send({ jsonrpc: "2.0", id: 51, method: "ping" } as never);
   transport.onclose?.();
 

--- a/packages/omp/src/extension.ts
+++ b/packages/omp/src/extension.ts
@@ -51,31 +51,40 @@ type JsonValue =
   | undefined
   | JsonValue[]
   | { [key: string]: JsonValue };
+
 type Attrs = { [key: string]: JsonValue };
+
 type JsonRecord = { [key: string]: JsonValue };
 
 function asRecord(value: JsonValue): JsonRecord | undefined {
   if (value === null || Array.isArray(value) || !(value instanceof Object)) return undefined;
+
   return value as JsonRecord;
 }
 
 function stringField(record: JsonRecord | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   if (value === undefined || value === null || value.constructor !== String || value === "")
     return undefined;
+
   return value as string;
 }
 
 function numberField(record: JsonRecord | undefined, key: string): number | undefined {
   const value = record?.[key];
+
   if (value === undefined || value === null || value.constructor !== Number) return undefined;
   const number = value as number;
+
   return Number.isFinite(number) ? number : undefined;
 }
 
 function booleanField(record: JsonRecord | undefined, key: string): boolean | undefined {
   const value = record?.[key];
+
   if (value === undefined || value === null || value.constructor !== Boolean) return undefined;
+
   return value as boolean;
 }
 
@@ -89,6 +98,7 @@ function reportError(onError: ((error: Error) => void) | undefined, cause: unkno
 
 function sessionId(ctx: TelemetryDevExtensionContext): string | undefined {
   const id = ctx.sessionManager.getSessionId();
+
   return id && id.length > 0 ? id : undefined;
 }
 
@@ -96,9 +106,11 @@ function sessionId(ctx: TelemetryDevExtensionContext): string | undefined {
 function textContent(content: JsonValue): string | undefined {
   if (!Array.isArray(content)) return undefined;
   const parts: string[] = [];
+
   for (const block of content) {
     const record = asRecord(block);
     const text = record?.text;
+
     if (
       record?.type === "text" &&
       text !== undefined &&
@@ -108,12 +120,15 @@ function textContent(content: JsonValue): string | undefined {
       parts.push(text as string);
     }
   }
+
   return parts.length > 0 ? parts.join("\n") : undefined;
 }
 
 function usageFields(message: JsonRecord): TokenUsage | undefined {
   const usage = asRecord(message.usage);
+
   if (!usage) return undefined;
+
   return {
     inputTokens: numberField(usage, "input"),
     outputTokens: numberField(usage, "output"),
@@ -126,7 +141,9 @@ function usageFields(message: JsonRecord): TokenUsage | undefined {
 
 function assistantMessageKey(message: JsonRecord): string | undefined {
   const timestamp = numberField(message, "timestamp");
+
   if (timestamp === undefined) return undefined;
+
   return JSON.stringify([
     timestamp,
     stringField(message, "provider") ?? "",
@@ -140,6 +157,7 @@ function assistantMessageKey(message: JsonRecord): string | undefined {
 function failureError(name: string, message: string | undefined): Error {
   const error = new Error(message ?? name);
   error.name = name;
+
   return error;
 }
 
@@ -175,6 +193,7 @@ export function telemetryDevExtension(
         event: string,
         handler: (event: E, ctx: TelemetryDevExtensionContext) => void | Promise<void>,
       ) => void;
+
       registerEvent(event, handler);
     }
 
@@ -205,6 +224,7 @@ export function telemetryDevExtension(
 
     function spanAttributes(ctx: TelemetryDevExtensionContext): Record<string, string> {
       const id = sessionId(ctx);
+
       return id ? { "gen_ai.conversation.id": id } : {};
     }
 
@@ -212,6 +232,7 @@ export function telemetryDevExtension(
       for (const span of toolSpans.values()) {
         span.end({ error: failureError("incomplete", "tool execution did not complete") });
       }
+
       toolSpans.clear();
       chatSpanByToolCall.clear();
     }
@@ -232,6 +253,7 @@ export function telemetryDevExtension(
           return handler(payload, ctx);
         } catch (error) {
           reportError(onError, error);
+
           return undefined;
         }
       });
@@ -255,10 +277,12 @@ export function telemetryDevExtension(
           // Keep the original prompt span open until the terminal agent_end.
           return;
         }
+
         // A fresh prompt while a previous loop never emitted agent_end: close
         // the dangling span instead of silently merging two prompts into it.
         endAgentSpan({ finishReason: "incomplete" });
       }
+
       agentSpan = startSpan("invoke_agent", {
         type: "agent",
         agentName,
@@ -270,26 +294,35 @@ export function telemetryDevExtension(
 
     on("agent_end", (event: { messages: JsonValue[]; willContinue?: boolean }, _ctx) => {
       if (!agentSpan) return;
+
       if (event.willContinue === true) {
         // The host scheduled another loop for this prompt (auto-retry,
         // compaction, or a queued continuation); this agent_end is not
         // terminal, so keep the prompt span open.
         void flush();
+
         return;
       }
+
       const messages = Array.isArray(event.messages) ? event.messages : [];
       let lastAssistant: JsonRecord | undefined;
+
       for (const message of messages) {
         const record = asRecord(message);
+
         if (record?.role === "assistant") lastAssistant = record;
       }
+
       if (lastAssistant) {
         const eventMessageKey = assistantMessageKey(lastAssistant);
+
         if (eventMessageKey === undefined || eventMessageKey !== agentMessageKey) {
           void flush();
+
           return;
         }
       }
+
       const stopReason = stringField(lastAssistant, "stopReason");
       const errorMessage = stringField(lastAssistant, "errorMessage");
       endAgentSpan({
@@ -302,13 +335,16 @@ export function telemetryDevExtension(
 
     on("message_end", (event: { message: JsonValue }, ctx) => {
       const message = asRecord(event.message);
+
       if (message?.role !== "assistant") return;
+
       if (agentSpan) agentMessageKey = assistantMessageKey(message);
       const model = stringField(message, "model");
       const startTime = numberField(message, "timestamp");
       const duration = numberField(message, "duration");
       const errorMessage = stringField(message, "errorMessage");
       const stopReason = stringField(message, "stopReason");
+
       const span = startSpan(model ? `chat ${model}` : "chat", {
         type: "generation",
         parent: agentSpan,
@@ -323,13 +359,16 @@ export function telemetryDevExtension(
         error: stopReason === "error" ? failureError(stopReason, errorMessage) : undefined,
         attributes: spanAttributes(ctx),
       });
+
       for (const block of Array.isArray(message.content) ? message.content : []) {
         const record = asRecord(block);
         const id = stringField(record, "id");
+
         if (record?.type === "toolCall" && id !== undefined) {
           chatSpanByToolCall.set(id, span);
         }
       }
+
       span.end({
         endTime:
           startTime !== undefined && duration !== undefined ? startTime + duration : undefined,
@@ -347,6 +386,7 @@ export function telemetryDevExtension(
           input: event.args,
           attributes: spanAttributes(ctx),
         });
+
         chatSpanByToolCall.delete(event.toolCallId);
         toolSpans.set(event.toolCallId, span);
       },
@@ -359,6 +399,7 @@ export function telemetryDevExtension(
         _ctx,
       ) => {
         const span = toolSpans.get(event.toolCallId);
+
         if (!span) return;
         toolSpans.delete(event.toolCallId);
         const resultText = textContent(asRecord(event.result)?.content);

--- a/packages/omp/src/index.ts
+++ b/packages/omp/src/index.ts
@@ -1,4 +1,5 @@
 export type { TelemetryDevOmpOptions } from "./config.ts";
+
 export {
   telemetryDevExtension,
   type TelemetryDevExtension,

--- a/packages/omp/tests/omp.test.ts
+++ b/packages/omp/tests/omp.test.ts
@@ -16,6 +16,7 @@ interface Exporters extends ClientOverrides {
 function makeExporters(): Exporters {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
+
   return { logRecordExporter: logs, logs, spanExporter: spans, spans };
 }
 
@@ -23,6 +24,7 @@ function telemetryOptions(options?: TelemetryDevExtensionOptions): TelemetryDevE
   const fetch = Object.assign(async () => new Response(null, { status: 200 }), {
     preconnect: () => undefined,
   });
+
   return {
     environment: "test",
     exportMode: "immediate" as const,
@@ -68,10 +70,12 @@ function makeContext(sessionId = "session-1"): ExtensionContext {
 
 function makeHarness(options?: TelemetryDevExtensionOptions): Harness {
   const exporters = makeExporters();
+
   const handlers = new Map<
     string,
     ((event: TestEvent, ctx: ExtensionContext) => void | Promise<void>)[]
   >();
+
   const api = {
     on(type: string, handler: (event: TestEvent, ctx: ExtensionContext) => void | Promise<void>) {
       const list = handlers.get(type) ?? [];
@@ -84,11 +88,13 @@ function makeHarness(options?: TelemetryDevExtensionOptions): Harness {
   factory(api as never);
 
   const defaultCtx = makeContext();
+
   const emit: EmitFn = async (event, ctx = defaultCtx) => {
     for (const handler of handlers.get(event.type) ?? []) {
       await handler(event, ctx);
     }
   };
+
   return { emit, exporters };
 }
 
@@ -127,6 +133,7 @@ async function runAgentLoop(harness: Harness, message = assistantMessage()): Pro
 function spanByName(exporters: Exporters, name: string): ReadableSpan {
   const span = exporters.spans.getFinishedSpans().find((candidate) => candidate.name === name);
   expect(span, `expected span ${name}`).toBeDefined();
+
   return span as ReadableSpan;
 }
 
@@ -151,6 +158,7 @@ test("willContinue agent_end keeps one invoke_agent span until the terminal agen
   const agents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(agents).toHaveLength(1);
   const agent = agents[0] as ReadableSpan;
   expect(agent.status.code).not.toBe(SpanStatusCode.ERROR);
@@ -179,6 +187,7 @@ test("continuation agent_start arriving before its willContinue agent_end keeps 
   const agents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(agents).toHaveLength(1);
   const agent = agents[0] as ReadableSpan;
   expect(agent.attributes["gen_ai.input.messages"]).toBe("fix the bug");
@@ -200,6 +209,7 @@ test("a fresh prompt after a missing agent_end closes the dangling span instead 
   const agents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(agents).toHaveLength(2);
   const [dangling, fresh] = agents as [ReadableSpan, ReadableSpan];
   expect(dangling.attributes["gen_ai.input.messages"]).toBe("first prompt");
@@ -210,10 +220,12 @@ test("a fresh prompt after a missing agent_end closes the dangling span instead 
 
 test("a delayed terminal agent_end does not close or clear the fresh prompt span", async () => {
   const harness = makeHarness();
+
   const oldMessage = assistantMessage({
     content: [{ type: "text", text: "Old output." }],
     responseId: "resp-old",
   });
+
   await harness.emit({ type: "before_agent_start", prompt: "first prompt" });
   await harness.emit({ type: "agent_start" });
   await harness.emit({ type: "message_end", message: oldMessage });
@@ -235,6 +247,7 @@ test("a delayed terminal agent_end does not close or clear the fresh prompt span
   const endedAgents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(endedAgents).toHaveLength(1);
   expect(endedAgents[0]?.attributes["gen_ai.input.messages"]).toBe("first prompt");
   expect(endedAgents[0]?.attributes["gen_ai.response.finish_reasons"]).toEqual(["incomplete"]);
@@ -246,10 +259,12 @@ test("a delayed terminal agent_end does not close or clear the fresh prompt span
     result: { content: [{ type: "text", text: "/tmp/project" }] },
     isError: false,
   });
+
   const freshMessage = assistantMessage({
     content: [{ type: "text", text: "Fresh output." }],
     responseId: "resp-fresh",
   });
+
   await harness.emit({ type: "message_end", message: freshMessage });
   await harness.emit({ type: "agent_end", messages: [freshMessage] });
   await flush();
@@ -257,6 +272,7 @@ test("a delayed terminal agent_end does not close or clear the fresh prompt span
   const agents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(agents).toHaveLength(2);
   const fresh = agents.find((span) => span.attributes["gen_ai.input.messages"] === "second prompt");
   expect(fresh?.attributes["gen_ai.output.messages"]).toBe("Fresh output.");
@@ -268,10 +284,12 @@ test("a delayed terminal agent_end does not close or clear the fresh prompt span
 test("agent_end closes the span when message_end receives a copied message", async () => {
   const harness = makeHarness();
   const original = assistantMessage();
+
   const displayed = {
     ...original,
     content: [{ type: "text", text: "All done." }],
   };
+
   await harness.emit({ type: "before_agent_start", prompt: "fix the bug" });
   await harness.emit({ type: "agent_start" });
   await harness.emit({ type: "message_end", message: displayed });
@@ -487,12 +505,14 @@ test("auto retry and compaction events are logged with severities", async () => 
 test("malformed events never throw and report through onError", async () => {
   const errors: unknown[] = [];
   const harness = makeHarness({ onError: (error) => errors.push(error) });
+
   const poisoned = {
     type: "message_end",
     get message(): never {
       throw new Error("poisoned event");
     },
   };
+
   await expect(harness.emit(poisoned as never)).resolves.toBeUndefined();
   expect(errors).toHaveLength(1);
 

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -446,10 +446,29 @@ function chatPartialFields(
 
 function recordChatChunk<T>(chunk: T, states: Map<number, ChatChoiceState>) {
   const c = asRecord(chunk) ?? {};
+  let hasOutput = false;
+
   for (const choice of asArray(c.choices) ?? []) {
     const choiceRecord = asRecord(choice) ?? {};
     const state = getChoiceState(states, readNumber(choiceRecord.index) ?? 0);
     const delta = asRecord(choiceRecord.delta) ?? {};
+    const audio = asRecord(delta.audio);
+    const legacyFunction = asRecord(delta.function_call);
+
+    if (
+      (typeof delta.content === "string" && delta.content.length > 0) ||
+      (typeof delta.refusal === "string" && delta.refusal.length > 0) ||
+      (typeof audio?.data === "string" && audio.data.length > 0) ||
+      (typeof legacyFunction?.arguments === "string" && legacyFunction.arguments.length > 0) ||
+      (asArray(delta.tool_calls) ?? []).some((toolCall) => {
+        const fn = asRecord(asRecord(toolCall)?.function);
+
+        return typeof fn?.arguments === "string" && fn.arguments.length > 0;
+      })
+    ) {
+      hasOutput = true;
+    }
+
     if (String(delta.role) === delta.role) state.role = delta.role;
     if (String(delta.content) === delta.content) state.content += delta.content;
     if (String(delta.refusal) === delta.refusal) state.refusal += delta.refusal;
@@ -464,6 +483,7 @@ function recordChatChunk<T>(chunk: T, states: Map<number, ChatChoiceState>) {
     responseId: readString(c.id),
     responseModel: readString(c.model),
     usage: chatUsage(c.usage),
+    hasOutput,
   };
 }
 
@@ -486,7 +506,11 @@ function createObservedChatStream(
     let terminalError: Error | undefined;
     try {
       for await (const chunk of source) {
+        const receivedAt = performance.now();
         const update = recordChatChunk(chunk, states);
+
+        if (update.hasOutput) span.recordOutputChunk?.(receivedAt);
+
         if (!sawFirst) {
           sawFirst = true;
           span.update({
@@ -522,7 +546,10 @@ function createObservedResponsesStream(
     let terminalError: Error | undefined;
     try {
       for await (const event of source) {
+        const receivedAt = performance.now();
         const e = asRecord(event) ?? {};
+
+        if (responseEventHasOutput(e)) span.recordOutputChunk?.(receivedAt);
         const response = asRecord(e.response);
         if (!sawFirst) {
           sawFirst = true;
@@ -549,6 +576,27 @@ function createObservedResponsesStream(
     }
   }
   return new Stream(() => iterator(), source.controller);
+}
+
+function responseEventHasOutput(event: JsonRecord): boolean {
+  return (
+    typeof event.type === "string" &&
+    [
+      "response.output_text.delta",
+      "response.refusal.delta",
+      "response.reasoning_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.function_call_arguments.delta",
+      "response.custom_tool_call_input.delta",
+      "response.code_interpreter_call_code.delta",
+      "response.mcp_call_arguments.delta",
+      "response.output_audio.delta",
+      "response.audio.delta",
+      "response.audio.transcript.delta",
+    ].includes(event.type) &&
+    typeof event.delta === "string" &&
+    event.delta.length > 0
+  );
 }
 
 function wrapStream<T>(

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -21,12 +21,16 @@ type JsonValue =
   | null
   | JsonValue[]
   | { [key: string]: JsonValue | undefined };
+
 type JsonRecord = { [key: string]: JsonValue | undefined };
+
 type WrappedFunction = ((...args: never[]) => JsonValue | Promise<JsonValue>) & {
   [WRAPPED]?: true;
   [ORIGINAL]?: (...args: never[]) => JsonValue | Promise<JsonValue>;
 };
+
 type ProviderResolver = <T>(resource: T) => string;
+
 type Operation = "chat" | "responses" | "embeddings";
 
 interface OpenAIClient {
@@ -68,18 +72,22 @@ function asError<T>(cause: T): Error {
 
 function compactUsage(usage: SpanFields["usage"]): SpanFields["usage"] {
   if (!usage) return undefined;
+
   return Object.values(usage).some((value) => value !== undefined) ? usage : undefined;
 }
 
 function stopSequences<T>(value: T): string[] | undefined {
   if (String(value) === value) return [String(value)];
+
   if (!Array.isArray(value)) return undefined;
   const strings = value.filter((item): item is string => String(item) === item);
+
   return strings.length > 0 ? strings : undefined;
 }
 
 function chatRequest(body: JsonRecord): RequestMapping {
   const model = readString(body.model);
+
   return {
     name: `chat ${model ?? "unknown"}`,
     fields: {
@@ -101,6 +109,7 @@ function chatUsage<T>(usage: T): SpanFields["usage"] {
   const u = asRecord(usage);
   const promptDetails = asRecord(u?.prompt_tokens_details);
   const completionDetails = asRecord(u?.completion_tokens_details);
+
   return compactUsage({
     inputTokens: readNumber(u?.prompt_tokens),
     outputTokens: readNumber(u?.completion_tokens),
@@ -113,9 +122,11 @@ function chatUsage<T>(usage: T): SpanFields["usage"] {
 function chatResponse<T>(response: T): SpanFields {
   const r = asRecord(response) ?? {};
   const choices = asArray(r.choices) ?? [];
+
   const finishReasons = choices
     .map((choice) => readString(asRecord(choice)?.finish_reason))
     .filter((reason): reason is string => reason !== undefined);
+
   const fields: SpanFields = {
     responseModel: readString(r.model),
     responseId: readString(r.id),
@@ -125,14 +136,17 @@ function chatResponse<T>(response: T): SpanFields {
       .filter((message) => message !== undefined),
     usage: chatUsage(r.usage),
   };
+
   if (finishReasons.length > 1) {
     fields.attributes = { "gen_ai.response.finish_reasons": finishReasons };
   }
+
   return fields;
 }
 
 function responsesRequest(body: JsonRecord): RequestMapping {
   const model = readString(body.model);
+
   return {
     name: `chat ${model ?? "unknown"}`,
     fields: {
@@ -151,6 +165,7 @@ function responsesUsage<T>(usage: T): SpanFields["usage"] {
   const u = asRecord(usage);
   const inputDetails = asRecord(u?.input_tokens_details);
   const outputDetails = asRecord(u?.output_tokens_details);
+
   return compactUsage({
     inputTokens: readNumber(u?.input_tokens),
     outputTokens: readNumber(u?.output_tokens),
@@ -164,6 +179,7 @@ function responsesResponse<T>(response: T): SpanFields {
   const r = asRecord(response) ?? {};
   const status = readString(r.status);
   const incompleteDetails = asRecord(r.incomplete_details);
+
   const fields: SpanFields = {
     responseModel: readString(r.model),
     responseId: readString(r.id),
@@ -172,13 +188,17 @@ function responsesResponse<T>(response: T): SpanFields {
     finishReason:
       status === "completed" ? "stop" : (readString(incompleteDetails?.reason) ?? status),
   };
+
   if (status === "failed") fields.error = responseFailedError(response);
+
   return fields;
 }
+
 function responseFailedError<T>(response: T): Error {
   const error = asRecord(asRecord(response)?.error);
   const code = readString(error?.code);
   const message = readString(error?.message);
+
   return new Error(["response.failed", code, message].filter(Boolean).join(": "));
 }
 
@@ -186,11 +206,13 @@ function responseStreamError<T>(event: T): Error {
   const e = asRecord(event);
   const code = readString(e?.code);
   const message = readString(e?.message);
+
   return new Error(["response.error", code, message].filter(Boolean).join(": "));
 }
 
 function embeddingsRequest(body: JsonRecord): RequestMapping {
   const model = readString(body.model);
+
   return {
     name: `embeddings ${model ?? "unknown"}`,
     fields: {
@@ -204,6 +226,7 @@ function embeddingsRequest(body: JsonRecord): RequestMapping {
 function embeddingsResponse<T>(response: T): SpanFields {
   const r = asRecord(response) ?? {};
   const usage = asRecord(r.usage);
+
   return {
     responseModel: readString(r.model),
     usage: compactUsage({
@@ -215,7 +238,9 @@ function embeddingsResponse<T>(response: T): SpanFields {
 
 function baseURLHost<T>(baseURL: T): string | undefined {
   const url = readString(baseURL);
+
   if (url === undefined) return undefined;
+
   try {
     return new URL(url).hostname;
   } catch {
@@ -226,12 +251,15 @@ function baseURLHost<T>(baseURL: T): string | undefined {
 function providerForClient<T>(client: T): string {
   if (client instanceof AzureOpenAI) return "azure.ai.openai";
   const host = baseURLHost(asRecord(client)?.baseURL)?.replace(/\.$/, "");
+
   if (host === "openrouter.ai" || host?.endsWith(".openrouter.ai")) return "openrouter";
+
   return "openai";
 }
 
 function providerForResource<T>(resource: T): string {
   const client = asRecord(resource)?._client;
+
   return providerForClient(client);
 }
 
@@ -245,11 +273,13 @@ function markWrapped<T extends WrappedFunction>(
 ): T {
   Object.defineProperty(fn, WRAPPED, { value: true });
   Object.defineProperty(fn, ORIGINAL, { value: original });
+
   return fn;
 }
 
 function endOnce(span: SpanHandle): (fields?: SpanFields) => void {
   let ended = false;
+
   return (fields?: SpanFields) => {
     if (ended) return;
     ended = true;
@@ -283,10 +313,13 @@ type InnerAPIPromise<T = JsonValue> = Promise<T> & {
 
 function mapRawResponse(response: Response): SpanFields {
   const requestId = response.headers.get("x-request-id");
+
   const fields: SpanFields = {
     attributes: { "http.response.status_code": response.status },
   };
+
   if (requestId) fields.responseId = requestId;
+
   return fields;
 }
 
@@ -294,7 +327,9 @@ function finalizeParsedValue<T>(value: T, ctx: TracePromiseContext): T | Stream<
   if (ctx.streaming) {
     return wrapStream(value, ctx.operation, ctx.span, ctx.startedAt, ctx.injectedUsage);
   }
+
   ctx.end(ctx.mapResponse(value));
+
   return value;
 }
 
@@ -307,42 +342,54 @@ function makeTracedPromise<T>(
   ctx: TracePromiseContext,
 ): TracedResult<T> {
   const source = inner;
+
   const handleError = <TError>(cause: TError): never => {
     ctx.end({ error: asError(cause) });
     throw cause;
   };
+
   const onParsed = (value: T) => {
     return finalizeParsedValue(value, ctx) as T;
   };
+
   const parsed = () =>
     (source.parse ? source.parse() : source.then((value) => value)).then(onParsed, handleError);
+
   return new Proxy(source, {
     get(target, property) {
       if (property === "parse") return parsed;
+
       if (property === "then") {
         return (
           onfulfilled: Parameters<Promise<T>["then"]>[0],
           onrejected: Parameters<Promise<T>["then"]>[1],
         ) => parsed().then(onfulfilled, onrejected);
       }
+
       if (property === "catch") {
         return (onrejected: Parameters<Promise<T>["catch"]>[0]) => parsed().catch(onrejected);
       }
+
       if (property === "finally") {
         return (onfinally: Parameters<Promise<T>["finally"]>[0]) => parsed().finally(onfinally);
       }
+
       if (property === "asResponse") {
         return () => {
           if (!target.asResponse) return rejectMissing("asResponse");
+
           return target.asResponse().then((response) => {
             ctx.end(mapRawResponse(response));
+
             return response;
           }, handleError);
         };
       }
+
       if (property === "withResponse") {
         return () => {
           if (!target.withResponse) return rejectMissing("withResponse");
+
           return target.withResponse().then(
             ({ data, response, request_id }) => ({
               data: finalizeParsedValue(data, ctx) as T,
@@ -353,6 +400,7 @@ function makeTracedPromise<T>(
           );
         };
       }
+
       if (property === "_thenUnwrap") {
         return <U>(transform: (data: T, ...args: never[]) => U): TracedResult<U> => {
           if (!target._thenUnwrap) {
@@ -360,12 +408,16 @@ function makeTracedPromise<T>(
               Promise.reject(new TypeError("wrapped result has no _thenUnwrap")),
               ctx,
             );
+
             return missing;
           }
+
           return makeTracedPromise(target._thenUnwrap(transform), ctx);
         };
       }
+
       const value = target[property as keyof InnerAPIPromise<T>];
+
       return value instanceof Function ? value.bind(target) : value;
     },
   }) as TracedResult<T>;
@@ -381,29 +433,38 @@ interface ChatChoiceState {
 
 function getChoiceState(states: Map<number, ChatChoiceState>, index: number): ChatChoiceState {
   let state = states.get(index);
+
   if (!state) {
     state = { content: "", refusal: "", toolCalls: new Map() };
     states.set(index, state);
   }
+
   return state;
 }
 
 function mergeToolCall(state: ChatChoiceState, delta: JsonRecord): void {
   const index = readNumber(delta.index) ?? state.toolCalls.size;
   const current = { ...state.toolCalls.get(index) };
+
   if (delta.id !== undefined) current.id = delta.id;
+
   if (delta.type !== undefined) current.type = delta.type;
   const incomingFunction = asRecord(delta.function);
+
   if (incomingFunction) {
     const currentFunction = { ...asRecord(current.function) };
+
     if (incomingFunction.name !== undefined) currentFunction.name = incomingFunction.name;
+
     if (incomingFunction.arguments !== undefined) {
       currentFunction.arguments = `${readString(currentFunction.arguments) ?? ""}${
         readString(incomingFunction.arguments) ?? ""
       }`;
     }
+
     current.function = currentFunction;
   }
+
   state.toolCalls.set(index, current);
 }
 
@@ -413,14 +474,18 @@ function chatOutput(states: Map<number, ChatChoiceState>): JsonRecord[] {
     .map(([, state]) => {
       const message = { role: state.role ?? "assistant" };
       const fields = Object.assign(message, {} as JsonRecord);
+
       if (state.content.length > 0) fields.content = state.content;
       else if (state.toolCalls.size > 0) fields.content = null;
+
       if (state.refusal.length > 0) fields.refusal = state.refusal;
+
       if (state.toolCalls.size > 0) {
         fields.tool_calls = [...state.toolCalls.entries()]
           .sort(([left], [right]) => left - right)
           .map(([, toolCall]) => toolCall);
       }
+
       return fields;
     });
 }
@@ -433,14 +498,17 @@ function chatPartialFields(
     .sort(([left], [right]) => left - right)
     .map(([, state]) => state.finishReason)
     .filter((reason): reason is string => reason !== undefined);
+
   const fields: SpanFields = {
     output: states.size > 0 ? chatOutput(states) : undefined,
     usage,
     finishReason: finishReasons[0],
   };
+
   if (finishReasons.length > 1) {
     fields.attributes = { "gen_ai.response.finish_reasons": finishReasons };
   }
+
   return fields;
 }
 
@@ -469,16 +537,23 @@ function recordChatChunk<T>(chunk: T, states: Map<number, ChatChoiceState>) {
       hasOutput = true;
     }
 
-    if (String(delta.role) === delta.role) state.role = delta.role;
-    if (String(delta.content) === delta.content) state.content += delta.content;
-    if (String(delta.refusal) === delta.refusal) state.refusal += delta.refusal;
+    if (typeof delta.role === "string") state.role = delta.role;
+
+    if (typeof delta.content === "string") state.content += delta.content;
+
+    if (typeof delta.refusal === "string") state.refusal += delta.refusal;
+
     for (const toolCall of asArray(delta.tool_calls) ?? []) {
       const toolCallRecord = asRecord(toolCall);
+
       if (toolCallRecord) mergeToolCall(state, toolCallRecord);
     }
+
     const finishReason = readString(choiceRecord.finish_reason);
+
     if (finishReason) state.finishReason = finishReason;
   }
+
   return {
     responseId: readString(c.id),
     responseModel: readString(c.model),
@@ -489,6 +564,7 @@ function recordChatChunk<T>(chunk: T, states: Map<number, ChatChoiceState>) {
 
 function isSyntheticUsageChunk<T>(chunk: T): boolean {
   const c = asRecord(chunk);
+
   return !!c?.usage && (asArray(c.choices)?.length ?? 0) === 0;
 }
 
@@ -504,6 +580,7 @@ function createObservedChatStream(
     let usage: SpanFields["usage"];
     let sawFirst = false;
     let terminalError: Error | undefined;
+
     try {
       for await (const chunk of source) {
         const receivedAt = performance.now();
@@ -519,7 +596,9 @@ function createObservedChatStream(
             responseModel: update.responseModel,
           });
         }
+
         if (update.usage) usage = update.usage;
+
         if (!hideSyntheticUsage || !isSyntheticUsageChunk(chunk)) yield chunk;
       }
     } catch (error) {
@@ -527,10 +606,12 @@ function createObservedChatStream(
       throw error;
     } finally {
       const fields = chatPartialFields(states, usage);
+
       if (terminalError) fields.error = terminalError;
       end(fields);
     }
   }
+
   return new Stream(() => iterator(), source.controller);
 }
 
@@ -544,6 +625,7 @@ function createObservedResponsesStream(
     let sawFirst = false;
     let partial: SpanFields = {};
     let terminalError: Error | undefined;
+
     try {
       for await (const event of source) {
         const receivedAt = performance.now();
@@ -551,11 +633,14 @@ function createObservedResponsesStream(
 
         if (responseEventHasOutput(e)) span.recordOutputChunk?.(receivedAt);
         const response = asRecord(e.response);
+
         if (!sawFirst) {
           sawFirst = true;
           span.update({ timeToFirstChunkMs: Date.now() - startedAt });
         }
+
         if (response) partial = responsesResponse(response);
+
         if (e.type === "response.failed") {
           partial = { ...partial, error: responseFailedError(response) };
           end(partial);
@@ -565,6 +650,7 @@ function createObservedResponsesStream(
         } else if (e.type === "response.completed" || e.type === "response.incomplete") {
           end(partial);
         }
+
         yield event;
       }
     } catch (error) {
@@ -575,6 +661,7 @@ function createObservedResponsesStream(
       end(partial);
     }
   }
+
   return new Stream(() => iterator(), source.controller);
 }
 
@@ -609,15 +696,19 @@ function wrapStream<T>(
   if (!(value instanceof Stream)) return value;
   const end = endOnce(span);
   const source = value as Stream<JsonValue>;
+
   if (operation === "chat") {
     return createObservedChatStream(source, span, startedAt, end, injectedUsage);
   }
+
   return createObservedResponsesStream(source, span, startedAt, end);
 }
 
 function withChatUsageInjection(body: JsonRecord) {
   const options = asRecord(body.stream_options);
+
   if (options?.include_usage === true) return { body, injected: false };
+
   return {
     body: {
       ...body,
@@ -636,13 +727,16 @@ function wrapCreate<Fn extends (...args: never[]) => JsonValue | Promise<JsonVal
   injectUsage: boolean,
 ): Fn {
   if (isWrapped(original)) return original;
+
   const wrapped = function <This>(this: This, ...args: JsonValue[]) {
     const originalBody = asRecord(args[0]) ?? {};
     const streaming = originalBody.stream === true;
+
     const { body, injected } =
       operation === "chat" && streaming && injectUsage
         ? withChatUsageInjection(originalBody)
         : { body: originalBody, injected: false };
+
     const callArgs = body === originalBody ? args : [body, ...args.slice(1)];
     const request = mapRequest(body);
     const span = startSpan(request.name, { ...request.fields, provider: provider(this) });
@@ -652,6 +746,7 @@ function wrapCreate<Fn extends (...args: never[]) => JsonValue | Promise<JsonVal
     try {
       const result = original.apply(this, callArgs as never[]);
       const promise = result instanceof Promise ? result : Promise.resolve(result);
+
       return makeTracedPromise(promise, {
         end,
         span,
@@ -666,9 +761,12 @@ function wrapCreate<Fn extends (...args: never[]) => JsonValue | Promise<JsonVal
       throw cause;
     }
   };
+
   const marked = markWrapped(wrapped as WrappedFunction, original);
+
   return marked as Fn;
 }
+
 function responseRetrieveRequest<T>(responseId: T): RequestMapping {
   return {
     name: "chat unknown",
@@ -684,10 +782,12 @@ function wrapResponseRetrieve<Fn extends (...args: never[]) => JsonValue | Promi
   provider: ProviderResolver,
 ): Fn {
   if (isWrapped(original)) return original;
+
   const wrapped = function <This>(this: This, ...args: JsonValue[]) {
     const query = asRecord(args[1]);
     const options = asRecord(args[2]);
     const streaming = query?.stream === true || options?.stream === true;
+
     if (!streaming) {
       return original.apply(this, args as never[]);
     }
@@ -700,6 +800,7 @@ function wrapResponseRetrieve<Fn extends (...args: never[]) => JsonValue | Promi
     try {
       const result = original.apply(this, args as never[]);
       const promise = result instanceof Promise ? result : Promise.resolve(result);
+
       return makeTracedPromise(promise, {
         end,
         span,
@@ -714,6 +815,7 @@ function wrapResponseRetrieve<Fn extends (...args: never[]) => JsonValue | Promi
       throw cause;
     }
   };
+
   return markWrapped(wrapped as WrappedFunction, original) as Fn;
 }
 
@@ -726,14 +828,17 @@ function patchInstanceMethod<T extends JsonRecord>(
   injectUsage: boolean,
 ): void {
   const current = target[key];
+
   // An own wrapper means this instance is already instrumented. A wrapper
   // inherited from instrumentOpenAI()'s prototype patch must still be shadowed
   // by an own wrapper over the underlying original, so this client stays
   // instrumented after uninstrumentOpenAI() restores the prototype.
   if (isWrapped(current) && Object.prototype.hasOwnProperty.call(target, key)) return;
   const original = isWrapped(current) ? current[ORIGINAL] : current;
+
   if (!(original instanceof Function)) return;
   const bound: (...args: never[]) => JsonValue | Promise<JsonValue> = original.bind(target);
+
   const wrapped = wrapCreate(
     bound,
     operation,
@@ -742,12 +847,16 @@ function patchInstanceMethod<T extends JsonRecord>(
     () => providerForResource(target),
     injectUsage,
   );
+
   Object.assign(target, { [key]: wrapped });
 }
+
 function patchResponseRetrieveInstance(target: JsonRecord & { retrieve?: WrappedFunction }): void {
   const current = target["retrieve"];
+
   if (isWrapped(current) && Object.prototype.hasOwnProperty.call(target, "retrieve")) return;
   const original = isWrapped(current) ? current[ORIGINAL] : current;
+
   if (!(original instanceof Function)) return;
   target["retrieve"] = wrapResponseRetrieve(
     original.bind(target) as (...args: never[]) => JsonValue,
@@ -759,8 +868,11 @@ function patchResponseRetrievePrototype(): () => void {
   const rawPrototype: unknown = Responses.prototype;
   const prototype = rawPrototype as JsonRecord & { retrieve?: WrappedFunction };
   const original = prototype.retrieve;
+
   if (!(original instanceof Function)) return () => {};
+
   prototype.retrieve = wrapResponseRetrieve(original, providerForResource);
+
   return () => {
     prototype.retrieve = original;
   };
@@ -776,7 +888,9 @@ function patchPrototype(
 ): () => void {
   const prototype = klass.prototype as JsonRecord & { [key: string]: WrappedFunction | undefined };
   const original = prototype[key];
+
   if (!(original instanceof Function)) return () => {};
+
   prototype[key] = wrapCreate(
     original,
     operation,
@@ -785,6 +899,7 @@ function patchPrototype(
     providerForResource,
     injectUsage,
   );
+
   return () => {
     prototype[key] = original;
   };
@@ -812,10 +927,12 @@ export function wrapOpenAI<T extends OpenAIClient>(
   const rawCompletions: unknown = client.chat.completions;
   const completions = rawCompletions as JsonRecord & { create?: WrappedFunction };
   const rawResponses: unknown = client.responses;
+
   const responses = rawResponses as JsonRecord & {
     create?: WrappedFunction;
     retrieve?: WrappedFunction;
   };
+
   const rawEmbeddings: unknown = client.embeddings;
   const embeddings = rawEmbeddings as JsonRecord & { create?: WrappedFunction };
   patchInstanceMethod(completions, "create", "chat", chatRequest, chatResponse, injectUsage);
@@ -837,6 +954,7 @@ export function wrapOpenAI<T extends OpenAIClient>(
     injectUsage,
   );
   wrappedClients.add(client);
+
   return client;
 }
 
@@ -868,6 +986,7 @@ export function instrumentOpenAI(options?: InstrumentOpenAIOptions): void {
 
 export function uninstrumentOpenAI(): void {
   if (!installed) return;
+
   for (const restore of restorePatches.reverse()) restore();
   restorePatches = [];
   installed = false;

--- a/packages/openai/tests/openai.test.ts
+++ b/packages/openai/tests/openai.test.ts
@@ -1,7 +1,14 @@
 import { InMemorySpanExporter, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  type PushMetricExporter,
+} from "@opentelemetry/sdk-metrics";
 import { flush, init, shutdown } from "@telemetry-dev/sdk";
+import * as sdk from "@telemetry-dev/sdk";
 import OpenAI, { AzureOpenAI } from "openai";
-import { afterEach, expect, test } from "vitest";
+import { Stream } from "openai/core/streaming";
+import { afterEach, expect, test, vi } from "vitest";
 
 import {
   instrumentOpenAI,
@@ -127,7 +134,7 @@ function createFakeFetch(...responses: Response[]): FakeFetch {
   return { fetch: fetchImpl, requests };
 }
 
-function setupSpans(): InMemorySpanExporter {
+function setupSpans(metricExporter?: PushMetricExporter): InMemorySpanExporter {
   const spanExporter = new InMemorySpanExporter();
   init(
     {
@@ -138,7 +145,7 @@ function setupSpans(): InMemorySpanExporter {
       logLevel: "silent",
       fetch: async () => new Response(null, { status: 200 }),
     },
-    { spanExporter },
+    { spanExporter, metricExporter },
   );
   return spanExporter;
 }
@@ -193,6 +200,7 @@ async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]>
 afterEach(async () => {
   uninstrumentOpenAI();
   await shutdown();
+  vi.restoreAllMocks();
 });
 
 test("chat completions map request, response, usage, finish reason, provider, and sampling attributes", async () => {
@@ -524,6 +532,120 @@ test("chat completions record finish reasons for single and multi-choice respons
   expect(multi?.attributes["gen_ai.response.finish_reasons"]).toEqual(["stop", "length"]);
 });
 
+test.each([false, true])("chunk timing preserves delivery with old core=%s", async (oldCore) => {
+  const spans = setupSpans();
+
+  if (oldCore) {
+    const start = sdk.startSpan;
+    vi.spyOn(sdk, "startSpan").mockImplementation((...args) => {
+      const handle = start(...args);
+      Reflect.deleteProperty(handle, "recordOutputChunk");
+
+      return handle;
+    });
+  }
+
+  const deltas = [
+    { role: "assistant" },
+    { content: "A" },
+    { content: null },
+    { content: "" },
+    { tool_calls: [] },
+    { tool_calls: [{ index: 0, function: { arguments: "" } }] },
+    { content: "B" },
+    { function_call: { name: "weather" } },
+    { function_call: { arguments: "" } },
+    { function_call: { arguments: '{"city":' } },
+    {
+      content: "mixed",
+      function_call: { arguments: '"Paris"}' },
+      tool_calls: [{ index: 0, function: { arguments: "{}" } }],
+    },
+    {},
+  ];
+
+  const fake = createFakeFetch(
+    sseResponse(
+      deltas.map((delta) => ({
+        id: "chatcmpl_timing",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4o",
+        choices: [{ index: 0, delta, finish_reason: null }],
+      })),
+    ),
+  );
+
+  const stream = await clientWith(fake.fetch).chat.completions.create({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: "Hi" }],
+    stream: true,
+  });
+
+  expect(await collectStream(stream)).toHaveLength(deltas.length);
+  const span = await exportedSpan(spans);
+  expect(span.status.code).toBe(SPAN_STATUS_UNSET);
+
+  if (oldCore) expect(Symbol.for("telemetry.dev.outputChunkHistogram") in span).toBe(false);
+  else {
+    expect(span).toMatchObject({
+      [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 3 },
+    });
+  }
+});
+
+test.each(["chat", "responses"])("%s timestamps precede telemetry mapping", async (operation) => {
+  const spans = setupSpans();
+  let now = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+
+  const source = new Stream(async function* () {
+    for (const [receivedAt, mappingMs] of [
+      [100, 30],
+      [240, 90],
+    ] as const) {
+      now = receivedAt;
+      yield operation === "chat"
+        ? {
+            get choices() {
+              now = receivedAt + mappingMs;
+
+              return [{ index: 0, delta: { content: "A" } }];
+            },
+          }
+        : {
+            get type() {
+              now = receivedAt + mappingMs;
+
+              return "response.output_text.delta";
+            },
+            delta: "A",
+          };
+    }
+  }, new AbortController());
+
+  const client = wrapOpenAI({
+    chat: { completions: { create: async (_params: unknown) => source } },
+    responses: { create: async (_params: unknown) => source },
+    embeddings: {},
+  });
+
+  const stream =
+    operation === "chat"
+      ? await client.chat.completions.create({ model: "gpt-4o", messages: [], stream: true })
+      : await client.responses.create({ model: "gpt-4o", input: "Hi", stream: true });
+
+  expect(await collectStream(stream)).toHaveLength(2);
+  expect(await exportedSpan(spans)).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: {
+      count: 1,
+      sum: 0.14,
+      min: 0.14,
+      max: 0.14,
+    },
+  });
+});
+
 test("chat streams preserve tool-call-only output with null content", async () => {
   const spans = setupSpans();
   const toolCall = {
@@ -595,6 +717,9 @@ test("chat streams preserve tool-call-only output with null content", async () =
     { role: "assistant", content: null, tool_calls: [toolCall] },
   ]);
   expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual(["tool_calls"]);
+  expect(span).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 1 },
+  });
 });
 
 test("chat streams record finish reasons for every choice", async () => {
@@ -993,6 +1118,70 @@ test("responses create failed body records error while completed body stays OK",
   expect(success?.events.some((event) => event.name === "exception")).toBe(false);
   expect(success?.attributes["gen_ai.response.finish_reasons"]).toEqual(["stop"]);
   expect(jsonAttr(success!, "gen_ai.output.messages")).toEqual(successOutput);
+});
+
+test.each([
+  "response.custom_tool_call_input",
+  "response.code_interpreter_call_code",
+  "response.mcp_call_arguments",
+  "response.audio.transcript",
+])("%s deltas retain timing after completion and interruption", async (eventType) => {
+  const metricExporter = new InMemoryMetricExporter(AggregationTemporality.DELTA);
+  const spans = setupSpans(metricExporter);
+
+  const outputEvents = [
+    { type: `${eventType}.delta`, delta: "first", item_id: "item_1", output_index: 0 },
+    { type: `${eventType}.delta`, delta: "", item_id: "item_1", output_index: 0 },
+    { type: `${eventType}.delta`, delta: "second", item_id: "item_1", output_index: 0 },
+    {
+      type: `${eventType}.done`,
+      input: "firstsecond",
+      code: "firstsecond",
+      arguments: "firstsecond",
+      transcript: "firstsecond",
+    },
+  ];
+
+  const completed = {
+    type: "response.completed",
+    response: { id: "resp_timing", model: "gpt-4.1", status: "completed", output: [] },
+  };
+
+  const fake = createFakeFetch(
+    sseResponse([...outputEvents, completed]),
+    countedSseResponse([...outputEvents, completed]).response,
+  );
+
+  const client = clientWith(fake.fetch);
+  const stream = await client.responses.create({ model: "gpt-4.1", input: "Run", stream: true });
+  expect(await collectStream(stream)).toEqual([...outputEvents, completed]);
+
+  const interrupted = await client.responses.create({
+    model: "gpt-4.1",
+    input: "Run",
+    stream: true,
+  });
+
+  const iterator = interrupted[Symbol.asyncIterator]();
+
+  for (const event of outputEvents) expect((await iterator.next()).value).toEqual(event);
+  await iterator.return?.();
+
+  expect(await finishedSpans(spans, 2)).toHaveLength(2);
+
+  const metrics = metricExporter
+    .getMetrics()
+    .flatMap((batch) => batch.scopeMetrics.flatMap((scope) => scope.metrics));
+
+  const histogram = metrics.find(
+    (metric) => metric.descriptor.name === "gen_ai.client.operation.time_per_output_chunk",
+  );
+
+  expect(histogram?.dataPoints).toHaveLength(2);
+  expect(histogram?.dataPoints).toEqual([
+    expect.objectContaining({ value: expect.objectContaining({ count: 1 }) }),
+    expect.objectContaining({ value: expect.objectContaining({ count: 1 }) }),
+  ]);
 });
 
 test("responses streams end from response.completed terminal event", async () => {

--- a/packages/openai/tests/openai.test.ts
+++ b/packages/openai/tests/openai.test.ts
@@ -45,6 +45,7 @@ function jsonErrorResponse(status: number, message: string): Response {
 
 function sseResponse(events: unknown[]): Response {
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream", "x-request-id": "req_stream" },
@@ -54,19 +55,23 @@ function sseResponse(events: unknown[]): Response {
 function erroringSseResponse<TEvent, TError>(event: TEvent, error: TError): Response {
   const encoder = new TextEncoder();
   let sent = false;
+
   const body = new ReadableStream<Uint8Array>(
     {
       pull(controller) {
         if (!sent) {
           sent = true;
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+
           return;
         }
+
         controller.error(error);
       },
     },
     { highWaterMark: 0 },
   );
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream", "x-request-id": "req_stream_error" },
@@ -81,20 +86,26 @@ interface CountedResponse {
 
 function countedSseResponse(events: unknown[]): CountedResponse {
   const encoder = new TextEncoder();
+
   const parts = [
     ...events.map((event) => `data: ${JSON.stringify(event)}\n\n`),
     "data: [DONE]\n\n",
   ];
+
   let index = 0;
   let pulled = 0;
+
   const body = new ReadableStream<Uint8Array>(
     {
       pull(controller) {
         const part = parts[index];
+
         if (part === undefined) {
           controller.close();
+
           return;
         }
+
         index += 1;
         pulled += 1;
         controller.enqueue(encoder.encode(part));
@@ -102,6 +113,7 @@ function countedSseResponse(events: unknown[]): CountedResponse {
     },
     { highWaterMark: 0 },
   );
+
   return {
     response: new Response(body, {
       status: 200,
@@ -119,18 +131,22 @@ interface FakeFetch {
 
 function createFakeFetch(...responses: Response[]): FakeFetch {
   const requests: CapturedRequest[] = [];
+
   const fetchImpl: typeof fetch = async (input, init) => {
     const url = input instanceof Request ? input.url : String(input);
-    const bodyText = String(init?.body) === init?.body ? init.body : undefined;
+    const bodyText = typeof init?.body === "string" ? init.body : undefined;
     requests.push({
       method: init?.method,
       path: new URL(url).pathname,
       body: bodyText ? JSON.parse(bodyText) : undefined,
     });
     const response = responses.shift();
+
     if (!response) throw new Error(`unexpected request to ${url}`);
+
     return response;
   };
+
   return { fetch: fetchImpl, requests };
 }
 
@@ -147,6 +163,7 @@ function setupSpans(metricExporter?: PushMetricExporter): InMemorySpanExporter {
     },
     { spanExporter, metricExporter },
   );
+
   return spanExporter;
 }
 
@@ -161,22 +178,28 @@ async function finishedSpans(
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await flush();
     const spans = exporter.getFinishedSpans();
+
     if (spans.length === expectedCount) return spans;
+
     if (spans.length > expectedCount) expect(spans).toHaveLength(expectedCount);
     await Promise.resolve();
   }
+
   expect(exporter.getFinishedSpans()).toHaveLength(expectedCount);
+
   return exporter.getFinishedSpans();
 }
 
 async function exportedSpan(exporter: InMemorySpanExporter): Promise<ReadableSpan> {
   const spans = await finishedSpans(exporter, 1);
+
   return spans[0]!;
 }
 
 function jsonAttr<T>(span: ReadableSpan, key: string): T {
   const value = span.attributes[key];
   expect(String(value) === value).toBe(true);
+
   return JSON.parse(String(value)) as T;
 }
 
@@ -186,14 +209,19 @@ function isObject<T>(value: T): value is T & object {
 
 function hasSyntheticUsageChunk<T>(value: T): boolean {
   const raw: unknown = value;
+
   if (!isObject(raw) || Array.isArray(raw)) return false;
+
   if (!("usage" in raw) || !("choices" in raw)) return false;
+
   return raw.usage !== undefined && Array.isArray(raw.choices) && raw.choices.length === 0;
 }
 
 async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   const chunks: unknown[] = [];
+
   for await (const chunk of stream) chunks.push(chunk);
+
   return chunks;
 }
 
@@ -205,10 +233,12 @@ afterEach(async () => {
 
 test("chat completions map request, response, usage, finish reason, provider, and sampling attributes", async () => {
   const spans = setupSpans();
+
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
     { role: "system", content: "Be terse" },
     { role: "user", content: "Say hello" },
   ];
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_1",
@@ -227,6 +257,7 @@ test("chat completions map request, response, usage, finish reason, provider, an
       },
     }),
   );
+
   const client = clientWith(fake.fetch);
 
   await client.chat.completions.create({
@@ -271,6 +302,7 @@ test("chat completions map request, response, usage, finish reason, provider, an
 
 test("wrapped chat completion APIPromise keeps parse helper and promise identity", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_parse",
@@ -288,7 +320,9 @@ test("wrapped chat completion APIPromise keeps parse helper and promise identity
     model: "gpt-4o",
     messages: [{ role: "user", content: "Parse this" }],
   });
+
   const rawResult: unknown = result;
+
   const resultWithPrivateParse = rawResult as {
     parse(): Promise<Awaited<typeof result>>;
   };
@@ -334,9 +368,11 @@ test("chat completions record one error span when the OpenAI API returns 4xx", a
 test("chat completions record non-Error promise rejections", async () => {
   const spans = setupSpans();
   const rejection = "request rejected";
+
   const fetch: typeof globalThis.fetch = async () => {
     throw new Error("unexpected fetch");
   };
+
   const client = new OpenAI({ apiKey: "test", fetch, maxRetries: 0 });
   Object.assign(client.chat.completions, {
     create<T>(_body: T) {
@@ -360,9 +396,11 @@ test("chat completions record non-Error promise rejections", async () => {
 
 test("synchronous create and retrieve failures end spans and preserve thrown values", async () => {
   const spans = setupSpans();
+
   const unusedFetch: typeof fetch = async () => {
     throw new Error("unexpected fetch");
   };
+
   const client = new OpenAI({ apiKey: "test", fetch: unusedFetch, maxRetries: 0 });
   const createFailure = "create failed";
   const retrieveFailure = { message: "retrieve failed" };
@@ -379,6 +417,7 @@ test("synchronous create and retrieve failures end spans and preserve thrown val
   const wrapped = wrapOpenAI(client);
 
   let caughtCreate = false;
+
   try {
     void wrapped.chat.completions.create({
       model: "gpt-4o",
@@ -388,15 +427,18 @@ test("synchronous create and retrieve failures end spans and preserve thrown val
     caughtCreate = true;
     expect(error).toBe(createFailure);
   }
+
   expect(caughtCreate).toBe(true);
 
   let caughtRetrieve = false;
+
   try {
     void wrapped.responses.retrieve("resp_sync", { stream: true });
   } catch (error) {
     caughtRetrieve = true;
     expect(error).toBe(retrieveFailure);
   }
+
   expect(caughtRetrieve).toBe(true);
 
   const finished = await finishedSpans(spans, 2);
@@ -411,11 +453,13 @@ test("synchronous create and retrieve failures end spans and preserve thrown val
 
 test("chat completions preserve tool-call messages in output", async () => {
   const spans = setupSpans();
+
   const toolCall = {
     id: "call_1",
     type: "function",
     function: { name: "get_weather", arguments: '{"location":"Paris"}' },
   };
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_tool",
@@ -456,6 +500,7 @@ test("chat completions preserve tool-call messages in output", async () => {
 
 test("chat completions capture every returned choice", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_two",
@@ -486,6 +531,7 @@ test("chat completions capture every returned choice", async () => {
 
 test("chat completions record finish reasons for single and multi-choice responses", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_single_finish",
@@ -509,6 +555,7 @@ test("chat completions record finish reasons for single and multi-choice respons
       usage: { prompt_tokens: 10, completion_tokens: 8, total_tokens: 18 },
     }),
   );
+
   const client = clientWith(fake.fetch);
 
   await client.chat.completions.create({
@@ -522,12 +569,15 @@ test("chat completions record finish reasons for single and multi-choice respons
   });
 
   const finished = await finishedSpans(spans, 2);
+
   const single = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_single_finish",
   );
+
   const multi = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_multi_finish",
   );
+
   expect(single?.attributes["gen_ai.response.finish_reasons"]).toEqual(["stop"]);
   expect(multi?.attributes["gen_ai.response.finish_reasons"]).toEqual(["stop", "length"]);
 });
@@ -648,11 +698,13 @@ test.each(["chat", "responses"])("%s timestamps precede telemetry mapping", asyn
 
 test("chat streams preserve tool-call-only output with null content", async () => {
   const spans = setupSpans();
+
   const toolCall = {
     id: "call_stream",
     type: "function",
     function: { name: "get_weather", arguments: '{"location":"Paris"}' },
   };
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -710,6 +762,7 @@ test("chat streams preserve tool-call-only output with null content", async () =
       },
     ],
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -724,6 +777,7 @@ test("chat streams preserve tool-call-only output with null content", async () =
 
 test("chat streams record finish reasons for every choice", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -753,6 +807,7 @@ test("chat streams record finish reasons for every choice", async () => {
     stream: true,
     n: 2,
   });
+
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
@@ -765,6 +820,7 @@ test("chat streams record finish reasons for every choice", async () => {
 
 test("chat streams leave the request unchanged and capture no usage by default", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -789,6 +845,7 @@ test("chat streams leave the request unchanged and capture no usage by default",
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   const visibleChunks = await collectStream(stream);
   const rawRequestBody: unknown = fake.requests[0]?.body;
   const requestBody = rawRequestBody as { stream?: boolean; stream_options?: object } | undefined;
@@ -805,6 +862,7 @@ test("chat streams leave the request unchanged and capture no usage by default",
 
 test("chat stream helper routes through wrapped create and ends span", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -828,6 +886,7 @@ test("chat stream helper routes through wrapped create and ends span", async () 
     model: "gpt-4o",
     messages: [{ role: "user", content: "Say hi" }],
   });
+
   const events = await collectStream(runner);
 
   expect(events.length).toBeGreaterThan(0);
@@ -840,6 +899,7 @@ test("chat stream helper routes through wrapped create and ends span", async () 
 
 test("chat streams inject include_usage when opted in and hide only the synthetic usage chunk", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -872,6 +932,7 @@ test("chat streams inject include_usage when opted in and hide only the syntheti
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   const visibleChunks = await collectStream(stream);
 
   expect(fake.requests[0]?.body).toMatchObject({
@@ -901,6 +962,7 @@ test("chat streams inject include_usage when opted in and hide only the syntheti
 
 test("chat streams end once with partial output when the caller stops early", async () => {
   const spans = setupSpans();
+
   const counted = countedSseResponse([
     {
       id: "chatcmpl_abandoned",
@@ -925,6 +987,7 @@ test("chat streams end once with partial output when the caller stops early", as
       usage: { prompt_tokens: 9, completion_tokens: 2, total_tokens: 11 },
     },
   ]);
+
   const fake = createFakeFetch(counted.response);
 
   const stream = await clientWith(fake.fetch).chat.completions.create({
@@ -934,6 +997,7 @@ test("chat streams end once with partial output when the caller stops early", as
   });
 
   let visibleChunks = 0;
+
   for await (const chunk of stream) {
     visibleChunks += 1;
     expect(chunk.choices[0]?.delta.content).toBe("Hel");
@@ -960,6 +1024,7 @@ test("chat streams end once with partial output when the caller stops early", as
 test("chat streams record one error span with partial output when the SSE body errors", async () => {
   const spans = setupSpans();
   const streamError = "stream exploded";
+
   const firstChunk = {
     id: "chatcmpl_stream_error",
     object: "chat.completion.chunk",
@@ -967,6 +1032,7 @@ test("chat streams record one error span with partial output when the SSE body e
     model: "gpt-4o-2024-11-20",
     choices: [{ index: 0, delta: { role: "assistant", content: "Hel" }, finish_reason: null }],
   };
+
   const fake = createFakeFetch(erroringSseResponse(firstChunk, streamError));
 
   const stream = await clientWith(fake.fetch).chat.completions.create({
@@ -974,6 +1040,7 @@ test("chat streams record one error span with partial output when the SSE body e
     messages: [{ role: "user", content: "Say hello" }],
     stream: true,
   });
+
   const visibleChunks: OpenAI.Chat.Completions.ChatCompletionChunk[] = [];
 
   await expect(
@@ -994,6 +1061,7 @@ test("chat streams record one error span with partial output when the SSE body e
 
 test("chat streams preserve caller-requested usage chunks", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -1020,6 +1088,7 @@ test("chat streams preserve caller-requested usage chunks", async () => {
     stream: true,
     stream_options: { include_usage: true },
   });
+
   const visibleChunks = await collectStream(stream);
 
   expect(fake.requests[0]?.body).toMatchObject({
@@ -1033,9 +1102,11 @@ test("chat streams preserve caller-requested usage chunks", async () => {
 
 test("responses create maps instructions to system instructions", async () => {
   const spans = setupSpans();
+
   const output = [
     { type: "message", role: "assistant", content: [{ type: "output_text", text: "No." }] },
   ];
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "resp_1",
@@ -1077,9 +1148,11 @@ test("responses create maps instructions to system instructions", async () => {
 test("responses create failed body records error while completed body stays OK", async () => {
   const spans = setupSpans();
   const failedError = { code: "server_error", message: "model exploded" };
+
   const successOutput = [
     { type: "message", role: "assistant", content: [{ type: "output_text", text: "Recovered" }] },
   ];
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "resp_failed",
@@ -1098,6 +1171,7 @@ test("responses create failed body records error while completed body stays OK",
       usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 },
     }),
   );
+
   const client = clientWith(fake.fetch);
 
   await client.responses.create({ model: "gpt-4.1", input: "fail" });
@@ -1186,6 +1260,7 @@ test.each([
 
 test("responses streams end from response.completed terminal event", async () => {
   const spans = setupSpans();
+
   const completed = {
     id: "resp_stream",
     object: "response",
@@ -1196,6 +1271,7 @@ test("responses streams end from response.completed terminal event", async () =>
     ],
     usage: { input_tokens: 8, output_tokens: 2, total_tokens: 10 },
   };
+
   const fake = createFakeFetch(
     sseResponse([
       { type: "response.created", response: { id: "resp_stream", status: "in_progress" } },
@@ -1208,6 +1284,7 @@ test("responses streams end from response.completed terminal event", async () =>
     input: "Finish",
     stream: true,
   });
+
   const events = await collectStream(stream);
 
   expect(events).toHaveLength(2);
@@ -1227,6 +1304,7 @@ test("responses streams end from response.completed terminal event", async () =>
 
 test("responses stream helper routes through wrapped create and ends span", async () => {
   const spans = setupSpans();
+
   const completed = {
     id: "resp_stream_helper",
     object: "response",
@@ -1237,6 +1315,7 @@ test("responses stream helper routes through wrapped create and ends span", asyn
     ],
     usage: { input_tokens: 8, output_tokens: 2, total_tokens: 10 },
   };
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -1251,6 +1330,7 @@ test("responses stream helper routes through wrapped create and ends span", asyn
     model: "gpt-4.1",
     input: "Finish",
   });
+
   const events = await collectStream(runner);
 
   expect(events.length).toBeGreaterThan(0);
@@ -1263,6 +1343,7 @@ test("responses stream helper routes through wrapped create and ends span", asyn
 
 test("responses stream helper traces response-id retrieval streams", async () => {
   const spans = setupSpans();
+
   const completed = {
     id: "resp_existing",
     object: "response",
@@ -1273,6 +1354,7 @@ test("responses stream helper traces response-id retrieval streams", async () =>
     ],
     usage: { input_tokens: 8, output_tokens: 2, total_tokens: 10 },
   };
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -1286,6 +1368,7 @@ test("responses stream helper traces response-id retrieval streams", async () =>
   const runner = clientWith(fake.fetch).responses.stream({
     response_id: "resp_existing",
   });
+
   const events = await collectStream(runner);
 
   expect(events.length).toBeGreaterThan(0);
@@ -1299,6 +1382,7 @@ test("responses stream helper traces response-id retrieval streams", async () =>
 
 test("responses streams end from terminal event before reading the stream sentinel", async () => {
   const spans = setupSpans();
+
   const completed = {
     id: "resp_stream_terminal",
     object: "response",
@@ -1309,10 +1393,12 @@ test("responses streams end from terminal event before reading the stream sentin
     ],
     usage: { input_tokens: 8, output_tokens: 2, total_tokens: 10 },
   };
+
   const counted = countedSseResponse([
     { type: "response.created", response: { id: "resp_stream_terminal", status: "in_progress" } },
     { type: "response.completed", response: completed },
   ]);
+
   const fake = createFakeFetch(counted.response);
 
   const stream = await clientWith(fake.fetch).responses.create({
@@ -1320,6 +1406,7 @@ test("responses streams end from terminal event before reading the stream sentin
     input: "Finish",
     stream: true,
   });
+
   const iterator = stream[Symbol.asyncIterator]();
 
   try {
@@ -1353,6 +1440,7 @@ test("responses streams record error status from bare error events", async () =>
     input: "Stream",
     stream: true,
   });
+
   const events = await collectStream(stream);
 
   expect(events).toEqual([errorEvent]);
@@ -1374,6 +1462,7 @@ test("responses streams record error status from bare error events", async () =>
 
 test("responses streams record error status from response.failed terminal events", async () => {
   const spans = setupSpans();
+
   const failedResponse = {
     id: "resp_stream_failed",
     object: "response",
@@ -1382,7 +1471,9 @@ test("responses streams record error status from response.failed terminal events
     output: [],
     error: { code: "server_error", message: "stream failed" },
   };
+
   const failedEvent = { type: "response.failed", response: failedResponse };
+
   const fake = createFakeFetch(
     sseResponse([
       { type: "response.created", response: { id: "resp_stream_failed" } },
@@ -1395,6 +1486,7 @@ test("responses streams record error status from response.failed terminal events
     input: "Stream",
     stream: true,
   });
+
   const events = await collectStream(stream);
 
   expect(events).toEqual([
@@ -1417,10 +1509,12 @@ test("responses streams record error status from response.failed terminal events
 test("responses streams record non-Error iterator failures", async () => {
   const spans = setupSpans();
   const streamError = "responses stream exploded";
+
   const firstEvent = {
     type: "response.created",
     response: { id: "resp_stream_error", status: "in_progress", output: [] },
   };
+
   const fake = createFakeFetch(erroringSseResponse(firstEvent, streamError));
 
   const stream = await clientWith(fake.fetch).responses.create({
@@ -1428,6 +1522,7 @@ test("responses streams record non-Error iterator failures", async () => {
     input: "Stream",
     stream: true,
   });
+
   await expect(collectStream(stream)).rejects.toBe(streamError);
 
   const span = await exportedSpan(spans);
@@ -1436,8 +1531,10 @@ test("responses streams record non-Error iterator failures", async () => {
   const exception = span.events.find((event) => event.name === "exception");
   expect(exception?.attributes?.["exception.message"]).toBe(streamError);
 });
+
 test("embeddings map token usage without capturing embedding vectors as output", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       object: "list",
@@ -1467,9 +1564,11 @@ test("embeddings map token usage without capturing embedding vectors as output",
 test("global instrumentation records responses and embeddings with wrapOpenAI parity attributes", async () => {
   const spans = setupSpans();
   instrumentOpenAI();
+
   const output = [
     { type: "message", role: "assistant", content: [{ type: "output_text", text: "No." }] },
   ];
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "resp_global",
@@ -1492,6 +1591,7 @@ test("global instrumentation records responses and embeddings with wrapOpenAI pa
       usage: { prompt_tokens: 6, total_tokens: 6 },
     }),
   );
+
   const client = new OpenAI({ apiKey: "test", fetch: fake.fetch, maxRetries: 0 });
 
   await client.responses.create({
@@ -1532,6 +1632,7 @@ test("global instrumentation records responses and embeddings with wrapOpenAI pa
 test("instrumentOpenAI threads injectStreamUsage into chat streams", async () => {
   const spans = setupSpans();
   instrumentOpenAI({ injectStreamUsage: true });
+
   const fake = createFakeFetch(
     sseResponse([
       {
@@ -1551,6 +1652,7 @@ test("instrumentOpenAI threads injectStreamUsage into chat streams", async () =>
       },
     ]),
   );
+
   const client = new OpenAI({ apiKey: "test", fetch: fake.fetch, maxRetries: 0 });
 
   const stream = await client.chat.completions.create({
@@ -1558,6 +1660,7 @@ test("instrumentOpenAI threads injectStreamUsage into chat streams", async () =>
     messages: [{ role: "user", content: "Greet" }],
     stream: true,
   });
+
   const visibleChunks = await collectStream(stream);
 
   expect(fake.requests[0]?.body).toMatchObject({
@@ -1571,6 +1674,7 @@ test("instrumentOpenAI threads injectStreamUsage into chat streams", async () =>
 test("wrapOpenAI shadows global instrumentation and survives uninstrumentOpenAI", async () => {
   const spans = setupSpans();
   instrumentOpenAI();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_global_wrapped",
@@ -1593,6 +1697,7 @@ test("wrapOpenAI shadows global instrumentation and survives uninstrumentOpenAI"
       usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
     }),
   );
+
   const client = wrapOpenAI(new OpenAI({ apiKey: "test", fetch: fake.fetch, maxRetries: 0 }));
 
   await client.chat.completions.create({
@@ -1617,6 +1722,7 @@ test("wrapOpenAI shadows global instrumentation and survives uninstrumentOpenAI"
 
 test("AzureOpenAI clients report Azure provider for wrapped and global instrumentation", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_azure_wrapped",
@@ -1639,6 +1745,7 @@ test("AzureOpenAI clients report Azure provider for wrapped and global instrumen
       usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
     }),
   );
+
   const azureOptions = {
     apiKey: "test",
     apiVersion: "2024-10-21",
@@ -1658,18 +1765,22 @@ test("AzureOpenAI clients report Azure provider for wrapped and global instrumen
   });
 
   const finished = await finishedSpans(spans, 2);
+
   const wrapped = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_azure_wrapped",
   );
+
   const global = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_azure_global",
   );
+
   expect(wrapped?.attributes["gen_ai.provider.name"]).toBe("azure.ai.openai");
   expect(global?.attributes["gen_ai.provider.name"]).toBe("azure.ai.openai");
 });
 
 test("clients with an OpenRouter base URL report the openrouter provider", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_or_wrapped",
@@ -1692,6 +1803,7 @@ test("clients with an OpenRouter base URL report the openrouter provider", async
       usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
     }),
   );
+
   const openRouterOptions = {
     apiKey: "test",
     baseURL: "https://openrouter.ai/api/v1",
@@ -1710,12 +1822,15 @@ test("clients with an OpenRouter base URL report the openrouter provider", async
   });
 
   const finished = await finishedSpans(spans, 2);
+
   const wrapped = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_or_wrapped",
   );
+
   const global = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_or_global",
   );
+
   expect(wrapped?.attributes["gen_ai.provider.name"]).toBe("openrouter");
   expect(global?.attributes["gen_ai.provider.name"]).toBe("openrouter");
 });
@@ -1729,6 +1844,7 @@ test.each([
   "clients with an OpenRouter %s report the expected provider",
   async (_case, baseURL, provider) => {
     const spans = setupSpans();
+
     const fake = createFakeFetch(
       jsonResponse({
         id: "chatcmpl_or_host",
@@ -1756,6 +1872,7 @@ test.each([
 
 test("wrapOpenAI resolves the provider from the current base URL for each operation", async () => {
   const spans = setupSpans();
+
   const completed = {
     id: "resp_dynamic_provider",
     object: "response",
@@ -1764,6 +1881,7 @@ test("wrapOpenAI resolves the provider from the current base URL for each operat
     output: [],
     usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
   };
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_dynamic_provider",
@@ -1783,6 +1901,7 @@ test("wrapOpenAI resolves the provider from the current base URL for each operat
       { type: "response.completed", response: completed },
     ]),
   );
+
   const client = wrapOpenAI(
     new OpenAI({
       apiKey: "test",
@@ -1801,12 +1920,15 @@ test("wrapOpenAI resolves the provider from the current base URL for each operat
   await collectStream(client.responses.stream({ response_id: "resp_dynamic_provider" }));
 
   const finished = await finishedSpans(spans, 2);
+
   const chat = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "chatcmpl_dynamic_provider",
   );
+
   const retrieve = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "resp_dynamic_provider",
   );
+
   expect(chat?.attributes["gen_ai.provider.name"]).toBe("openai");
   expect(retrieve?.attributes["gen_ai.provider.name"]).toBe("openrouter");
 });
@@ -1814,6 +1936,7 @@ test("wrapOpenAI resolves the provider from the current base URL for each operat
 test("wrapped clients fail open when telemetry is not initialized", async () => {
   await shutdown();
   uninstrumentOpenAI();
+
   const fake = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_no_telemetry",
@@ -1842,6 +1965,7 @@ test("instrumentOpenAI and wrapOpenAI are idempotent and uninstrumentOpenAI rest
   const spans = setupSpans();
   instrumentOpenAI();
   instrumentOpenAI();
+
   const instrumented = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_global",
@@ -1870,6 +1994,7 @@ test("instrumentOpenAI and wrapOpenAI are idempotent and uninstrumentOpenAI rest
   await finishedSpans(spans, 1);
 
   uninstrumentOpenAI();
+
   const wrapped = createFakeFetch(
     jsonResponse({
       id: "chatcmpl_wrapped",
@@ -1882,6 +2007,7 @@ test("instrumentOpenAI and wrapOpenAI are idempotent and uninstrumentOpenAI rest
       usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
     }),
   );
+
   await wrapOpenAI(
     wrapOpenAI(new OpenAI({ apiKey: "test", fetch: wrapped.fetch, maxRetries: 0 })),
   ).chat.completions.create({

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,4 +1,5 @@
 export type { TelemetryDevOpencodeOptions } from "./config.ts";
+
 export {
   telemetryDevPlugin,
   type TelemetryDevHooks,

--- a/packages/opencode/src/plugin.ts
+++ b/packages/opencode/src/plugin.ts
@@ -58,14 +58,17 @@ type PendingTool = {
 
 function stringField(record: JsonObject | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   if (value instanceof Object) return undefined;
   const parsed = String(value);
+
   return parsed === value && parsed.length > 0 ? parsed : undefined;
 }
 
 function numberField(record: JsonObject | undefined, key: string): number | undefined {
   const value = record?.[key];
   const parsed = Number(value);
+
   return parsed === value && Number.isFinite(parsed) ? parsed : undefined;
 }
 
@@ -80,13 +83,17 @@ function reportError(onError: ((cause: Error) => void) | undefined, cause: unkno
 function textParts<T>(parts: T): string | undefined {
   if (!Array.isArray(parts)) return undefined;
   const text: string[] = [];
+
   for (const part of parts) {
     const record = asJsonObject(part);
+
     if (stringField(record, "type") === "text") {
       const value = stringField(record, "text");
+
       if (value !== undefined) text.push(value);
     }
   }
+
   return text.length > 0 ? text.join("\n") : undefined;
 }
 
@@ -94,6 +101,7 @@ function textParts<T>(parts: T): string | undefined {
 function failureError(name: string, message: string | undefined): Error {
   const error = new Error(message ?? name);
   error.name = name;
+
   return error;
 }
 
@@ -121,6 +129,7 @@ function messageError(message: JsonObject): Error | undefined {
   if (message.error === undefined || message.error === null) return undefined;
   const error = asJsonObject(message.error);
   const data = asJsonObject(error?.data);
+
   return failureError(
     stringField(error, "name") ?? "AssistantMessageError",
     stringField(data, "message"),
@@ -140,11 +149,14 @@ export function telemetryDevPlugin(
       ...options,
       ...configuredOptions,
     };
+
     const { agentName: configuredAgentName, ...sdkOptions } = mergedOptions;
+
     const agentName =
       String(configuredAgentName) === configuredAgentName && configuredAgentName.length > 0
         ? configuredAgentName
         : "opencode";
+
     const onError = sdkOptions.onError;
 
     try {
@@ -196,6 +208,7 @@ export function telemetryDevPlugin(
         open.span.end({ error, finishReason: error ? undefined : "incomplete" });
         openChats.delete(messageID);
       }
+
       chatBySession.delete(sessionID);
     }
 
@@ -208,6 +221,7 @@ export function telemetryDevPlugin(
       for (const [key, pending] of pendingTools) {
         if (pending.sessionID !== sessionID) continue;
         pendingTools.delete(key);
+
         const span = startSpan(`execute_tool ${pending.tool}`, {
           type: "tool",
           parent: chatBySession.get(sessionID) ?? agentSpans.get(sessionID),
@@ -217,6 +231,7 @@ export function telemetryDevPlugin(
           input: pending.args,
           attributes: conversationAttributes(sessionID),
         });
+
         span.end({ error });
       }
     }
@@ -227,14 +242,17 @@ export function telemetryDevPlugin(
         toolCallByPart.delete(sessionID);
         const error = pendingErrors.get(sessionID);
         pendingErrors.delete(sessionID);
+
         if (error) endPendingTools(sessionID, error);
         endOpenChats(sessionID, error);
         const span = agentSpans.get(sessionID);
+
         if (span) {
           span.end({ error });
           agentSpans.delete(sessionID);
         }
       }
+
       void flush().catch((error) => reportError(onError, error));
     }
 
@@ -243,10 +261,13 @@ export function telemetryDevPlugin(
         try {
           if (agentSpans.has(input.sessionID)) return;
           const parentID = parentSession.get(input.sessionID);
+
           const parent = parentID
             ? (chatBySession.get(parentID) ?? agentSpans.get(parentID))
             : undefined;
+
           const attributes: Record<string, string> = conversationAttributes(input.sessionID);
+
           if (input.agent) attributes["opencode.agent"] = input.agent;
           agentSpans.set(
             input.sessionID,
@@ -277,6 +298,7 @@ export function telemetryDevPlugin(
               const messageID = stringField(info, "id");
               const sessionID = stringField(info, "sessionID");
               const model = stringField(info, "modelID");
+
               if (
                 stringField(info, "role") !== "assistant" ||
                 messageID === undefined ||
@@ -289,6 +311,7 @@ export function telemetryDevPlugin(
 
               // Open the chat span on first sight so tool spans can nest under it.
               let open = openChats.get(messageID);
+
               if (!open) {
                 open = {
                   span: startSpan(`chat ${model}`, {
@@ -304,10 +327,12 @@ export function telemetryDevPlugin(
                 openChats.set(messageID, open);
                 chatBySession.set(sessionID, open.span);
               }
+
               if (completed === undefined) return;
 
               completedMessages.add(messageID);
               openChats.delete(messageID);
+
               if (chatBySession.get(sessionID) === open.span) chatBySession.delete(sessionID);
               open.span.end({
                 endTime: completed,
@@ -317,11 +342,13 @@ export function telemetryDevPlugin(
                 usage: usageFields(info ?? {}),
                 error: messageError(info ?? {}),
               });
+
               return;
             }
 
             case "message.part.updated": {
               const part = asJsonObject(properties?.part);
+
               if (stringField(part, "type") !== "tool") return;
               const state = asJsonObject(part?.state);
               const status = stringField(state, "status");
@@ -329,6 +356,7 @@ export function telemetryDevPlugin(
               const callID = stringField(part, "callID");
               const partID = stringField(part, "id");
               const tool = stringField(part, "tool");
+
               if (!sessionID || !callID || !tool) return;
 
               if (status === "running") {
@@ -336,8 +364,10 @@ export function telemetryDevPlugin(
                 const calls = toolCallByPart.get(sessionID) ?? new Map<string, string>();
                 calls.set(partID, callID);
                 toolCallByPart.set(sessionID, calls);
+
                 return;
               }
+
               if (status !== "error") return;
 
               // The synthetic Task path keys its hook calls by part id, not by
@@ -345,11 +375,14 @@ export function telemetryDevPlugin(
               const callKey = `${sessionID}:${callID}` as const;
               const partKey = `${sessionID}:${partID}` as const;
               const pending = pendingTools.get(callKey) ?? pendingTools.get(partKey);
+
               if (!pending) return;
               pendingTools.delete(callKey);
               pendingTools.delete(partKey);
+
               if (partID) toolCallByPart.get(sessionID)?.delete(partID);
               const timing = asJsonObject(state?.time);
+
               const span = startSpan(`execute_tool ${tool}`, {
                 type: "tool",
                 parent: chatBySession.get(sessionID) ?? agentSpans.get(sessionID),
@@ -359,6 +392,7 @@ export function telemetryDevPlugin(
                 input: state?.input,
                 attributes: conversationAttributes(sessionID),
               });
+
               span.end({
                 endTime: numberField(timing, "end"),
                 error: failureError(
@@ -366,11 +400,13 @@ export function telemetryDevPlugin(
                   stringField(state, "error") ?? "tool execution failed",
                 ),
               });
+
               return;
             }
 
             case "session.idle": {
               settleSession(stringField(properties, "sessionID"));
+
               return;
             }
 
@@ -381,6 +417,7 @@ export function telemetryDevPlugin(
               if (stringField(asJsonObject(properties?.status), "type") === "idle") {
                 settleSession(stringField(properties, "sessionID"));
               }
+
               return;
             }
 
@@ -391,13 +428,16 @@ export function telemetryDevPlugin(
               const errorName = stringField(hostError, "name") ?? "SessionError";
               const errorMessage = stringField(errorData, "message");
               const attributes = { "opencode.error.name": errorName };
+
               if (errorMessage)
                 Object.assign(attributes, { "opencode.error.message": errorMessage });
               emit("session.error", sessionID, "error", "Session error", attributes);
+
               // Not always terminal: a context overflow publishes this event,
               // then compacts and continues the same prompt. Record the error
               // and apply it when the session settles.
               if (sessionID) pendingErrors.set(sessionID, failureError(errorName, errorMessage));
+
               return;
             }
 
@@ -406,20 +446,26 @@ export function telemetryDevPlugin(
               const sessionID = stringField(info, "id");
               const parentID = stringField(info, "parentID");
               const attributes: Attrs = {};
+
               if (parentID) {
                 attributes["opencode.session.parent_id"] = parentID;
+
                 if (sessionID) parentSession.set(sessionID, parentID);
               }
+
               emit("session.created", sessionID, "info", "Session created", attributes);
+
               return;
             }
 
             case "session.compacted": {
               const sessionID = stringField(properties, "sessionID");
+
               // Compaction after a context-overflow session.error means the
               // host recovered and the prompt continues; drop the stale error.
               if (sessionID) pendingErrors.delete(sessionID);
               emit("session.compacted", sessionID, "info", "Session compacted");
+
               return;
             }
           }
@@ -453,6 +499,7 @@ export function telemetryDevPlugin(
           pendingTools.delete(key);
           const mappedCallID = toolCallByPart.get(input.sessionID)?.get(input.callID);
           toolCallByPart.get(input.sessionID)?.delete(input.callID);
+
           const span = startSpan(`execute_tool ${input.tool}`, {
             type: "tool",
             parent: chatBySession.get(input.sessionID) ?? agentSpans.get(input.sessionID),
@@ -467,6 +514,7 @@ export function telemetryDevPlugin(
             },
             attributes: conversationAttributes(input.sessionID),
           });
+
           span.end();
         } catch (error) {
           reportError(onError, error);
@@ -478,16 +526,20 @@ export function telemetryDevPlugin(
           // Disposal is not gated on session idle; apply each session's
           // deferred session.error instead of ending spans as merely incomplete.
           for (const [sessionID, error] of pendingErrors) endPendingTools(sessionID, error);
+
           for (const [messageID, open] of openChats) {
             const error = pendingErrors.get(open.sessionID);
             open.span.end({ error, finishReason: error ? undefined : "incomplete" });
             openChats.delete(messageID);
           }
+
           chatBySession.clear();
+
           for (const [sessionID, span] of agentSpans) {
             const error = pendingErrors.get(sessionID);
             span.end({ error, finishReason: error ? undefined : "incomplete" });
           }
+
           agentSpans.clear();
           parentSession.clear();
           pendingTools.clear();

--- a/packages/opencode/src/type-guards.ts
+++ b/packages/opencode/src/type-guards.ts
@@ -1,4 +1,5 @@
 export type JsonObject = { [key: string]: JsonValue | undefined };
+
 export type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonObject;
 
 export function isJsonObject<T>(value: T): value is T & JsonObject {

--- a/packages/opencode/tests/opencode.test.ts
+++ b/packages/opencode/tests/opencode.test.ts
@@ -22,6 +22,7 @@ interface Harness {
 function makeExporters(): Exporters {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
+
   return { logRecordExporter: logs, logs, spanExporter: spans, spans };
 }
 
@@ -51,6 +52,7 @@ async function makeHarness(options?: TelemetryDevPluginOptions): Promise<Harness
   const exporters = makeExporters();
   const plugin = telemetryDevPlugin(telemetryOptions(options), exporters);
   const hooks = await plugin(pluginInput);
+
   return { exporters, hooks };
 }
 
@@ -67,6 +69,7 @@ async function event(hooks: Hooks, type: string, properties: JsonValue): Promise
 }
 
 type JsonObject = { [key: string]: JsonValue };
+
 type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
 
 function assistantMessage(overrides?: JsonObject) {
@@ -99,6 +102,7 @@ function spansByName(exporters: Exporters, name: string): ReadableSpan[] {
 function spanByName(exporters: Exporters, name: string): ReadableSpan {
   const spans = spansByName(exporters, name);
   expect(spans, `expected one span named ${name}`).toHaveLength(1);
+
   return spans[0]!;
 }
 
@@ -279,6 +283,7 @@ test("dispose ends every dangling agent span as incomplete and flushes", async (
 
   const spans = spansByName(harness.exporters, "invoke_agent");
   expect(spans).toHaveLength(2);
+
   for (const span of spans) {
     expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual(["incomplete"]);
   }
@@ -350,11 +355,13 @@ describe("synthetic Task correlation", () => {
 test("poisoned events report through onError without throwing", async () => {
   const errors: unknown[] = [];
   const harness = await makeHarness({ onError: (error) => errors.push(error) });
+
   const poisoned = {
     get type(): never {
       throw "poisoned event";
     },
   };
+
   await expect(harness.hooks.event?.({ event: poisoned as never })).resolves.toBeUndefined();
   expect(errors).toHaveLength(1);
   expect(errors[0]).toEqual(new Error("poisoned event"));

--- a/packages/openrouter/src/index.ts
+++ b/packages/openrouter/src/index.ts
@@ -20,8 +20,11 @@ const STREAM_CAPTURE_ITEM_BYTES = 16;
 
 function jsonEscapedLength(codePoint: number): number {
   if (codePoint === 0x22 || codePoint === 0x5c) return 2;
+
   if (codePoint >= 0xd800 && codePoint <= 0xdfff) return 6;
+
   if (codePoint >= 0x20) return 1;
+
   return codePoint === 0x08 ||
     codePoint === 0x09 ||
     codePoint === 0x0a ||
@@ -38,6 +41,7 @@ class StreamCaptureBudget {
 
   accept<T>(value: T): boolean {
     if (this.truncated) return false;
+
     try {
       const measured = this.measure(
         value,
@@ -46,16 +50,21 @@ class StreamCaptureBudget {
         0,
         new Set(),
       );
+
       if (!measured) {
         this.truncated = true;
+
         return false;
       }
+
       const [byteCount, itemCount] = measured;
       this.bytesUsed += byteCount;
       this.itemsUsed += itemCount;
+
       return true;
     } catch {
       this.truncated = true;
+
       return false;
     }
   }
@@ -65,18 +74,23 @@ class StreamCaptureBudget {
     candidate.bytesUsed = this.bytesUsed;
     candidate.itemsUsed = this.itemsUsed;
     candidate.truncated = this.truncated;
+
     return candidate.accept(value);
   }
 
   replace<T>(value: T): boolean {
     const replacement = new StreamCaptureBudget();
+
     if (!replacement.accept(value)) {
       this.truncated = true;
+
       return false;
     }
+
     this.bytesUsed = replacement.bytesUsed;
     this.itemsUsed = replacement.itemsUsed;
     this.truncated = false;
+
     return true;
   }
 
@@ -94,24 +108,34 @@ class StreamCaptureBudget {
     ) {
       return undefined;
     }
+
     let byteCount = STREAM_CAPTURE_ITEM_BYTES;
     let itemCount = 1;
     const text = readString(value);
+
     if (text !== undefined) {
       for (const character of text) {
         const codePoint = character.codePointAt(0) ?? 0;
+
         const utf8Bytes =
           codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+
         byteCount += Math.max(utf8Bytes, jsonEscapedLength(codePoint));
+
         if (byteCount > remainingBytes) return undefined;
       }
+
       return [byteCount, itemCount];
     }
+
     const record = asRecord(value);
+
     if (!record) return [byteCount, itemCount];
+
     if (seen.has(record)) return [byteCount, itemCount];
     seen.add(record);
     const values = asArray(value);
+
     if (values) {
       for (const child of values) {
         const measured = this.measure(
@@ -121,14 +145,18 @@ class StreamCaptureBudget {
           depth + 1,
           seen,
         );
+
         if (!measured) return undefined;
         byteCount += measured[0];
         itemCount += measured[1];
       }
+
       return [byteCount, itemCount];
     }
+
     for (const key in record) {
       if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+
       for (const part of [key, record[key]]) {
         const measured = this.measure(
           part,
@@ -137,28 +165,36 @@ class StreamCaptureBudget {
           depth + 1,
           seen,
         );
+
         if (!measured) return undefined;
         byteCount += measured[0];
         itemCount += measured[1];
       }
     }
+
     return [byteCount, itemCount];
   }
 }
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
+
 type MethodValue = JsonValue | ReadableStream<JsonValue>;
+
 type Method = (...args: never[]) => MethodValue | Promise<MethodValue>;
+
 type WrappedFunction = Method & {
   [WRAPPED]?: true;
   [ORIGINAL]?: Method;
 };
+
 interface CallableRecord {
   [key: string]: JsonValue | WrappedFunction;
 }
+
 type Operation = "chat" | "responses" | "embeddings";
 
 interface OpenRouterClient {
@@ -199,6 +235,7 @@ interface ResponsesOutputItemState {
 
 function asRecord<T>(value: T): JsonRecord | undefined {
   if (value === null || value === undefined || value instanceof Function) return undefined;
+
   return Object(value) === value ? (value as JsonRecord) : undefined;
 }
 
@@ -220,35 +257,46 @@ function snakeCase(key: string): string {
 
 function responseNative<T>(value: T, seen = new Map<object, JsonValue>()): JsonValue {
   const record = asRecord(value);
+
   if (!record) return value as JsonValue;
   const existing = seen.get(record);
+
   if (existing !== undefined) return existing;
   const values = asArray(value);
+
   if (values) {
     const result: JsonValue[] = [];
     seen.set(record, result);
+
     for (const item of values) result.push(responseNative(item, seen));
+
     return result;
   }
+
   const raw = asRecord(record.raw);
+
   if (
     raw &&
     (record.isUnknown === true || record.is_unknown === true || record.type === "UNKNOWN")
   ) {
     return responseNative(raw, seen);
   }
+
   const result: JsonRecord = {};
   seen.set(record, result);
+
   for (const key in record) {
     if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
     result[snakeCase(key)] = responseNative(record[key], seen);
   }
+
   return result;
 }
 
 function eventRecord<T>(value: T): JsonRecord {
   const record = asRecord(value) ?? {};
   const raw = asRecord(record.raw);
+
   return raw &&
     (record.isUnknown === true || record.is_unknown === true || record.type === "UNKNOWN")
     ? raw
@@ -265,24 +313,31 @@ function eventString(event: JsonRecord, camel: string, snake: string): string | 
 
 function compactUsage(usage: SpanFields["usage"]): SpanFields["usage"] {
   if (!usage) return undefined;
+
   return Object.values(usage).some((value) => value !== undefined) ? usage : undefined;
 }
 
 function stopSequences<T>(value: T): string[] | undefined {
   const single = readString(value);
+
   if (single !== undefined) return [single];
   const values = asArray(value);
+
   if (!values) return undefined;
+
   const strings = values.flatMap((item) => {
     const string = readString(item);
+
     return string === undefined ? [] : [string];
   });
+
   return strings.length > 0 ? strings : undefined;
 }
 
 function usageCost<T>(usage: T): number | undefined {
   const u = asRecord(usage);
   const details = asRecord(u?.costDetails) ?? asRecord(u?.cost_details);
+
   return (
     readNumber(u?.cost) ??
     readNumber(details?.upstreamInferenceCost) ??
@@ -293,6 +348,7 @@ function usageCost<T>(usage: T): number | undefined {
 function chatRequest(request: JsonRecord): RequestMapping {
   const body = asRecord(request.chatRequest) ?? {};
   const model = readString(body.model);
+
   return {
     name: `chat ${model ?? "unknown"}`,
     fields: {
@@ -316,6 +372,7 @@ function chatUsage<T>(usage: T): SpanFields["usage"] {
   const u = asRecord(usage);
   const promptDetails = asRecord(u?.promptTokensDetails);
   const completionDetails = asRecord(u?.completionTokensDetails);
+
   return compactUsage({
     inputTokens: readNumber(u?.promptTokens),
     outputTokens: readNumber(u?.completionTokens),
@@ -328,18 +385,22 @@ function chatUsage<T>(usage: T): SpanFields["usage"] {
 
 function finishReasonFields(finishReasons: string[]): SpanFields {
   const fields: SpanFields = { finishReason: finishReasons[0] };
+
   if (finishReasons.length > 1) {
     fields.attributes = { "gen_ai.response.finish_reasons": finishReasons };
   }
+
   return fields;
 }
 
 function chatResponse<T>(response: T): SpanFields {
   const r = asRecord(response) ?? {};
   const choices = asArray(r.choices) ?? [];
+
   const finishReasons = choices
     .map((choice) => readString(asRecord(choice)?.finishReason))
     .filter((reason): reason is string => reason !== undefined);
+
   return {
     responseModel: readString(r.model),
     responseId: readString(r.id),
@@ -355,6 +416,7 @@ function chatResponse<T>(response: T): SpanFields {
 function responsesRequest(request: JsonRecord): RequestMapping {
   const body = asRecord(request.responsesRequest) ?? {};
   const model = readString(body.model);
+
   return {
     name: `chat ${model ?? "unknown"}`,
     fields: {
@@ -377,6 +439,7 @@ function responsesUsage<T>(usage: T): SpanFields["usage"] {
   const u = asRecord(usage);
   const inputDetails = asRecord(u?.inputTokensDetails) ?? asRecord(u?.input_tokens_details);
   const outputDetails = asRecord(u?.outputTokensDetails) ?? asRecord(u?.output_tokens_details);
+
   return compactUsage({
     inputTokens: readNumber(u?.inputTokens) ?? readNumber(u?.input_tokens),
     outputTokens: readNumber(u?.outputTokens) ?? readNumber(u?.output_tokens),
@@ -394,6 +457,7 @@ function responsesResponse<T>(response: T, includeOutput = true): SpanFields {
   const r = asRecord(response) ?? {};
   const status = readString(r.status);
   const incompleteDetails = asRecord(r.incompleteDetails) ?? asRecord(r.incomplete_details);
+
   const fields: SpanFields = {
     responseModel: readString(r.model),
     responseId: readString(r.id),
@@ -402,8 +466,11 @@ function responsesResponse<T>(response: T, includeOutput = true): SpanFields {
     finishReason:
       status === "completed" ? "stop" : (readString(incompleteDetails?.reason) ?? status),
   };
+
   if (includeOutput) fields.output = responseNative(r.output);
+
   if (status === "failed") fields.error = responseFailedError(response);
+
   return fields;
 }
 
@@ -411,6 +478,7 @@ function responseFailedError<T>(response: T): Error {
   const error = asRecord(asRecord(response)?.error);
   const code = readNumber(error?.code) ?? readString(error?.code);
   const message = readString(error?.message);
+
   return new Error(["response.failed", code, message].filter(Boolean).join(": "));
 }
 
@@ -418,12 +486,14 @@ function responseStreamError<T>(event: T): Error {
   const e = asRecord(event);
   const code = readNumber(e?.code) ?? readString(e?.code);
   const message = readString(e?.message);
+
   return new Error(["response.error", code, message].filter(Boolean).join(": "));
 }
 
 function embeddingsRequest(request: JsonRecord): RequestMapping {
   const body = asRecord(request.requestBody) ?? {};
   const model = readString(body.model);
+
   return {
     name: `embeddings ${model ?? "unknown"}`,
     fields: {
@@ -438,6 +508,7 @@ function embeddingsRequest(request: JsonRecord): RequestMapping {
 function embeddingsResponse<T>(response: T): SpanFields {
   const r = asRecord(response) ?? {};
   const usage = asRecord(r.usage);
+
   return {
     responseModel: readString(r.model),
     responseId: readString(r.id),
@@ -456,11 +527,13 @@ function isWrapped<T>(fn: T): fn is T & WrappedFunction {
 function markWrapped<T extends WrappedFunction>(fn: T, original: Method): T {
   Object.defineProperty(fn, WRAPPED, { value: true });
   Object.defineProperty(fn, ORIGINAL, { value: original });
+
   return fn;
 }
 
 function endOnce(span: SpanHandle): (fields?: SpanFields) => void {
   let ended = false;
+
   return (fields?: SpanFields) => {
     if (ended) return;
     ended = true;
@@ -474,11 +547,14 @@ function getChoiceState(
   budget: StreamCaptureBudget,
 ): ChatChoiceState | undefined {
   let state = states.get(index);
+
   if (!state) {
     if (states.size >= MAX_STREAM_CAPTURE_ITEMS) {
       budget.truncated = true;
+
       return undefined;
     }
+
     state = {
       content: "",
       reasoning: "",
@@ -488,23 +564,31 @@ function getChoiceState(
     };
     states.set(index, state);
   }
+
   return state;
 }
 
 function mergeToolCall(state: ChatChoiceState, delta: JsonRecord): void {
   const index = readNumber(delta.index) ?? state.toolCalls.size;
   const current = { ...state.toolCalls.get(index) };
+
   if (delta.id !== undefined) current.id = delta.id;
+
   if (delta.type !== undefined) current.type = delta.type;
   const incomingFunction = asRecord(delta.function);
+
   if (incomingFunction) {
     const currentFunction = { ...asRecord(current.function) };
+
     if (incomingFunction.name !== undefined) currentFunction.name = incomingFunction.name;
+
     if (incomingFunction.arguments !== undefined) {
       currentFunction.arguments = `${readString(currentFunction.arguments) ?? ""}${readString(incomingFunction.arguments) ?? ""}`;
     }
+
     current.function = currentFunction;
   }
+
   state.toolCalls.set(index, current);
 }
 
@@ -513,13 +597,18 @@ function chatOutput(states: Map<number, ChatChoiceState>): JsonRecord[] {
     .sort(([left], [right]) => left - right)
     .map(([, state]) => {
       const message = { role: state.role ?? "assistant" };
+
       if (state.content.length > 0) Object.assign(message, { content: state.content });
       else if (state.toolCalls.size > 0) Object.assign(message, { content: null });
+
       if (state.reasoning.length > 0) Object.assign(message, { reasoning: state.reasoning });
+
       if (state.reasoningDetails.length > 0) {
         Object.assign(message, { reasoningDetails: state.reasoningDetails });
       }
+
       if (state.refusal.length > 0) Object.assign(message, { refusal: state.refusal });
+
       if (state.toolCalls.size > 0) {
         Object.assign(message, {
           tool_calls: [...state.toolCalls.entries()]
@@ -527,6 +616,7 @@ function chatOutput(states: Map<number, ChatChoiceState>): JsonRecord[] {
             .map(([, toolCall]) => toolCall),
         });
       }
+
       return message;
     });
 }
@@ -541,18 +631,21 @@ function chatPartialFields(
     .sort(([left], [right]) => left - right)
     .map(([, state]) => state.finishReason)
     .filter((reason): reason is string => reason !== undefined);
+
   const fields: SpanFields = {
     output: states.size > 0 ? chatOutput(states) : undefined,
     usage,
     costUsd,
     ...finishReasonFields(finishReasons),
   };
+
   if (budget.truncated) {
     fields.attributes = {
       ...fields.attributes,
       [CAPTURE_TRUNCATED_ATTRIBUTE]: true,
     };
   }
+
   return fields;
 }
 
@@ -562,38 +655,53 @@ function recordChatChunk<T>(
   budget: StreamCaptureBudget,
 ) {
   const c = asRecord(chunk) ?? {};
+
   for (const choice of asArray(c.choices) ?? []) {
     const choiceRecord = asRecord(choice) ?? {};
     const state = getChoiceState(states, readNumber(choiceRecord.index) ?? 0, budget);
+
     if (!state) continue;
     const delta = asRecord(choiceRecord.delta) ?? {};
     const role = readString(delta.role);
+
     if (role !== undefined && budget.accept(role)) state.role = role;
     const content = readString(delta.content);
+
     if (content !== undefined && budget.accept(content)) {
       state.content += content;
     }
+
     const reasoning = readString(delta.reasoning);
+
     if (reasoning !== undefined && budget.accept(reasoning)) {
       state.reasoning += reasoning;
     }
+
     for (const detail of asArray(delta.reasoningDetails) ?? []) {
       if (budget.accept(detail)) state.reasoningDetails.push(detail);
     }
+
     const refusal = readString(delta.refusal);
+
     if (refusal !== undefined && budget.accept(refusal)) {
       state.refusal += refusal;
     }
+
     for (const toolCall of asArray(delta.toolCalls) ?? []) {
       const toolCallRecord = asRecord(toolCall);
+
       if (toolCallRecord && budget.accept(toolCallRecord)) mergeToolCall(state, toolCallRecord);
     }
+
     const finishReason = readString(choiceRecord.finishReason);
+
     if (finishReason) state.finishReason = finishReason;
   }
+
   const error = asRecord(c.error);
   const code = readNumber(error?.code) ?? readString(error?.code);
   const message = readString(error?.message);
+
   const update = {
     responseId: readString(c.id),
     responseModel: readString(c.model),
@@ -601,7 +709,9 @@ function recordChatChunk<T>(
     usage: chatUsage(c.usage),
     costUsd: usageCost(c.usage),
   };
+
   if (!error) return update;
+
   return {
     ...update,
     error: new Error(["chat stream error", code, message].filter(Boolean).join(": ")),
@@ -620,29 +730,36 @@ function observeStream(
 ): ReadableStream<JsonValue> {
   let reader: ReadableStreamDefaultReader<JsonValue> | undefined;
   let released = false;
+
   const getReader = () => {
     reader ??= source.getReader();
+
     return reader;
   };
+
   const release = () => {
     if (released || !reader) return;
     released = true;
     reader.releaseLock();
   };
+
   const observed = new ReadableStream<JsonValue>(
     {
       async pull(controller) {
         try {
           const result = await getReader().read();
           const receivedAt = performance.now();
+
           if (result.done) {
             release();
             end(observer.finish());
             controller.close();
+
             return;
           }
 
           const terminal = observer.record(result.value, receivedAt);
+
           if (terminal) end(terminal);
           controller.enqueue(result.value);
         } catch (error) {
@@ -665,7 +782,9 @@ function observeStream(
     },
     { highWaterMark: 0 },
   );
+
   Object.setPrototypeOf(observed, Object.getPrototypeOf(source));
+
   return observed;
 }
 
@@ -683,6 +802,7 @@ function createObservedChatStream(
   let responseModel: string | undefined;
   let streamError: Error | undefined;
   let sawFirst = false;
+
   return observeStream(
     source,
     {
@@ -731,14 +851,19 @@ function createObservedChatStream(
             responseModel: update.responseModel,
           });
         }
+
         if (update.responseId !== undefined) responseId = update.responseId;
+
         if (update.responseModel !== undefined) responseModel = update.responseModel;
+
         if (update.usagePresent) {
           usage = update.usage;
           costUsd = update.costUsd;
         }
+
         if ("error" in update && update.error) {
           streamError = update.error;
+
           return {
             ...chatPartialFields(states, usage, costUsd, budget),
             responseId,
@@ -746,6 +871,7 @@ function createObservedChatStream(
             error: update.error,
           };
         }
+
         return undefined;
       },
       finish(cause) {
@@ -754,9 +880,11 @@ function createObservedChatStream(
           responseId,
           responseModel,
         };
+
         if (cause !== undefined || streamError !== undefined) {
           fields.error = (cause ?? streamError) as Error;
         }
+
         return fields;
       },
     },
@@ -782,8 +910,10 @@ function responsesStreamOutputWithItem(
 ): JsonRecord[] {
   const items = [...states.entries()].map(([index, state]) => [index, state.item] as const);
   const position = items.findIndex(([index]) => index === outputIndex);
+
   if (position === -1) items.push([outputIndex, item]);
   else items[position] = [outputIndex, item];
+
   return [
     ...items.sort(([left], [right]) => left - right).map(([, value]) => value),
     ...syntheticEvents,
@@ -796,17 +926,24 @@ function hydrateResponsesItem(
   item: JsonRecord,
 ): ResponsesOutputItemState {
   const content = new Map<number, JsonRecord>();
+
   for (const [index, value] of (asArray(item.content) ?? []).entries()) {
     const part = asRecord(value);
+
     if (part) content.set(index, part);
   }
+
   const summary = new Map<number, JsonRecord>();
+
   for (const [index, value] of (asArray(item.summary) ?? []).entries()) {
     const part = asRecord(value);
+
     if (part) summary.set(index, part);
   }
+
   const state = { content, item, summary };
   states.set(outputIndex, state);
+
   return state;
 }
 
@@ -817,8 +954,10 @@ function getResponsesItem(
   type: string,
 ): ResponsesOutputItemState {
   const existing = states.get(outputIndex);
+
   if (existing) return existing;
   const reasoning = type.startsWith("response.reasoning_");
+
   const item = {
     id: eventString(event, "itemId", "item_id") ?? `output_${outputIndex}`,
     type: reasoning ? "reasoning" : "message",
@@ -826,6 +965,7 @@ function getResponsesItem(
     ...(reasoning ? { summary: [] } : { role: "assistant" }),
     content: [],
   };
+
   return hydrateResponsesItem(states, outputIndex, item);
 }
 
@@ -837,6 +977,7 @@ function responsesItemCandidate(
   summary?: JsonRecord,
 ) {
   const item = { ...state.item };
+
   if (contentIndex !== undefined && content !== undefined) {
     const values = new Map(state.content);
     values.set(contentIndex, content);
@@ -844,6 +985,7 @@ function responsesItemCandidate(
       .sort(([left], [right]) => left - right)
       .map(([, value]) => value);
   }
+
   if (summaryIndex !== undefined && summary !== undefined) {
     const values = new Map(state.summary);
     values.set(summaryIndex, summary);
@@ -851,6 +993,7 @@ function responsesItemCandidate(
       .sort(([left], [right]) => left - right)
       .map(([, value]) => value);
   }
+
   return item;
 }
 
@@ -860,6 +1003,7 @@ function syncResponsesItem(state: ResponsesOutputItemState): void {
       .sort(([left], [right]) => left - right)
       .map(([, content]) => content);
   }
+
   if (state.summary.size > 0) {
     state.item.summary = [...state.summary.entries()]
       .sort(([left], [right]) => left - right)
@@ -874,6 +1018,7 @@ function replaceResponsesOutput<T>(
 ): boolean {
   if (!budget.replace(output)) return false;
   budget.truncated = providerCapture.truncated;
+
   return true;
 }
 
@@ -883,6 +1028,7 @@ function responsesProviderEventPayload(event: JsonRecord, type: string) {
   const timings = debug?.timings;
   const sequenceNumber = eventNumber(event, "sequenceNumber", "sequence_number");
   const value = timings === undefined ? {} : { timings: responseNative(timings) };
+
   return sequenceNumber === undefined
     ? { type, debug: value }
     : { type, sequence_number: sequenceNumber, debug: value };
@@ -896,18 +1042,24 @@ function recordResponsesEvent(
   providerCapture: { truncated: boolean },
 ): boolean {
   const type = readString(event.type);
+
   if (!type) return false;
   const outputIndex = eventNumber(event, "outputIndex", "output_index") ?? 0;
 
   if (type === "response.output_item.added" || type === "response.output_item.done") {
     const replacement = type.endsWith(".done");
     const preflight = replacement ? new StreamCaptureBudget() : budget;
+
     if (!preflight.canAccept(event.item)) {
       budget.truncated = true;
+
       return false;
     }
+
     const item = asRecord(responseNative(event.item));
+
     if (!item) return false;
+
     if (replacement) {
       if (
         !replaceResponsesOutput(
@@ -920,23 +1072,30 @@ function recordResponsesEvent(
       }
     } else if (!budget.accept(item)) return false;
     hydrateResponsesItem(states, outputIndex, item);
+
     return true;
   }
 
   if (type === "response.content_part.added" || type === "response.content_part.done") {
     const replacement = type.endsWith(".done");
     const preflight = replacement ? new StreamCaptureBudget() : budget;
+
     if (!preflight.canAccept(event.part)) {
       budget.truncated = true;
+
       return false;
     }
+
     const part = asRecord(responseNative(event.part));
+
     if (!part) return false;
     const existing = states.get(outputIndex);
     const state = getResponsesItem(states, outputIndex, event, type);
     const contentIndex = eventNumber(event, "contentIndex", "content_index") ?? 0;
+
     if (replacement) {
       const item = responsesItemCandidate(state, contentIndex, part);
+
       if (
         !replaceResponsesOutput(
           budget,
@@ -945,11 +1104,13 @@ function recordResponsesEvent(
         )
       ) {
         if (!existing) states.delete(outputIndex);
+
         return false;
       }
     } else if (!budget.accept(part)) return false;
     state.content.set(contentIndex, part);
     syncResponsesItem(state);
+
     return true;
   }
 
@@ -958,6 +1119,7 @@ function recordResponsesEvent(
     const existingPart = states.get(outputIndex)?.content.get(contentIndex);
     const annotations = asArray(existingPart?.annotations) ?? [];
     const annotationIndex = eventNumber(event, "annotationIndex", "annotation_index");
+
     if (
       annotationIndex !== undefined &&
       (!Number.isSafeInteger(annotationIndex) ||
@@ -965,24 +1127,32 @@ function recordResponsesEvent(
         annotationIndex > annotations.length)
     ) {
       budget.truncated = true;
+
       return false;
     }
+
     if (!budget.canAccept(event.annotation)) {
       budget.truncated = true;
+
       return false;
     }
+
     const annotation = responseNative(event.annotation);
+
     if (annotation === undefined || !budget.accept(annotation)) return false;
     const state = getResponsesItem(states, outputIndex, event, type);
     let part = state.content.get(contentIndex);
+
     if (!part) {
       part = { type: "output_text", text: "", annotations: [] };
       state.content.set(contentIndex, part);
     }
+
     if (annotationIndex === undefined) annotations.push(annotation);
     else annotations[annotationIndex] = annotation;
     part.annotations = annotations;
     syncResponsesItem(state);
+
     return true;
   }
 
@@ -994,6 +1164,7 @@ function recordResponsesEvent(
   ) {
     const functionCall = type.startsWith("response.function_call_arguments");
     const existing = states.get(outputIndex);
+
     const state =
       existing ??
       hydrateResponsesItem(states, outputIndex, {
@@ -1002,17 +1173,22 @@ function recordResponsesEvent(
         status: "in_progress",
         ...(functionCall ? { arguments: "" } : { input: "" }),
       });
+
     const field = functionCall ? "arguments" : "input";
     const done = type.endsWith(".done");
     const value = done ? readString(event[field]) : readString(event.delta);
+
     if (value === undefined) return false;
+
     if (done) {
       const item = {
         ...state.item,
         [field]: value,
       };
+
       if (event.name !== undefined) item.name = event.name;
       item.status = "completed";
+
       if (
         !replaceResponsesOutput(
           budget,
@@ -1021,14 +1197,18 @@ function recordResponsesEvent(
         )
       ) {
         if (!existing) states.delete(outputIndex);
+
         return false;
       }
+
       state.item = item;
     } else {
       if (!budget.accept(value)) return false;
       state.item[field] = `${readString(state.item[field]) ?? ""}${value}`;
+
       if (event.name !== undefined) state.item.name = event.name;
     }
+
     return true;
   }
 
@@ -1038,17 +1218,23 @@ function recordResponsesEvent(
   ) {
     const replacement = type.endsWith(".done");
     const preflight = replacement ? new StreamCaptureBudget() : budget;
+
     if (!preflight.canAccept(event.part)) {
       budget.truncated = true;
+
       return false;
     }
+
     const part = asRecord(responseNative(event.part));
+
     if (!part) return false;
     const existing = states.get(outputIndex);
     const state = getResponsesItem(states, outputIndex, event, type);
     const summaryIndex = eventNumber(event, "summaryIndex", "summary_index") ?? 0;
+
     if (replacement) {
       const item = responsesItemCandidate(state, undefined, undefined, summaryIndex, part);
+
       if (
         !replaceResponsesOutput(
           budget,
@@ -1057,11 +1243,13 @@ function recordResponsesEvent(
         )
       ) {
         if (!existing) states.delete(outputIndex);
+
         return false;
       }
     } else if (!budget.accept(part)) return false;
     state.summary.set(summaryIndex, part);
     syncResponsesItem(state);
+
     return true;
   }
 
@@ -1091,12 +1279,16 @@ function recordResponsesEvent(
       event_type: type,
       payload: responsesProviderEventPayload(event, type),
     };
+
     if (!budget.accept(synthetic)) {
       budget.truncated = true;
       providerCapture.truncated = true;
+
       return false;
     }
+
     syntheticEvents.push(synthetic);
+
     return true;
   }
 
@@ -1114,26 +1306,33 @@ function recordResponsesEvent(
   ) {
     return false;
   }
+
   const done = type.endsWith(".done");
   const refusal = type.startsWith("response.refusal.");
   const value = done ? readString(event[refusal ? "refusal" : "text"]) : readString(event.delta);
+
   if (value === undefined || (!done && !budget.accept(value))) return false;
   const summaryText = type.startsWith("response.reasoning_summary_text.");
   const existing = states.get(outputIndex);
   const state = getResponsesItem(states, outputIndex, event, type);
+
   if (summaryText) {
     const summaryIndex = eventNumber(event, "summaryIndex", "summary_index") ?? 0;
     let summary = state.summary.get(summaryIndex);
+
     if (!summary) {
       summary = { type: "summary_text", text: "" };
+
       if (!done) {
         state.summary.set(summaryIndex, summary);
         syncResponsesItem(state);
       }
     }
+
     if (done) {
       const part = { ...summary, text: value };
       const item = responsesItemCandidate(state, undefined, undefined, summaryIndex, part);
+
       if (
         !replaceResponsesOutput(
           budget,
@@ -1142,17 +1341,22 @@ function recordResponsesEvent(
         )
       ) {
         if (!existing) states.delete(outputIndex);
+
         return false;
       }
+
       state.summary.set(summaryIndex, part);
       syncResponsesItem(state);
     } else {
       summary.text = `${readString(summary.text) ?? ""}${value}`;
     }
+
     return true;
   }
+
   const contentIndex = eventNumber(event, "contentIndex", "content_index") ?? 0;
   let part = state.content.get(contentIndex);
+
   if (!part) {
     if (refusal) {
       part = { type: "refusal", refusal: "" };
@@ -1161,19 +1365,24 @@ function recordResponsesEvent(
         type: type.startsWith("response.reasoning_text.") ? "reasoning_text" : "output_text",
         text: "",
       };
+
       if (type.startsWith("response.output_text.")) part.annotations = [];
     }
+
     if (!done) {
       state.content.set(contentIndex, part);
       syncResponsesItem(state);
     }
   }
+
   if (done) {
     const replacement = {
       ...part,
       [refusal ? "refusal" : "text"]: value,
     };
+
     const item = responsesItemCandidate(state, contentIndex, replacement);
+
     if (
       !replaceResponsesOutput(
         budget,
@@ -1182,8 +1391,10 @@ function recordResponsesEvent(
       )
     ) {
       if (!existing) states.delete(outputIndex);
+
       return false;
     }
+
     state.content.set(contentIndex, replacement);
     syncResponsesItem(state);
   } else if (refusal) {
@@ -1191,6 +1402,7 @@ function recordResponsesEvent(
   } else {
     part.text = `${readString(part.text) ?? ""}${value}`;
   }
+
   return true;
 }
 
@@ -1206,6 +1418,7 @@ function createObservedResponsesStream(
   const providerCapture = { truncated: false };
   let budget = new StreamCaptureBudget();
   let sawFirst = false;
+
   return observeStream(
     source,
     {
@@ -1214,6 +1427,7 @@ function createObservedResponsesStream(
 
         if (responseEventHasOutput(e)) span().recordOutputChunk?.(receivedAt);
         const response = asRecord(e.response);
+
         if (!sawFirst) {
           sawFirst = true;
           span().update({
@@ -1222,28 +1436,36 @@ function createObservedResponsesStream(
             responseModel: readString(response?.model),
           });
         }
+
         if (response) {
           const retainedOutput = partial.output;
           let output = retainedOutput;
+
           if (response.output !== undefined) {
             const responseBudget = new StreamCaptureBudget();
+
             if (!responseBudget.canAccept(response.output)) {
               budget.truncated = true;
             } else {
               const responseOutput = responseNative(response.output);
               const responseItems = asArray(responseOutput);
+
               if (responseItems === undefined) {
                 budget.truncated = true;
               } else {
                 const responseArtifact = [...responseItems, ...syntheticEvents];
+
                 if (!responseBudget.accept(responseArtifact)) {
                   budget.truncated = true;
                 } else {
                   outputStates.clear();
+
                   for (const [index, value] of responseItems.entries()) {
                     const item = asRecord(value);
+
                     if (item) hydrateResponsesItem(outputStates, index, item);
                   }
+
                   output = responseArtifact;
                   responseBudget.truncated = providerCapture.truncated;
                   budget = responseBudget;
@@ -1251,7 +1473,9 @@ function createObservedResponsesStream(
               }
             }
           }
+
           partial = responsesResponse(response, false);
+
           if (output !== undefined) partial.output = output;
         } else if (
           recordResponsesEvent(e, outputStates, syntheticEvents, budget, providerCapture)
@@ -1261,6 +1485,7 @@ function createObservedResponsesStream(
             output: responsesStreamOutput(outputStates, syntheticEvents),
           };
         }
+
         if (budget.truncated) {
           partial = {
             ...partial,
@@ -1277,26 +1502,35 @@ function createObservedResponsesStream(
             ...(Object.keys(attributes).length > 0 ? { attributes } : { attributes: undefined }),
           };
         }
+
         if (e.type === "response.failed") {
           partial = { ...partial, error: responseFailedError(response) };
+
           return partial;
         }
+
         if (e.type === "error") {
           partial = { ...partial, error: responseStreamError(e) };
+
           return partial;
         }
+
         if (e.type === "response.completed" || e.type === "response.incomplete") return partial;
+
         return undefined;
       },
       finish(cause) {
         const fields: SpanFields = { ...partial };
+
         if (budget.truncated) {
           fields.attributes = {
             ...partial.attributes,
             [CAPTURE_TRUNCATED_ATTRIBUTE]: true,
           };
         }
+
         if (cause !== undefined) fields.error = cause as Error;
+
         return fields;
       },
     },
@@ -1330,19 +1564,23 @@ function responseEventHasOutput(event: JsonRecord): boolean {
 
 function asReadableStream<T>(value: T): ReadableStream<JsonValue> | undefined {
   const stream = asRecord(value);
+
   return stream?.getReader instanceof Function ? (value as ReadableStream<JsonValue>) : undefined;
 }
 
 function finalizeResult<T>(value: T, context: TraceContext) {
   if (context.streaming) {
     const stream = asReadableStream(value);
+
     if (stream) {
       return context.operation === "chat"
         ? createObservedChatStream(stream, context.span, context.startedAt, context.end)
         : createObservedResponsesStream(stream, context.span, context.startedAt, context.end);
     }
   }
+
   context.end(context.mapResponse(value));
+
   return value;
 }
 
@@ -1353,6 +1591,7 @@ function wrapMethod<Fn extends Method>(
   mapResponse: <T>(response: T) => SpanFields,
 ): Fn {
   if (isWrapped(original)) return original;
+
   const wrapped = function <This>(this: This, ...args: JsonValue[]) {
     const request = asRecord(args[0]) ?? {};
     const bodyKey = operation === "chat" ? "chatRequest" : "responsesRequest";
@@ -1362,17 +1601,22 @@ function wrapMethod<Fn extends Method>(
     const parent = activeContext();
     let span: SpanHandle | undefined;
     let finish: ((fields?: SpanFields) => void) | undefined;
+
     const getSpan = () => {
       if (span) return span;
       span = startSpan(mapped.name, { ...mapped.fields, parent, startTime: startedAt });
       finish = endOnce(span);
+
       return span;
     };
+
     const end = (fields?: SpanFields) => {
       getSpan();
       finish?.(fields);
     };
+
     if (!streaming) getSpan();
+
     const context: TraceContext = {
       end,
       span: getSpan,
@@ -1381,8 +1625,10 @@ function wrapMethod<Fn extends Method>(
       streaming,
       mapResponse,
     };
+
     try {
       const result = original.apply(this, args as never[]);
+
       return Promise.resolve(result).then(
         (value) => finalizeResult(value, context),
         (cause) => {
@@ -1395,7 +1641,9 @@ function wrapMethod<Fn extends Method>(
       throw cause;
     }
   };
+
   const marked = markWrapped(wrapped as WrappedFunction, original);
+
   return marked as Fn;
 }
 
@@ -1407,8 +1655,10 @@ function patchInstanceMethod<T extends CallableRecord>(
   response: <R>(value: R) => SpanFields,
 ): void {
   const current = target[key];
+
   if (isWrapped(current) && Object.prototype.hasOwnProperty.call(target, key)) return;
   const original = isWrapped(current) ? current[ORIGINAL] : current;
+
   if (!(original instanceof Function)) return;
   const bound: Method = original.bind(target);
   const wrapped = wrapMethod(bound, operation, request, response);
@@ -1424,9 +1674,12 @@ function patchPrototype(
 ): () => void {
   const prototype = klass.prototype as CallableRecord;
   const original = prototype[key];
+
   if (!(original instanceof Function)) return () => {};
+
   const wrapped = wrapMethod(original as Method, operation, request, response);
   prototype[key] = wrapped;
+
   return () => {
     if (prototype[key] === wrapped) prototype[key] = original;
   };
@@ -1447,6 +1700,7 @@ export function wrapOpenRouter<T extends OpenRouterClient>(client: T): T {
   patchInstanceMethod(responses, "send", "responses", responsesRequest, responsesResponse);
   patchInstanceMethod(embeddings, "generate", "embeddings", embeddingsRequest, embeddingsResponse);
   wrappedClients.add(client);
+
   return client;
 }
 
@@ -1462,6 +1716,7 @@ export function instrumentOpenRouter(): void {
 
 export function uninstrumentOpenRouter(): void {
   if (!installed) return;
+
   for (const restore of restorePatches.reverse()) restore();
   restorePatches = [];
   installed = false;

--- a/packages/openrouter/src/index.ts
+++ b/packages/openrouter/src/index.ts
@@ -609,7 +609,7 @@ function recordChatChunk<T>(
 }
 
 interface StreamObserver {
-  record(value: JsonValue): SpanFields | undefined;
+  record(value: JsonValue, receivedAt: number): SpanFields | undefined;
   finish(cause?: unknown): SpanFields;
 }
 
@@ -634,13 +634,15 @@ function observeStream(
       async pull(controller) {
         try {
           const result = await getReader().read();
+          const receivedAt = performance.now();
           if (result.done) {
             release();
             end(observer.finish());
             controller.close();
             return;
           }
-          const terminal = observer.record(result.value);
+
+          const terminal = observer.record(result.value, receivedAt);
           if (terminal) end(terminal);
           controller.enqueue(result.value);
         } catch (error) {
@@ -684,8 +686,43 @@ function createObservedChatStream(
   return observeStream(
     source,
     {
-      record(chunk) {
+      record(chunk, receivedAt) {
         const update = recordChatChunk(chunk, states, budget);
+
+        if (
+          (asArray(asRecord(chunk)?.choices) ?? []).some((choice) => {
+            const delta = asRecord(asRecord(choice)?.delta);
+            const audio = asRecord(delta?.audio);
+
+            const reasoningDetails = [
+              ...(asArray(delta?.reasoningDetails) ?? []),
+              ...(asArray(delta?.reasoning_details) ?? []),
+            ];
+
+            return (
+              delta &&
+              ((typeof delta.content === "string" && delta.content.length > 0) ||
+                (typeof delta.reasoning === "string" && delta.reasoning.length > 0) ||
+                (typeof delta.refusal === "string" && delta.refusal.length > 0) ||
+                (typeof audio?.data === "string" && audio.data.length > 0) ||
+                reasoningDetails.some((detail) => {
+                  const record = asRecord(detail);
+
+                  return (
+                    (typeof record?.text === "string" && record.text.length > 0) ||
+                    (typeof record?.summary === "string" && record.summary.length > 0)
+                  );
+                }) ||
+                (asArray(delta.toolCalls) ?? []).some((toolCall) => {
+                  const fn = asRecord(asRecord(toolCall)?.function);
+
+                  return typeof fn?.arguments === "string" && fn.arguments.length > 0;
+                }))
+            );
+          })
+        )
+          span().recordOutputChunk?.(receivedAt);
+
         if (!sawFirst) {
           sawFirst = true;
           span().update({
@@ -1172,8 +1209,10 @@ function createObservedResponsesStream(
   return observeStream(
     source,
     {
-      record(event) {
+      record(event, receivedAt) {
         const e = eventRecord(event);
+
+        if (responseEventHasOutput(e)) span().recordOutputChunk?.(receivedAt);
         const response = asRecord(e.response);
         if (!sawFirst) {
           sawFirst = true;
@@ -1262,6 +1301,30 @@ function createObservedResponsesStream(
       },
     },
     end,
+  );
+}
+
+function responseEventHasOutput(event: JsonRecord): boolean {
+  return (
+    typeof event.type === "string" &&
+    [
+      "response.output_text.delta",
+      "response.refusal.delta",
+      "response.reasoning_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.function_call_arguments.delta",
+      "response.custom_tool_call_input.delta",
+      "response.code_interpreter_call_code.delta",
+      "response.mcp_call_arguments.delta",
+      "response.apply_patch_call_operation_diff.delta",
+      "response.fusion_call.panel.delta",
+      "response.fusion_call.panel.reasoning.delta",
+      "response.output_audio.delta",
+      "response.audio.delta",
+      "response.audio.transcript.delta",
+    ].includes(event.type) &&
+    typeof event.delta === "string" &&
+    event.delta.length > 0
   );
 }
 

--- a/packages/openrouter/tests/openrouter.test.ts
+++ b/packages/openrouter/tests/openrouter.test.ts
@@ -13,9 +13,11 @@ const SPAN_STATUS_UNSET = 0;
 const SPAN_STATUS_ERROR = 2;
 
 type JsonValue = string | number | boolean | null | undefined | JsonValue[] | JsonRecord;
+
 interface JsonRecord {
   [key: string]: JsonValue;
 }
+
 interface CapturedRequest {
   method: string;
   path: string;
@@ -31,6 +33,7 @@ function jsonResponse<T>(body: T): Response {
 
 function sseResponse(events: unknown[]): Response {
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -39,6 +42,7 @@ function sseResponse(events: unknown[]): Response {
 
 function openSseResponse(events: unknown[]): Response {
   const encoder = new TextEncoder();
+
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       for (const event of events) {
@@ -46,6 +50,7 @@ function openSseResponse(events: unknown[]): Response {
       }
     },
   });
+
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -54,6 +59,7 @@ function openSseResponse(events: unknown[]): Response {
 
 function createFakeFetcher(...responses: Response[]) {
   const requests: CapturedRequest[] = [];
+
   const fetcher: Fetcher = async (input, init) => {
     const request = input instanceof Request ? input : new Request(input, init);
     const text = await request.clone().text();
@@ -63,9 +69,12 @@ function createFakeFetcher(...responses: Response[]) {
       body: text.length > 0 ? JSON.parse(text) : undefined,
     });
     const response = responses.shift();
+
     if (!response) throw new Error(`unexpected request to ${request.url}`);
+
     return response;
   };
+
   return { fetcher, requests };
 }
 
@@ -83,6 +92,7 @@ function setupSpans(mask?: MaskFn): InMemorySpanExporter {
     },
     { spanExporter },
   );
+
   return spanExporter;
 }
 
@@ -92,6 +102,7 @@ function clientWith(fetcher: Fetcher, wrapped = true): OpenRouter {
     httpClient: new HTTPClient({ fetcher }),
     retryConfig: { strategy: "none" },
   });
+
   return wrapped ? wrapOpenRouter(client) : client;
 }
 
@@ -102,22 +113,28 @@ async function finishedSpans(
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await flush();
     const spans = exporter.getFinishedSpans();
+
     if (spans.length === expectedCount) return spans;
+
     if (spans.length > expectedCount) expect(spans).toHaveLength(expectedCount);
     await Promise.resolve();
   }
+
   expect(exporter.getFinishedSpans()).toHaveLength(expectedCount);
+
   return exporter.getFinishedSpans();
 }
 
 async function exportedSpan(exporter: InMemorySpanExporter): Promise<ReadableSpan> {
   const spans = await finishedSpans(exporter, 1);
+
   return spans[0]!;
 }
 
 function jsonAttr<T>(span: ReadableSpan, key: string): T {
   const value = span.attributes[key];
   expect(String(value)).toBe(value);
+
   return JSON.parse(String(value)) as T;
 }
 
@@ -137,7 +154,9 @@ function chatBody(
     prompt_tokens_details: { cached_tokens: 3, cache_write_tokens: 6 },
     completion_tokens_details: { reasoning_tokens: 2 },
   };
+
   if (options.cost !== undefined) Object.assign(usage, { cost: options.cost });
+
   if (options.upstreamCost !== undefined) {
     Object.assign(usage, {
       cost_details: {
@@ -147,6 +166,7 @@ function chatBody(
       },
     });
   }
+
   return {
     id,
     object: "chat.completion",
@@ -187,8 +207,11 @@ function chatChunk(
       },
     ],
   };
+
   if (options.usage !== undefined) Object.assign(chunk, { usage: options.usage });
+
   if (options.error !== undefined) Object.assign(chunk, { error: options.error });
+
   return chunk;
 }
 
@@ -197,6 +220,7 @@ function responsesBody(
   status: "completed" | "failed" | "incomplete" | "in_progress" = "completed",
 ) {
   const output = Array<JsonValue>();
+
   return {
     completed_at: status === "completed" ? 2 : null,
     created_at: 1,
@@ -253,12 +277,15 @@ function embeddingsBody(id: string) {
 
 async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   const chunks: unknown[] = [];
+
   for await (const chunk of stream) chunks.push(chunk);
+
   return chunks;
 }
 
 function prototypeMethod<T extends object>(target: T, key: string) {
   const value: unknown = Object.getOwnPropertyDescriptor(target, key)?.value;
+
   return value instanceof Function ? value : undefined;
 }
 
@@ -270,6 +297,7 @@ afterEach(async () => {
 
 test("chat maps request, response, usage, primary cost, provider, and sampling fields", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     jsonResponse(
       chatBody("chat_1", {
@@ -278,7 +306,9 @@ test("chat maps request, response, usage, primary cost, provider, and sampling f
       }),
     ),
   );
+
   const client = clientWith(fake.fetcher);
+
   const messages = [
     { role: "system" as const, content: "Be terse" },
     { role: "user" as const, content: "Say hello" },
@@ -350,6 +380,7 @@ test("chat maps request, response, usage, primary cost, provider, and sampling f
 
 test("cost falls back to upstream inference cost when usage cost is absent", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     jsonResponse(chatBody("chat_cost_fallback", { upstreamCost: 0.009 })),
   );
@@ -550,6 +581,7 @@ test.each(["chat", "responses"])("%s timestamps precede telemetry mapping", asyn
 
 test("consumed chat streams remain readable, reconstruct tool calls, and use final usage without request mutation", async () => {
   const spans = setupSpans();
+
   const finalUsage = {
     prompt_tokens: 11,
     completion_tokens: 6,
@@ -563,6 +595,7 @@ test("consumed chat streams remain readable, reconstruct tool calls, and use fin
       upstream_inference_prompt_cost: 0.006,
     },
   };
+
   const fake = createFakeFetcher(
     sseResponse([
       chatChunk("stream_1", { role: "assistant", content: "" }),
@@ -585,7 +618,9 @@ test("consumed chat streams remain readable, reconstruct tool calls, and use fin
       ),
     ]),
   );
+
   const client = clientWith(fake.fetcher);
+
   const request = {
     chatRequest: {
       model: "openai/gpt-4o",
@@ -597,6 +632,7 @@ test("consumed chat streams remain readable, reconstruct tool calls, and use fin
   const stream = await client.chat.send(request);
   expect(stream).toBeInstanceOf(ReadableStream);
   expect(stream).toBeInstanceOf(EventStream);
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const chunks = await collectStream(stream);
 
@@ -645,9 +681,11 @@ test("consumed chat streams remain readable, reconstruct tool calls, and use fin
 test("chat stream capture is bounded without dropping chunks or terminal metadata", async () => {
   const spans = setupSpans();
   const content = "x".repeat(1024);
+
   const deltas = Array.from({ length: 70 }, (_, index) =>
     chatChunk("stream_bounded", index === 0 ? { role: "assistant", content } : { content }),
   );
+
   const usage = { prompt_tokens: 3, completion_tokens: 70, total_tokens: 73, cost: 0.04 };
   const events = [...deltas, chatChunk("stream_bounded", {}, { finishReason: "stop", usage })];
   const fake = createFakeFetcher(sseResponse(events));
@@ -659,6 +697,7 @@ test("chat stream capture is bounded without dropping chunks or terminal metadat
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const chunks = await collectStream(stream);
 
@@ -675,6 +714,7 @@ test("chat stream capture is bounded without dropping chunks or terminal metadat
 
 test("chat stream chunk errors end one error span with partial output", async () => {
   const spans = setupSpans();
+
   const errorChunk = {
     id: "stream_error",
     object: "chat.completion.chunk",
@@ -683,6 +723,7 @@ test("chat stream chunk errors end one error span with partial output", async ()
     choices: [],
     error: { code: 502, message: "upstream disconnected" },
   };
+
   const fake = createFakeFetcher(
     openSseResponse([
       chatChunk("stream_error", { role: "assistant", content: "Partial" }),
@@ -697,6 +738,7 @@ test("chat stream chunk errors end one error span with partial output", async ()
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
   expect((await reader.read()).done).toBe(false);
@@ -716,6 +758,7 @@ test("chat stream chunk errors end one error span with partial output", async ()
 
 test("early chat stream cancellation captures partial output and ends once", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     sseResponse([
       chatChunk("stream_cancel", { role: "assistant", content: "First" }),
@@ -730,6 +773,7 @@ test("early chat stream cancellation captures partial output and ends once", asy
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
   const first = await reader.read();
@@ -746,6 +790,7 @@ test("early chat stream cancellation captures partial output and ends once", asy
 
 test("early Responses stream cancellation captures final text, reasoning, summary, and refusal", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.output_text.delta",
@@ -814,13 +859,16 @@ test("early Responses stream cancellation captures final text, reasoning, summar
       text: "Final summary",
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Cancel", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
+
   for (const _event of events) expect((await reader.read()).done).toBe(false);
   await reader.cancel("caller stopped");
 
@@ -850,6 +898,7 @@ test("early Responses stream cancellation captures final text, reasoning, summar
 
 test("early Responses stream cancellation retains partial text, reasoning, summary, and refusal", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.output_text.delta",
@@ -885,13 +934,16 @@ test("early Responses stream cancellation retains partial text, reasoning, summa
       delta: "Summary",
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Cancel", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
+
   for (const _event of events) expect((await reader.read()).done).toBe(false);
   await reader.cancel("caller stopped");
 
@@ -930,6 +982,7 @@ test.each(["response.created", "response.in_progress"])(
         content: [{ type: "output_text", text: "Retained output", annotations: [] }],
       },
     ];
+
     const events = [
       { type, sequence_number: 1, response },
       {
@@ -941,13 +994,16 @@ test.each(["response.created", "response.in_progress"])(
         },
       },
     ];
+
     const fake = createFakeFetcher(sseResponse(events));
 
     const stream = await clientWith(fake.fetcher).responses.send({
       responsesRequest: { model: "openai/gpt-4o", input: "Cancel", stream: true },
     });
+
     if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
     const reader = stream.getReader();
+
     for (const _event of events) expect((await reader.read()).done).toBe(false);
     await reader.cancel("caller stopped");
 
@@ -980,21 +1036,25 @@ test("terminal Responses output retains previously consumed provider events", as
       content: [{ type: "output_text", text: "Terminal output", annotations: [] }],
     },
   ];
+
   const providerEvent = {
     type: "response.image_generation_call.completed",
     sequence_number: 1,
     item_id: "image_terminal",
     output_index: 1,
   };
+
   const events = [
     providerEvent,
     { type: "response.completed", sequence_number: 2, response: terminal },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Complete", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -1022,6 +1082,7 @@ test("terminal Responses output preserves provider event truncation", async () =
       content: [{ type: "output_text", text: "Terminal output", annotations: [] }],
     },
   ];
+
   const events = [
     {
       type: "response.image_generation_call.partial_image",
@@ -1033,11 +1094,13 @@ test("terminal Responses output preserves provider event truncation", async () =
     },
     { type: "response.completed", sequence_number: 2, response: terminal },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Complete", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -1048,6 +1111,7 @@ test("terminal Responses output preserves provider event truncation", async () =
 
 test("early Responses stream cancellation retains hydrated items, content, annotations, and tool arguments", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.output_item.added",
@@ -1133,13 +1197,16 @@ test("early Responses stream cancellation retains hydrated items, content, annot
       },
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Weather", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
+
   for (const _event of events) expect((await reader.read()).done).toBe(false);
   await reader.cancel("caller stopped");
 
@@ -1179,6 +1246,7 @@ test("early Responses stream cancellation retains hydrated items, content, annot
 
 test("Responses stream capture rejects sparse annotation indexes", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.content_part.added",
@@ -1204,13 +1272,16 @@ test("Responses stream capture rejects sparse annotation indexes", async () => {
       },
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Annotate", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
+
   for (const _event of events) expect((await reader.read()).done).toBe(false);
   await reader.cancel("caller stopped");
 
@@ -1229,6 +1300,7 @@ test("Responses stream capture rejects sparse annotation indexes", async () => {
 
 test("Responses stream cancellation retains custom tools and bounded provider event payloads", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.output_item.added",
@@ -1411,13 +1483,16 @@ test("Responses stream cancellation retains custom tools and bounded provider ev
       },
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Tools", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
+
   for (const _event of events) expect((await reader.read()).done).toBe(false);
   await reader.cancel("caller stopped");
 
@@ -1469,10 +1544,12 @@ test("Responses streams map completed and failed terminal events", async () => {
   const spans = setupSpans();
   const completed = responsesBody("resp_completed", "completed");
   const failed = responsesBody("resp_failed", "failed");
+
   const fake = createFakeFetcher(
     sseResponse([{ type: "response.completed", sequence_number: 1, response: completed }]),
     sseResponse([{ type: "response.failed", sequence_number: 1, response: failed }]),
   );
+
   const client = clientWith(fake.fetcher);
 
   const completedStream = await client.responses.send({
@@ -1486,6 +1563,7 @@ test("Responses streams map completed and failed terminal events", async () => {
       stream: true,
     },
   });
+
   if (!(completedStream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(completedStream);
 
@@ -1496,16 +1574,20 @@ test("Responses streams map completed and failed terminal events", async () => {
       stream: true,
     },
   });
+
   if (!(failedStream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(failedStream);
 
   const finished = await finishedSpans(spans, 2);
+
   const completedSpan = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "resp_completed",
   );
+
   const failedSpan = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "resp_failed",
   );
+
   expect(completedSpan?.name).toBe("chat openai/gpt-4o");
   expect(completedSpan?.status.code).toBe(SPAN_STATUS_UNSET);
   expect(completedSpan?.attributes["gen_ai.provider.name"]).toBe("openrouter");
@@ -1527,12 +1609,14 @@ test("Responses streams map completed and failed terminal events", async () => {
 
 test("Responses streams capture SDK unknown-event wrappers", async () => {
   const spans = setupSpans();
+
   const usage = {
     input_tokens: 3,
     output_tokens: 2,
     total_tokens: 5,
     cost_details: { upstream_inference_cost: 0.004 },
   };
+
   const fake = createFakeFetcher(
     sseResponse([
       {
@@ -1567,17 +1651,20 @@ test("Responses streams capture SDK unknown-event wrappers", async () => {
       },
     ]),
   );
+
   const client = clientWith(fake.fetcher);
 
   const completedStream = await client.responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Complete", stream: true },
   });
+
   if (!(completedStream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const completedEvents = await collectStream(completedStream);
 
   const failedStream = await client.responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Fail", stream: true },
   });
+
   if (!(failedStream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(failedStream);
 
@@ -1586,12 +1673,15 @@ test("Responses streams capture SDK unknown-event wrappers", async () => {
     expect.objectContaining({ type: "UNKNOWN", isUnknown: true }),
   ]);
   const finished = await finishedSpans(spans, 2);
+
   const completedSpan = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "resp_raw_completed",
   );
+
   const failedSpan = finished.find(
     (span) => span.attributes["gen_ai.response.id"] === "resp_raw_failed",
   );
+
   expect(jsonAttr(completedSpan!, "gen_ai.output.messages")).toEqual([
     {
       id: "msg_raw",
@@ -1609,9 +1699,11 @@ test("Responses streams capture SDK unknown-event wrappers", async () => {
 
 test("stream spans are parented by the invocation context, not the consumer context", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     sseResponse([chatChunk("stream_parented", { role: "assistant", content: "Parented" })]),
   );
+
   const client = clientWith(fake.fetcher);
 
   const invocation = await startActiveSpan("invocation", async (parent) => {
@@ -1622,9 +1714,12 @@ test("stream spans are parented by the invocation context, not the consumer cont
         stream: true,
       },
     });
+
     return { stream, parentSpanId: parent.spanId };
   });
+
   const invocationStream = invocation.stream;
+
   if (!(invocationStream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await startActiveSpan("consumer", async () => collectStream(invocationStream));
 
@@ -1636,10 +1731,13 @@ test("stream spans are parented by the invocation context, not the consumer cont
 
 test("unconsumed streams export no span until the caller cancels", async () => {
   let captureCount = 0;
+
   const spans = setupSpans((value) => {
     captureCount += 1;
+
     return value;
   });
+
   const fake = createFakeFetcher(
     sseResponse([chatChunk("stream_unconsumed", { content: "Not consumed" })]),
   );
@@ -1651,6 +1749,7 @@ test("unconsumed streams export no span until the caller cancels", async () => {
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await flush();
   expect(spans.getFinishedSpans()).toHaveLength(0);
@@ -1669,12 +1768,14 @@ test.each([
 ])("chat stream capture accounts for JSON escape overhead from %s", async (_, character) => {
   const spans = setupSpans();
   const escaped = character.repeat(1024);
+
   const events = Array.from({ length: 70 }, (_, index) =>
     chatChunk(
       "stream_escaped",
       index === 0 ? { role: "assistant", content: escaped } : { content: escaped },
     ),
   );
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).chat.send({
@@ -1684,6 +1785,7 @@ test.each([
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   expect(await collectStream(stream)).toHaveLength(events.length);
 
@@ -1699,11 +1801,13 @@ test.each([
 
 test("chat streams bound choice-state creation without dropping chunks", async () => {
   const spans = setupSpans();
+
   const choices = Array.from({ length: 1200 }, (_, index) => ({
     index,
     delta: index === 0 ? { role: "assistant", content: "Hi" } : {},
     finish_reason: null,
   }));
+
   const fake = createFakeFetcher(
     sseResponse([
       {
@@ -1723,14 +1827,17 @@ test("chat streams bound choice-state creation without dropping chunks", async (
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   expect(await collectStream(stream)).toHaveLength(1);
 
   const span = await exportedSpan(spans);
+
   const output = jsonAttr<Array<{ role: string; content?: string }>>(
     span,
     "gen_ai.output.messages",
   );
+
   expect(output).toHaveLength(1024);
   expect(output[0]).toEqual({ role: "assistant", content: "Hi" });
   expect(span.attributes["telemetry.dev.capture.truncated"]).toBe(true);
@@ -1738,6 +1845,7 @@ test("chat streams bound choice-state creation without dropping chunks", async (
 
 test("multi-choice chat streams reconstruct every choice", async () => {
   const spans = setupSpans();
+
   const chunk = (deltas: Array<{ index: number; delta: JsonRecord; finish?: string }>) => ({
     id: "stream_multi",
     object: "chat.completion.chunk",
@@ -1749,6 +1857,7 @@ test("multi-choice chat streams reconstruct every choice", async () => {
       finish_reason: finish ?? null,
     })),
   });
+
   const fake = createFakeFetcher(
     sseResponse([
       chunk([
@@ -1769,6 +1878,7 @@ test("multi-choice chat streams reconstruct every choice", async () => {
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -1782,6 +1892,7 @@ test("multi-choice chat streams reconstruct every choice", async () => {
 
 test("non-2xx chat responses end one error span and propagate the failure", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     new Response(JSON.stringify({ error: { code: 500, message: "provider exploded" } }), {
       status: 500,
@@ -1826,6 +1937,7 @@ test("mid-stream body failures end one error span with partial output", async ()
   const spans = setupSpans();
   const encoder = new TextEncoder();
   let delivered = false;
+
   const body = new ReadableStream<Uint8Array>({
     pull(controller) {
       if (delivered) throw new Error("connection reset");
@@ -1837,6 +1949,7 @@ test("mid-stream body failures end one error span with partial output", async ()
       );
     },
   });
+
   const fake = createFakeFetcher(
     new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
   );
@@ -1848,6 +1961,7 @@ test("mid-stream body failures end one error span with partial output", async ()
       stream: true,
     },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await expect(collectStream(stream)).rejects.toThrow("connection reset");
 
@@ -1861,6 +1975,7 @@ test("mid-stream body failures end one error span with partial output", async ()
 
 test("Responses stream error events record numeric codes and end once", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     openSseResponse([
       {
@@ -1878,6 +1993,7 @@ test("Responses stream error events record numeric codes and end once", async ()
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Fail mid-stream", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const reader = stream.getReader();
   expect((await reader.read()).done).toBe(false);
@@ -1895,6 +2011,7 @@ test("Responses stream error events record numeric codes and end once", async ()
 test("final Responses text replaces delta-truncated output using a fresh budget", async () => {
   const spans = setupSpans();
   const delta = "y".repeat(1024);
+
   const deltas = Array.from({ length: 70 }, (_, sequenceNumber) => ({
     type: "response.output_text.delta",
     sequence_number: sequenceNumber,
@@ -1904,6 +2021,7 @@ test("final Responses text replaces delta-truncated output using a fresh budget"
     delta,
     logprobs: [],
   }));
+
   const events = [
     ...deltas,
     {
@@ -1916,11 +2034,13 @@ test("final Responses text replaces delta-truncated output using a fresh budget"
       logprobs: [],
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Long answer", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -1939,6 +2059,7 @@ test("final Responses text replaces delta-truncated output using a fresh budget"
 
 test("final Responses text preserves provider event truncation", async () => {
   const spans = setupSpans();
+
   const events = [
     {
       type: "response.image_generation_call.partial_image",
@@ -1958,11 +2079,13 @@ test("final Responses text preserves provider event truncation", async () => {
       logprobs: [],
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Long answer", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -1982,6 +2105,7 @@ test("final Responses text preserves provider event truncation", async () => {
 test("oversized final Responses text preserves bounded partial output", async () => {
   const spans = setupSpans();
   const delta = "y".repeat(1024);
+
   const deltas = Array.from({ length: 20 }, (_, sequenceNumber) => ({
     type: "response.output_text.delta",
     sequence_number: sequenceNumber,
@@ -1991,6 +2115,7 @@ test("oversized final Responses text preserves bounded partial output", async ()
     delta,
     logprobs: [],
   }));
+
   const events = [
     ...deltas,
     {
@@ -2003,19 +2128,23 @@ test("oversized final Responses text preserves bounded partial output", async ()
       logprobs: [],
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Long answer", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
+
   const output = jsonAttr<Array<{ content: Array<{ text: string }> }>>(
     span,
     "gen_ai.output.messages",
   );
+
   expect(output[0]?.content[0]?.text).toBe(delta.repeat(deltas.length));
   expect(output[0]?.content[0]?.text).not.toContain("z");
   expect(span.attributes["telemetry.dev.capture.truncated"]).toBe(true);
@@ -2024,6 +2153,7 @@ test("oversized final Responses text preserves bounded partial output", async ()
 test("small terminal Responses output replaces delta-truncated output", async () => {
   const spans = setupSpans();
   const delta = "y".repeat(1024);
+
   const deltas = Array.from({ length: 70 }, (_, sequenceNumber) => ({
     type: "response.output_text.delta",
     sequence_number: sequenceNumber,
@@ -2033,6 +2163,7 @@ test("small terminal Responses output replaces delta-truncated output", async ()
     delta,
     logprobs: [],
   }));
+
   const events = [
     ...deltas,
     {
@@ -2041,11 +2172,13 @@ test("small terminal Responses output replaces delta-truncated output", async ()
       response: responsesBody("resp_bounded"),
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Long answer", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   const received = await collectStream(stream);
 
@@ -2062,6 +2195,7 @@ test("small terminal Responses output replaces delta-truncated output", async ()
 test("oversized terminal Responses output preserves bounded partial output", async () => {
   const spans = setupSpans();
   const delta = "y".repeat(1024);
+
   const deltas = Array.from({ length: 20 }, (_, sequenceNumber) => ({
     type: "response.output_text.delta",
     sequence_number: sequenceNumber,
@@ -2071,6 +2205,7 @@ test("oversized terminal Responses output preserves bounded partial output", asy
     delta,
     logprobs: [],
   }));
+
   const terminal = responsesBody("resp_oversized");
   terminal.output = [
     {
@@ -2081,6 +2216,7 @@ test("oversized terminal Responses output preserves bounded partial output", asy
       content: [{ type: "output_text", text: "z".repeat(70 * 1024), annotations: [] }],
     },
   ];
+
   const events = [
     ...deltas,
     {
@@ -2089,19 +2225,23 @@ test("oversized terminal Responses output preserves bounded partial output", asy
       response: terminal,
     },
   ];
+
   const fake = createFakeFetcher(sseResponse(events));
 
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Long answer", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
   const span = await exportedSpan(spans);
+
   const output = jsonAttr<Array<{ content: Array<{ text: string }> }>>(
     span,
     "gen_ai.output.messages",
   );
+
   expect(output[0]?.content[0]?.text).toBe(delta.repeat(deltas.length));
   expect(output[0]?.content[0]?.text).not.toContain("z");
   expect(span.attributes["telemetry.dev.capture.truncated"]).toBe(true);
@@ -2126,6 +2266,7 @@ test("non-streaming failed Responses record a useful error", async () => {
 
 test("failed Responses stream events keep numeric provider error codes", async () => {
   const spans = setupSpans();
+
   const fake = createFakeFetcher(
     sseResponse([
       {
@@ -2144,6 +2285,7 @@ test("failed Responses stream events keep numeric provider error codes", async (
   const stream = await clientWith(fake.fetcher).responses.send({
     responsesRequest: { model: "openai/gpt-4o", input: "Fail", stream: true },
   });
+
   if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
   await collectStream(stream);
 
@@ -2194,6 +2336,7 @@ test("wrap and global instrumentation have parity, are idempotent, and restore p
     jsonResponse(responsesBody("global_response")),
     jsonResponse(embeddingsBody("global_embedding")),
   );
+
   const globalClient = clientWith(globalFake.fetcher, false);
   await globalClient.chat.send({
     chatRequest: {
@@ -2214,6 +2357,7 @@ test("wrap and global instrumentation have parity, are idempotent, and restore p
     jsonResponse(embeddingsBody("wrapped_embedding")),
     jsonResponse(chatBody("wrapped_after_restore", { cost: 0.012 })),
   );
+
   const wrappedClient = wrapOpenRouter(wrapOpenRouter(clientWith(wrappedFake.fetcher, false)));
   await wrappedClient.chat.send({
     chatRequest: {
@@ -2229,6 +2373,7 @@ test("wrap and global instrumentation have parity, are idempotent, and restore p
   });
 
   const initial = await finishedSpans(spans, 6);
+
   for (const id of [
     "global_chat",
     "global_response",
@@ -2267,6 +2412,7 @@ test("wrap and global instrumentation have parity, are idempotent, and restore p
 
 test("global uninstrumentation preserves later prototype patches", () => {
   const originalDescriptor = Object.getOwnPropertyDescriptor(Chat.prototype, "send");
+
   if (!originalDescriptor) throw new Error("Chat.prototype.send is missing");
   instrumentOpenRouter();
   const laterPatch = () => undefined;
@@ -2285,6 +2431,7 @@ test("global uninstrumentation preserves later prototype patches", () => {
 
 test("wrapped clients fail open when telemetry is not initialized", async () => {
   await shutdown();
+
   const fake = createFakeFetcher(
     jsonResponse(chatBody("no_telemetry", { content: "Still works" })),
   );

--- a/packages/openrouter/tests/openrouter.test.ts
+++ b/packages/openrouter/tests/openrouter.test.ts
@@ -5,7 +5,7 @@ import { Embeddings } from "@openrouter/sdk/sdk/embeddings.js";
 import { EventStream } from "@openrouter/sdk/lib/event-streams.js";
 import { Responses } from "@openrouter/sdk/sdk/responses.js";
 import { flush, init, type MaskFn, shutdown, startActiveSpan } from "@telemetry-dev/sdk";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 import { instrumentOpenRouter, uninstrumentOpenRouter, wrapOpenRouter } from "../src/index.ts";
 
@@ -265,6 +265,7 @@ function prototypeMethod<T extends object>(target: T, key: string) {
 afterEach(async () => {
   uninstrumentOpenRouter();
   await shutdown();
+  vi.restoreAllMocks();
 });
 
 test("chat maps request, response, usage, primary cost, provider, and sampling fields", async () => {
@@ -362,6 +363,189 @@ test("cost falls back to upstream inference cost when usage cost is absent", asy
 
   const span = await exportedSpan(spans);
   expect(span.attributes["gen_ai.usage.cost"]).toBe(0.009);
+});
+
+test("chat output chunks recognize decoded reasoning text but not opaque metadata", async () => {
+  const spans = setupSpans();
+
+  const fake = createFakeFetcher(
+    sseResponse([
+      chatChunk("tool_timing", { role: "assistant", content: "" }),
+      chatChunk("tool_timing", {
+        reasoning_details: [{ type: "reasoning.text", text: "Inspect" }],
+      }),
+      chatChunk("tool_timing", {
+        content: "once",
+        reasoning_details: [{ type: "reasoning.summary", summary: "Summary" }],
+      }),
+      chatChunk("tool_timing", {
+        reasoning_details: [{ type: "reasoning.summary", summary: "Summary only" }],
+      }),
+      chatChunk("tool_timing", {
+        reasoning_details: [{ type: "reasoning.summary", summary: "" }],
+      }),
+      chatChunk("tool_timing", {
+        reasoning_details: [
+          { type: "reasoning.encrypted", data: "opaque" },
+          { type: "reasoning.text", signature: "signed", text: "" },
+        ],
+      }),
+      chatChunk("tool_timing", {
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "weather", arguments: '{"city":' },
+          },
+        ],
+      }),
+      chatChunk("tool_timing", { tool_calls: [{ index: 0, function: { arguments: "" } }] }),
+      chatChunk("tool_timing", { content: null }),
+      chatChunk("tool_timing", { tool_calls: [{ index: 0, function: { arguments: '"Paris"}' } }] }),
+    ]),
+  );
+
+  const stream = await clientWith(fake.fetcher).chat.send({
+    chatRequest: {
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "Weather" }],
+      stream: true,
+    },
+  });
+
+  if (!(stream instanceof ReadableStream)) throw new Error("expected a readable stream");
+  expect(await collectStream(stream)).toHaveLength(10);
+  const span = await exportedSpan(spans);
+  expect(span).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 4 },
+  });
+});
+
+test("Responses output timing accepts code, MCP, and audio transcript deltas but excludes done snapshots", async () => {
+  const spans = setupSpans();
+
+  const outputEvents = [
+    { type: "response.code_interpreter_call_code.delta", delta: "print(1)" },
+    { type: "response.code_interpreter_call_code.done", code: "print(1)" },
+    { type: "response.mcp_call_arguments.delta", delta: '{"city":"Paris"}' },
+    { type: "response.mcp_call_arguments.delta", delta: "" },
+    { type: "response.mcp_call_arguments.done", arguments: '{"city":"Paris"}' },
+    { type: "response.audio.transcript.delta", delta: "Hello" },
+    { type: "response.audio.transcript.delta", delta: "" },
+    { type: "response.audio.transcript.delta", delta: " world" },
+    { type: "response.audio.transcript.done", transcript: "Hello world" },
+  ];
+
+  const fake = createFakeFetcher(
+    sseResponse([
+      ...outputEvents,
+      { type: "response.completed", response: responsesBody("resp_metric") },
+    ]),
+    openSseResponse(outputEvents),
+  );
+
+  const client = clientWith(fake.fetcher);
+
+  const completed = await client.responses.send({
+    responsesRequest: { model: "openai/gpt-4o", input: "Run", stream: true },
+  });
+
+  if (!(completed instanceof ReadableStream)) throw new Error("expected a readable stream");
+  await collectStream(completed);
+
+  const interrupted = await client.responses.send({
+    responsesRequest: { model: "openai/gpt-4o", input: "Run", stream: true },
+  });
+
+  if (!(interrupted instanceof ReadableStream)) throw new Error("expected a readable stream");
+  const reader = interrupted.getReader();
+
+  for (const _event of outputEvents) expect((await reader.read()).done).toBe(false);
+  await reader.cancel("caller stopped");
+
+  const finished = await finishedSpans(spans, 2);
+  expect(finished).toHaveLength(2);
+
+  for (const span of finished) {
+    expect(span).toMatchObject({
+      [Symbol.for("telemetry.dev.outputChunkHistogram")]: { count: 3 },
+    });
+  }
+});
+
+test.each(["chat", "responses"])("%s timestamps precede telemetry mapping", async (operation) => {
+  const spans = setupSpans();
+  let now = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+
+  const timings = [
+    [100, 30],
+    [240, 90],
+  ] as const;
+
+  let index = 0;
+
+  const source = new ReadableStream(
+    {
+      pull(controller) {
+        const timing = timings[index++];
+
+        if (!timing) {
+          controller.close();
+
+          return;
+        }
+
+        const [receivedAt, mappingMs] = timing;
+        now = receivedAt;
+        controller.enqueue(
+          operation === "chat"
+            ? {
+                get choices() {
+                  now = receivedAt + mappingMs;
+
+                  return [{ index: 0, delta: { content: "A" } }];
+                },
+              }
+            : {
+                get type() {
+                  now = receivedAt + mappingMs;
+
+                  return "response.output_text.delta";
+                },
+                delta: "A",
+              },
+        );
+      },
+    },
+    { highWaterMark: 0 },
+  );
+
+  const client = wrapOpenRouter({
+    chat: { send: async (_params: unknown) => source },
+    responses: { send: async (_params: unknown) => source },
+    embeddings: {},
+  });
+
+  const stream =
+    operation === "chat"
+      ? await client.chat.send({
+          chatRequest: { model: "openai/gpt-4o", messages: [], stream: true },
+        })
+      : await client.responses.send({
+          responsesRequest: { model: "openai/gpt-4o", input: "Hi", stream: true },
+        });
+
+  expect(await collectStream(stream)).toHaveLength(2);
+  expect(await exportedSpan(spans)).toMatchObject({
+    [Symbol.for("telemetry.dev.outputChunkHistogram")]: {
+      count: 1,
+      sum: 0.14,
+      min: 0.14,
+      max: 0.14,
+    },
+  });
 });
 
 test("consumed chat streams remain readable, reconstruct tool calls, and use final usage without request mutation", async () => {

--- a/packages/otel/src/attrs.ts
+++ b/packages/otel/src/attrs.ts
@@ -8,12 +8,15 @@ export const SCOPE_VERSION = "0.0.0";
 
 export function omitUndefined(attributes: Attributes): Attributes {
   const out: Attributes = {};
+
   for (const key of Object.keys(attributes)) {
     const value = attributes[key];
+
     if (value !== undefined) {
       out[key] = value;
     }
   }
+
   return out;
 }
 
@@ -29,7 +32,9 @@ export type JsonValue =
 
 export function jsonAttr<T>(value: T): string | undefined {
   if (value === undefined) return undefined;
+
   if (typeof value === "string") return value;
+
   try {
     return JSON.stringify(value);
   } catch {

--- a/packages/otel/src/config.ts
+++ b/packages/otel/src/config.ts
@@ -1,5 +1,7 @@
 export type LogLevel = "debug" | "info" | "warn" | "error";
+
 export type SdkLogLevel = LogLevel | "silent";
+
 export type ExportMode = "batched" | "immediate";
 
 export interface BatchOptions {
@@ -24,5 +26,6 @@ export const DEFAULT_BATCH: Required<BatchOptions> = {
 
 export function resolveEnv(): Record<string, string | undefined> {
   if (globalThis.process !== undefined && process.env) return process.env;
+
   return {};
 }

--- a/packages/otel/src/context.ts
+++ b/packages/otel/src/context.ts
@@ -12,6 +12,7 @@ import { jsonAttr } from "./attrs.ts";
 import { diag } from "./debug.ts";
 
 type AlsConstructor = new <T>() => AsyncLocalStorage<T>;
+
 type RuntimeGlobal = typeof globalThis & {
   AsyncLocalStorage?: AlsConstructor;
   process?: {
@@ -24,10 +25,13 @@ type RuntimeGlobal = typeof globalThis & {
 // Node >= 20.19 and Workers with nodejs_compat expose process.getBuiltinModule.
 function loadAls(): AlsConstructor | undefined {
   const g: RuntimeGlobal = globalThis;
+
   if (g.AsyncLocalStorage) return g.AsyncLocalStorage;
+
   try {
     return g.process?.getBuiltinModule?.("node:async_hooks")?.AsyncLocalStorage;
   } catch {}
+
   return undefined;
 }
 
@@ -48,6 +52,7 @@ export function activeContext(): Context {
 /** Run `fn` with `ctx` active in both our ALS and the global OTel context manager. */
 export function withContext<T>(ctx: Context, fn: () => T): T {
   const run = () => apiContext.with(ctx, fn);
+
   return als ? als.run(ctx, run) : run();
 }
 
@@ -66,8 +71,11 @@ const RESERVED_METADATA_KEYS = new Set(["userId", "sessionId", "user_id", "sessi
 
 export function buildPropagatedAttributes(attrs: PropagatedAttributes): Attributes {
   const out: Attributes = {};
+
   if (attrs.userId !== undefined) out["user.id"] = attrs.userId;
+
   if (attrs.sessionId !== undefined) out["gen_ai.conversation.id"] = attrs.sessionId;
+
   if (attrs.metadata) {
     for (const [key, value] of Object.entries(attrs.metadata)) {
       if (RESERVED_METADATA_KEYS.has(key)) {
@@ -76,10 +84,13 @@ export function buildPropagatedAttributes(attrs: PropagatedAttributes): Attribut
         );
         continue;
       }
+
       const attr = typeof value === "string" ? value : jsonAttr(value);
+
       if (attr !== undefined) out[`td.metadata.${key}`] = attr;
     }
   }
+
   return out;
 }
 
@@ -94,6 +105,7 @@ export function propagatedFromContext(ctx: Context): Attributes | undefined {
 export function propagateAttributes<T>(attributes: PropagatedAttributes, fn: () => T): T {
   const base = activeContext();
   const merged = { ...propagatedFromContext(base), ...buildPropagatedAttributes(attributes) };
+
   return withContext(base.setValue(PROPAGATED_KEY, merged), fn);
 }
 
@@ -112,19 +124,23 @@ export class AlsContextManager implements ContextManager {
     ...args: A
   ): ReturnType<F> {
     const cb = thisArg == null ? fn : fn.bind(thisArg);
+
     return this.storage.run(context, cb as (...args: A) => ReturnType<F>, ...args);
   }
 
   bind<T>(context: Context, target: T): T {
     if (typeof target === "function") {
       const storage = this.storage;
+
       const bound = function (this: unknown, ...args: unknown[]) {
         return storage.run(context, () =>
           (target as (...a: unknown[]) => unknown).apply(this, args),
         );
       };
+
       return bound as T;
     }
+
     return target;
   }
 
@@ -134,6 +150,7 @@ export class AlsContextManager implements ContextManager {
 
   disable(): this {
     this.storage.disable();
+
     return this;
   }
 }

--- a/packages/otel/src/debug.ts
+++ b/packages/otel/src/debug.ts
@@ -31,5 +31,6 @@ export function reportError(onError: ((error: Error) => void) | undefined, cause
   } catch {
     // onError itself must never propagate
   }
+
   diag.error(cause);
 }

--- a/packages/otel/src/generation.ts
+++ b/packages/otel/src/generation.ts
@@ -61,6 +61,7 @@ export function createGenerationEmitter(
   const core = coreFor(config);
   const transport: Transport = { fetchImpl: config.fetchImpl, onError: config.onError };
   const onError = config.onError;
+
   const sendSpans =
     overrides?.sendSpans ?? ((spans: ReadableSpan[]) => core.sendSpans(spans, transport));
 
@@ -72,6 +73,7 @@ export function createGenerationEmitter(
     overrides?.recordDuration ??
     ((seconds: number, attributes: Attributes) =>
       ensureMetrics().durationHistogram.record(seconds, attributes));
+
   const recordTokens =
     overrides?.recordTokens ??
     ((tokenType: "input" | "output", count: number, attributes: Attributes) =>
@@ -84,24 +86,30 @@ export function createGenerationEmitter(
     // Detach before the first await so overlapping flushes cannot share metrics.
     const pipeline = metrics;
     metrics = undefined;
+
     const p = (async () => {
       try {
         const sampled = spans.filter(isReadableSpan);
+
         if (sampled.length) await sendSpans(sampled);
       } catch (e) {
         onError?.(e instanceof Error ? e : String(e));
       }
+
       try {
         if (pipeline) await pipeline.shutdown();
       } catch (e) {
         onError?.(e instanceof Error ? e : String(e));
       }
     })();
+
     // Await export unless the serverless runtime receives the promise through waitUntil.
     if (config.waitUntil) {
       config.waitUntil(p);
+
       return Promise.resolve();
     }
+
     return p;
   };
 
@@ -130,18 +138,22 @@ function coreFor(config: GenerationEmitterConfig): EmitterCore {
   if (config.sampler) return buildCore(config);
   const key = `${config.sdkName}|${config.apiKey}|${config.baseUrl}|${config.environment}|${config.serviceName}`;
   const cached = cache.get(key);
+
   if (cached) return cached;
   const core = buildCore(config);
   cache.set(key, core);
+
   return core;
 }
 
 function buildCore(config: GenerationEmitterConfig): EmitterCore {
   const { apiKey, baseUrl, environment, serviceName, sdkName } = config;
+
   const resource = resourceFromAttributes({
     "service.name": serviceName,
     "deployment.environment.name": environment,
   });
+
   const headers = otlpHeaders(apiKey ?? "", sdkName);
 
   const provider = new BasicTracerProvider({ resource, sampler: sessionSampler(config.sampler) });
@@ -164,6 +176,7 @@ function buildCore(config: GenerationEmitterConfig): EmitterCore {
       exporter: createMetricExporter({ url: `${baseUrl}/v1/metrics`, headers }, transport),
       exportIntervalMillis: DORMANT_INTERVAL_MS,
     });
+
     const meterProvider = new MeterProvider({ resource, readers: [reader] });
     const meter = meterProvider.getMeter(sdkName, SCOPE_VERSION);
 
@@ -171,6 +184,7 @@ function buildCore(config: GenerationEmitterConfig): EmitterCore {
       unit: "s",
       advice: { explicitBucketBoundaries: DURATION_BUCKETS },
     });
+
     const tokenHistogram = meter.createHistogram("gen_ai.client.token.usage", {
       unit: "{token}",
       advice: { explicitBucketBoundaries: TOKEN_BUCKETS },

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -30,6 +30,8 @@ export {
   createMetricsPipeline,
   DORMANT_INTERVAL_MS,
   DURATION_BUCKETS,
+  OUTPUT_CHUNK_HISTOGRAM,
+  type OutputChunkHistogram,
   type MetricsPipeline,
   TOKEN_BUCKETS,
 } from "./metrics.ts";

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -1,4 +1,5 @@
 export { jsonAttr, omitUndefined, SCOPE_NAME, SCOPE_VERSION } from "./attrs.ts";
+
 export {
   type BatchOptions,
   DEFAULT_BASE_URL,
@@ -8,6 +9,7 @@ export {
   resolveEnv,
   type SdkLogLevel,
 } from "./config.ts";
+
 export {
   activeContext,
   als,
@@ -19,12 +21,15 @@ export {
   propagatedFromContext,
   withContext,
 } from "./context.ts";
+
 export { diag, reportError, setLogLevel } from "./debug.ts";
+
 export {
   createGenerationEmitter,
   type GenerationEmitter,
   type GenerationEmitterOverrides,
 } from "./generation.ts";
+
 export {
   BATCHED_METRIC_INTERVAL_MS,
   createMetricsPipeline,
@@ -35,12 +40,15 @@ export {
   type MetricsPipeline,
   TOKEN_BUCKETS,
 } from "./metrics.ts";
+
 export {
   createTelemetrySpanExporter,
   TelemetrySpanProcessor,
   type TelemetrySpanProcessorOptions,
 } from "./otel.ts";
+
 export { StampingSpanProcessor, type StampingProcessorOptions } from "./processor.ts";
+
 export {
   sessionIdOf,
   type SessionRootOf,
@@ -50,6 +58,7 @@ export {
   sha256,
   withSessionParent,
 } from "./session.ts";
+
 export {
   createLogExporter,
   createMetricExporter,

--- a/packages/otel/src/metrics.ts
+++ b/packages/otel/src/metrics.ts
@@ -18,6 +18,7 @@ import { omitUndefined, SCOPE_NAME, SCOPE_VERSION } from "./attrs.ts";
 export const DURATION_BUCKETS = [
   0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
+
 export const TOKEN_BUCKETS = [
   1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
 ];
@@ -128,6 +129,7 @@ export function createMetricsPipeline({
     unit: "s",
     advice: { explicitBucketBoundaries: DURATION_BUCKETS },
   });
+
   const tokenHistogram = meter.createHistogram("gen_ai.client.token.usage", {
     unit: "{token}",
     advice: { explicitBucketBoundaries: TOKEN_BUCKETS },
@@ -140,13 +142,16 @@ export function createMetricsPipeline({
 
   const record = (span: ReadableSpan): void => {
     const operation = span.attributes["gen_ai.operation.name"];
+
     if (operation?.constructor !== String || !DURATION_OPERATIONS.has(`${operation}`)) return;
+
     const attrs: Attributes = omitUndefined({
       "gen_ai.operation.name": operation,
       "gen_ai.provider.name": stringAttr(span.attributes["gen_ai.provider.name"]),
       "gen_ai.request.model": stringAttr(span.attributes["gen_ai.request.model"]),
       "gen_ai.response.model": stringAttr(span.attributes["gen_ai.response.model"]),
     });
+
     const durationSec = span.duration[0] + span.duration[1] / 1e9;
     const errorType = stringAttr(span.attributes["error.type"]);
     durationHistogram.record(
@@ -195,10 +200,13 @@ export function createMetricsPipeline({
 
     if (!TOKEN_OPERATIONS.has(operation)) return;
     const inputTokens = span.attributes["gen_ai.usage.input_tokens"];
+
     if (inputTokens?.constructor === Number) {
       tokenHistogram.record(inputTokens, { ...attrs, "gen_ai.token.type": "input" });
     }
+
     const outputTokens = span.attributes["gen_ai.usage.output_tokens"];
+
     if (outputTokens?.constructor === Number) {
       tokenHistogram.record(outputTokens, { ...attrs, "gen_ai.token.type": "output" });
     }

--- a/packages/otel/src/metrics.ts
+++ b/packages/otel/src/metrics.ts
@@ -1,8 +1,12 @@
-import type { Attributes } from "@opentelemetry/api";
+import { ValueType, type Attributes } from "@opentelemetry/api";
+import { millisToHrTime } from "@opentelemetry/core";
 import type { Resource } from "@opentelemetry/resources";
 import {
   MeterProvider,
   PeriodicExportingMetricReader,
+  AggregationTemporality,
+  DataPointType,
+  type MetricProducer,
   type PushMetricExporter,
 } from "@opentelemetry/sdk-metrics";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
@@ -25,6 +29,20 @@ const TOKEN_OPERATIONS = new Set(["chat", "invoke_agent", "embeddings"]);
 export const DORMANT_INTERVAL_MS = 2 ** 31 - 1;
 export const BATCHED_METRIC_INTERVAL_MS = 60_000;
 
+export interface OutputChunkHistogram {
+  count: number;
+  sum: number;
+  min: number;
+  max: number;
+  bucketCounts: number[];
+}
+
+export const OUTPUT_CHUNK_HISTOGRAM = Symbol.for("telemetry.dev.outputChunkHistogram");
+
+type SpanWithOutputChunks = ReadableSpan & {
+  [OUTPUT_CHUNK_HISTOGRAM]?: OutputChunkHistogram;
+};
+
 export interface MetricsPipeline {
   record(span: ReadableSpan): void;
   forceFlush(): Promise<void>;
@@ -44,7 +62,65 @@ export function createMetricsPipeline({
   exporter: PushMetricExporter;
   exportIntervalMillis: number;
 }): MetricsPipeline {
-  const reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis });
+  const pending = new Map<string, { attributes: Attributes; value: OutputChunkHistogram }>();
+  let collectionStart = millisToHrTime(Date.now());
+
+  const producer: MetricProducer = {
+    collect: () => {
+      const endTime = millisToHrTime(Date.now());
+
+      const points = [...pending.values()].map(({ attributes, value }) => ({
+        attributes,
+        startTime: collectionStart,
+        endTime,
+        value: {
+          count: value.count,
+          sum: value.sum,
+          min: value.min,
+          max: value.max,
+          buckets: { boundaries: [...DURATION_BUCKETS], counts: [...value.bucketCounts] },
+        },
+      }));
+
+      pending.clear();
+      collectionStart = endTime;
+
+      return Promise.resolve({
+        errors: [],
+        resourceMetrics: {
+          resource,
+          scopeMetrics: [
+            {
+              scope: { name: SCOPE_NAME, version: SCOPE_VERSION },
+              metrics:
+                points.length === 0
+                  ? []
+                  : [
+                      {
+                        descriptor: {
+                          name: "gen_ai.client.operation.time_per_output_chunk",
+                          description: "",
+                          unit: "s",
+                          valueType: ValueType.DOUBLE,
+                        },
+                        aggregationTemporality: AggregationTemporality.DELTA,
+                        dataPointType: DataPointType.HISTOGRAM,
+                        dataPoints: points,
+                      },
+                    ],
+            },
+          ],
+        },
+      });
+    },
+  };
+
+  const reader = new PeriodicExportingMetricReader({
+    exporter,
+    exportIntervalMillis,
+    metricProducers: [producer],
+  });
+
   const meterProvider = new MeterProvider({ resource, readers: [reader] });
   const meter = meterProvider.getMeter(SCOPE_NAME, SCOPE_VERSION);
 
@@ -55,6 +131,11 @@ export function createMetricsPipeline({
   const tokenHistogram = meter.createHistogram("gen_ai.client.token.usage", {
     unit: "{token}",
     advice: { explicitBucketBoundaries: TOKEN_BUCKETS },
+  });
+
+  const firstChunkHistogram = meter.createHistogram("gen_ai.client.operation.time_to_first_chunk", {
+    unit: "s",
+    advice: { explicitBucketBoundaries: DURATION_BUCKETS },
   });
 
   const record = (span: ReadableSpan): void => {
@@ -72,6 +153,46 @@ export function createMetricsPipeline({
       durationSec,
       errorType !== undefined ? { ...attrs, "error.type": errorType } : attrs,
     );
+    const firstChunkSeconds = span.attributes["gen_ai.response.time_to_first_chunk"];
+
+    if (
+      operation === "chat" &&
+      typeof firstChunkSeconds === "number" &&
+      Number.isFinite(firstChunkSeconds) &&
+      firstChunkSeconds >= 0
+    ) {
+      firstChunkHistogram.record(firstChunkSeconds, attrs);
+    }
+
+    const outputChunks = (span as SpanWithOutputChunks)[OUTPUT_CHUNK_HISTOGRAM];
+
+    if (operation === "chat" && outputChunks?.count) {
+      let key = JSON.stringify(attrs);
+      let chunkAttrs = attrs;
+
+      if (!pending.has(key) && pending.size >= 1999) {
+        key = "overflow";
+        chunkAttrs = { "otel.metric.overflow": true };
+      }
+
+      const existing = pending.get(key);
+
+      if (existing) {
+        existing.value.count += outputChunks.count;
+        existing.value.sum += outputChunks.sum;
+        existing.value.min = Math.min(existing.value.min, outputChunks.min);
+        existing.value.max = Math.max(existing.value.max, outputChunks.max);
+        outputChunks.bucketCounts.forEach((count, index) => {
+          existing.value.bucketCounts[index] += count;
+        });
+      } else {
+        pending.set(key, {
+          attributes: chunkAttrs,
+          value: { ...outputChunks, bucketCounts: [...outputChunks.bucketCounts] },
+        });
+      }
+    }
+
     if (!TOKEN_OPERATIONS.has(operation)) return;
     const inputTokens = span.attributes["gen_ai.usage.input_tokens"];
     if (inputTokens?.constructor === Number) {

--- a/packages/otel/src/otel.ts
+++ b/packages/otel/src/otel.ts
@@ -64,10 +64,12 @@ export class TelemetrySpanProcessor implements SpanProcessor {
   constructor(options: TelemetrySpanProcessorOptions = {}) {
     const env = resolveEnv();
     const apiKey = options.apiKey ?? env.TELEMETRY_DEV_API_KEY;
+
     const baseUrl = (options.baseUrl ?? env.TELEMETRY_DEV_BASE_URL ?? DEFAULT_BASE_URL).replace(
       /\/+$/,
       "",
     );
+
     const transport: Transport = {
       fetchImpl: options.fetch ?? globalThis.fetch,
       onError: options.onError,
@@ -82,20 +84,24 @@ export class TelemetrySpanProcessor implements SpanProcessor {
             transport,
           )
         : undefined);
+
     if (!exporter) {
       diag.debug(
         "no api key (apiKey option or TELEMETRY_DEV_API_KEY); TelemetrySpanProcessor is a no-op",
       );
+
       return;
     }
 
     const exportMode = options.exportMode ?? "batched";
+
     if (options.metrics !== false && apiKey) {
       const resource = resourceFromAttributes({
         "service.name": options.serviceName ?? env.OTEL_SERVICE_NAME ?? "unknown_service",
         "deployment.environment.name":
           options.environment ?? env.TELEMETRY_DEV_ENVIRONMENT ?? "production",
       });
+
       this.metrics = createMetricsPipeline({
         resource,
         exporter: createMetricExporter(
@@ -149,18 +155,22 @@ export function createTelemetrySpanExporter(
 ): SpanExporter {
   const env = resolveEnv();
   const apiKey = options.apiKey ?? env.TELEMETRY_DEV_API_KEY;
+
   const baseUrl = (options.baseUrl ?? env.TELEMETRY_DEV_BASE_URL ?? DEFAULT_BASE_URL).replace(
     /\/+$/,
     "",
   );
+
   if (!apiKey) {
     diag.debug("no api key (apiKey option or TELEMETRY_DEV_API_KEY); exporter is a no-op");
+
     return {
       export: (_spans, resultCallback) => resultCallback({ code: ExportResultCode.SUCCESS }),
       forceFlush: () => Promise.resolve(),
       shutdown: () => Promise.resolve(),
     };
   }
+
   return createTraceExporter(
     { url: `${baseUrl}/v1/traces`, headers: otlpHeaders(apiKey) },
     {

--- a/packages/otel/src/processor.ts
+++ b/packages/otel/src/processor.ts
@@ -40,10 +40,12 @@ export class StampingSpanProcessor implements SpanProcessor {
       const propagated =
         (parentContext.getValue(PROPAGATED_KEY) as Attributes | undefined) ??
         propagatedFromContext(activeContext());
+
       if (propagated) span.setAttributes(propagated);
     } catch (error) {
       reportError(this.options.onError, error);
     }
+
     this.inner.onStart(span, parentContext);
   }
 
@@ -54,11 +56,13 @@ export class StampingSpanProcessor implements SpanProcessor {
       // A throwing filter must not drop spans; fall through and export.
       reportError(this.options.onError, error);
     }
+
     try {
       this.options.recordMetrics?.(span);
     } catch (error) {
       reportError(this.options.onError, error);
     }
+
     this.inner.onEnd(span);
   }
 

--- a/packages/otel/src/session.ts
+++ b/packages/otel/src/session.ts
@@ -36,10 +36,12 @@ export function sessionSampler(inner: Sampler = samplerFromEnv()): Sampler {
     shouldSample(ctx, traceId, name, kind, attributes, links) {
       const parent = trace.getSpan(ctx);
       const original = parent && SESSION_PARENTS.get(parent);
+
       if (original) {
         const span = trace.getSpan(original);
         ctx = span ? trace.setSpan(ctx, span) : trace.deleteSpan(ctx);
       }
+
       return inner.shouldSample(ctx, traceId, name, kind, attributes, links);
     },
     toString: () => `SessionSampler{${inner.toString()}}`,
@@ -49,6 +51,7 @@ export function sessionSampler(inner: Sampler = samplerFromEnv()): Sampler {
 function samplerFromEnv(): Sampler {
   const name = getStringFromEnv("OTEL_TRACES_SAMPLER") ?? "parentbased_always_on";
   let root: Sampler;
+
   switch (name) {
     case "always_off":
     case "parentbased_always_off":
@@ -58,20 +61,25 @@ function samplerFromEnv(): Sampler {
     case "parentbased_traceidratio": {
       const ratio = getNumberFromEnv("OTEL_TRACES_SAMPLER_ARG");
       const valid = ratio !== undefined && Number.isFinite(ratio) && ratio >= 0 && ratio <= 1;
+
       if (!valid) diag.error("Invalid OTEL_TRACES_SAMPLER_ARG; using 1.");
       root = new TraceIdRatioBasedSampler(valid ? ratio : 1);
       break;
     }
+
     case "always_on":
     case "parentbased_always_on":
       root = new AlwaysOnSampler();
       break;
     default:
       diag.error(`Invalid OTEL_TRACES_SAMPLER "${name}"; using parentbased_always_on.`);
+
       return new ParentBasedSampler({ root: new AlwaysOnSampler() });
   }
+
   return name.startsWith("parentbased_") ? new ParentBasedSampler({ root }) : root;
 }
+
 /**
  * Deterministic remote parent for a session: every root span of the session joins one trace
  * (`traceId = SHA-256(apiKey ‖ 0x00 ‖ sessionId)[0:16]`, parent `spanId = digest[16:24]`).
@@ -81,6 +89,7 @@ function samplerFromEnv(): Sampler {
  */
 export function sessionSpanContext(apiKey: string | undefined, sessionId: string): SpanContext {
   const digest = sha256(new TextEncoder().encode(`${apiKey ?? ""}\0${sessionId}`));
+
   return {
     traceId: hex(digest.subarray(0, 16)),
     spanId: hex(digest.subarray(16, 24)),
@@ -106,22 +115,28 @@ export function sessionRootTracerProvider(
 ): TracerProvider {
   const reparent = (name: string, options: SpanOptions | undefined, ctx: Context): Context => {
     if (!apiKey) return ctx;
+
     try {
       const sessionId = sessionRootOf(name, options?.attributes ?? {});
+
       return sessionId
         ? setSessionParent(options?.root ? trace.deleteSpan(ctx) : ctx, sessionId, apiKey)
         : ctx;
     } catch (error) {
       reportError(onError, error);
+
       return ctx;
     }
   };
+
   return {
     getTracer(name, version, options): Tracer {
       const tracer = inner.getTracer(name, version, options);
+
       return {
         startSpan: (spanName, spanOptions, ctx = apiContext.active()) => {
           const parent = reparent(spanName, spanOptions, ctx);
+
           return tracer.startSpan(
             spanName,
             parent !== ctx && spanOptions?.root ? { ...spanOptions, root: false } : spanOptions,
@@ -136,6 +151,7 @@ export function sessionRootTracerProvider(
           const spanOptions = args.length > 1 ? (args[0] as SpanOptions) : undefined;
           const ctx = args.length > 2 ? (args[1] as Context) : apiContext.active();
           const parent = reparent(spanName, spanOptions, ctx);
+
           return tracer.startActiveSpan(
             spanName,
             parent !== ctx && spanOptions?.root
@@ -161,7 +177,9 @@ export function withSessionParent(
 ): Context {
   if (!apiKey || !sessionId) return ctx;
   const current = trace.getSpanContext(ctx);
+
   if (current && isSpanContextValid(current)) return ctx;
+
   return setSessionParent(ctx, sessionId, apiKey);
 }
 
@@ -170,20 +188,26 @@ function setSessionParent(ctx: Context, sessionId: string, apiKey: string): Cont
     ...sessionSpanContext(apiKey, sessionId),
     traceState: trace.getSpanContext(ctx)?.traceState,
   });
+
   SESSION_PARENTS.set(parent, ctx);
+
   return trace.setSpan(ctx, parent);
 }
 
 export function sessionIdOf(ctx: Context, attributes?: Attributes): string | undefined {
   const explicit = attributes?.["gen_ai.conversation.id"];
+
   if (typeof explicit === "string") return explicit;
   const propagated = propagatedFromContext(ctx)?.["gen_ai.conversation.id"];
+
   return typeof propagated === "string" ? propagated : undefined;
 }
 
 function hex(bytes: Uint8Array): string {
   let s = "";
+
   for (const b of bytes) s += b.toString(16).padStart(2, "0");
+
   return s;
 }
 
@@ -205,6 +229,7 @@ export function sha256(bytes: Uint8Array): Uint8Array {
   const h = new Uint32Array([
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
   ]);
+
   const padded = new Uint8Array(Math.ceil((bytes.length + 9) / 64) * 64);
   padded.set(bytes);
   padded[bytes.length] = 0x80;
@@ -213,8 +238,10 @@ export function sha256(bytes: Uint8Array): Uint8Array {
   view.setUint32(padded.length - 8, Math.floor(bitLen / 0x100000000));
   view.setUint32(padded.length - 4, bitLen >>> 0);
   const w = new Uint32Array(64);
+
   for (let off = 0; off < padded.length; off += 64) {
     for (let i = 0; i < 16; i++) w[i] = view.getUint32(off + i * 4);
+
     for (let i = 16; i < 64; i++) {
       const x = w[i - 15]!;
       const y = w[i - 2]!;
@@ -222,6 +249,7 @@ export function sha256(bytes: Uint8Array): Uint8Array {
       const s1 = rotr(y, 17) ^ rotr(y, 19) ^ (y >>> 10);
       w[i] = (w[i - 16]! + s0 + w[i - 7]! + s1) >>> 0;
     }
+
     let a = h[0]!;
     let b = h[1]!;
     let c = h[2]!;
@@ -230,10 +258,12 @@ export function sha256(bytes: Uint8Array): Uint8Array {
     let f = h[5]!;
     let g = h[6]!;
     let hh = h[7]!;
+
     for (let i = 0; i < 64; i++) {
       const t1 =
         (hh + (rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)) + ((e & f) ^ (~e & g)) + K[i]! + w[i]!) >>>
         0;
+
       const t2 = ((rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)) + ((a & b) ^ (a & c) ^ (b & c))) >>> 0;
       hh = g;
       g = f;
@@ -244,6 +274,7 @@ export function sha256(bytes: Uint8Array): Uint8Array {
       b = a;
       a = (t1 + t2) >>> 0;
     }
+
     h[0] = (h[0]! + a) >>> 0;
     h[1] = (h[1]! + b) >>> 0;
     h[2] = (h[2]! + c) >>> 0;
@@ -253,8 +284,11 @@ export function sha256(bytes: Uint8Array): Uint8Array {
     h[6] = (h[6]! + g) >>> 0;
     h[7] = (h[7]! + hh) >>> 0;
   }
+
   const out = new Uint8Array(32);
   const outView = new DataView(out.buffer);
+
   for (let i = 0; i < 8; i++) outView.setUint32(i * 4, h[i]!);
+
   return out;
 }

--- a/packages/otel/src/transport.ts
+++ b/packages/otel/src/transport.ts
@@ -48,7 +48,9 @@ const HTTP_MONTHS = [
   "Nov",
   "Dec",
 ];
+
 const HTTP_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 const HTTP_WEEKDAYS_LONG = [
   "Sunday",
   "Monday",
@@ -75,10 +77,12 @@ const httpDateTimestamp = (
   const hour = Number(hourText);
   const minute = Number(minuteText);
   const second = Number(secondText);
+
   if (hour > 23 || minute > 59 || second > 59) return undefined;
   const date = new Date(0);
   date.setUTCFullYear(year, month, day);
   date.setUTCHours(hour, minute, second, 0);
+
   if (
     date.getUTCFullYear() !== year ||
     date.getUTCMonth() !== month ||
@@ -87,6 +91,7 @@ const httpDateTimestamp = (
   ) {
     return undefined;
   }
+
   return date.getTime();
 };
 
@@ -95,6 +100,7 @@ const parseHttpDate = (value: string): number | undefined => {
     /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/.exec(
       value,
     );
+
   if (imf)
     return httpDateTimestamp(
       ...(imf.slice(1) as [string, string, string, string, string, string, string]),
@@ -105,12 +111,15 @@ const parseHttpDate = (value: string): number | undefined => {
     /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/.exec(
       value,
     );
+
   if (rfc850) {
     const fields = rfc850.slice(1) as [string, string, string, string, string, string, string];
     const currentYear = new Date().getUTCFullYear();
     let year = Math.floor(currentYear / 100) * 100 + Number(fields[3]);
+
     if (year > currentYear + 50) year -= 100;
     fields[3] = String(year);
+
     return httpDateTimestamp(...fields, HTTP_WEEKDAYS_LONG);
   }
 
@@ -118,8 +127,10 @@ const parseHttpDate = (value: string): number | undefined => {
     /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( [1-9]|[12]\d|3[01]) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/.exec(
       value,
     );
+
   if (!asctime) return undefined;
   const [, weekday, month, day, hour, minute, second, year] = asctime;
+
   return httpDateTimestamp(
     weekday!,
     day!.trim(),
@@ -134,9 +145,12 @@ const parseHttpDate = (value: string): number | undefined => {
 
 const retryAfterMs = (res: Response): number | undefined => {
   const header = res.headers.get("retry-after")?.trim();
+
   if (header === undefined) return undefined;
+
   if (/^\d+$/.test(header)) return Number(header) * 1000;
   const at = parseHttpDate(header);
+
   return at === undefined ? undefined : Math.max(0, at - Date.now());
 };
 
@@ -146,10 +160,12 @@ const delay = (ms: number, signal?: AbortSignal) =>
       clearTimeout(timer);
       reject(signal?.reason ?? new Error("telemetry.dev export aborted"));
     };
+
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
       resolve();
     }, ms);
+
     if (signal?.aborted) onAbort();
     else signal?.addEventListener("abort", onAbort, { once: true });
   });
@@ -175,6 +191,7 @@ export const postOtlp = async ({
 }) => {
   for (let attempt = 0; ; attempt += 1) {
     let retryAfter: number | undefined;
+
     try {
       const res = await fetchImpl(url, {
         method: "POST",
@@ -182,7 +199,9 @@ export const postOtlp = async ({
         body: body as RequestInit["body"],
         signal,
       });
+
       retryAfter = retryAfterMs(res);
+
       if (
         res.ok ||
         !isRetryableStatus(res.status) ||
@@ -190,8 +209,10 @@ export const postOtlp = async ({
         (retryAfter !== undefined && retryAfter > MAX_RETRY_AFTER_MS)
       ) {
         await cancelBody(res);
+
         return res;
       }
+
       await cancelBody(res);
     } catch (error) {
       if (attempt === RETRY_DELAYS_MS.length) throw error;
@@ -209,11 +230,14 @@ export async function maybeGzip(
   if (body.byteLength <= GZIP_THRESHOLD_BYTES || globalThis.CompressionStream === undefined) {
     return { body };
   }
+
   try {
     const stream = new Blob([body as Uint8Array<ArrayBuffer>])
       .stream()
       .pipeThrough(new CompressionStream("gzip"));
+
     const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+
     return { body: compressed, contentEncoding: "gzip" };
   } catch {
     // Fail-open: ship uncompressed rather than lose the batch.
@@ -230,9 +254,11 @@ async function postSerialized(
   signal?: AbortSignal,
 ): Promise<void> {
   const { body: finalBody, contentEncoding } = await maybeGzip(body);
+
   const headers = contentEncoding
     ? { ...target.headers, "content-encoding": contentEncoding }
     : target.headers;
+
   const res = await post({
     fetchImpl: transport.fetchImpl,
     url: target.url,
@@ -240,13 +266,16 @@ async function postSerialized(
     body: finalBody,
     signal,
   });
+
   if (!res.ok) {
     const retryAfter = retryAfterMs(res);
     const retryAfterHeader = res.headers.get("retry-after")?.trim();
+
     const retryDetail =
       retryAfter !== undefined && retryAfter > MAX_RETRY_AFTER_MS && retryAfterHeader !== undefined
         ? `; retry-after ${retryAfterHeader} exceeds ${MAX_RETRY_AFTER_MS / 1000}s retry cap`
         : "";
+
     throw new Error(`telemetry.dev ${label} ingest failed: ${res.status}${retryDetail}`);
   }
 }
@@ -254,8 +283,10 @@ async function postSerialized(
 const createExportLifecycle = (transport: Transport) => {
   const inFlight = new Set<Promise<void>>();
   let shutDown = false;
+
   const configuredTimeoutMillis =
     transport.exportTimeoutMillis ?? DEFAULT_BATCH.exportTimeoutMillis;
+
   const timeoutMillis =
     Number.isFinite(configuredTimeoutMillis) &&
     configuredTimeoutMillis >= 0 &&
@@ -278,16 +309,20 @@ const createExportLifecycle = (transport: Transport) => {
     if (shutDown) {
       const error = new Error("telemetry.dev exporter is shut down");
       callback(resultCallback, { code: ExportResultCode.FAILED, error });
+
       return;
     }
+
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout>;
+
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
         controller.abort();
         reject(new Error(`telemetry.dev export timed out after ${timeoutMillis}ms`));
       }, timeoutMillis);
     });
+
     let tracked: Promise<void>;
     tracked = Promise.race([Promise.resolve().then(() => send(controller.signal)), timeout])
       .then(
@@ -306,8 +341,10 @@ const createExportLifecycle = (transport: Transport) => {
   };
 
   const forceFlush = () => Promise.all(inFlight).then(() => undefined);
+
   const shutdown = () => {
     shutDown = true;
+
     return forceFlush();
   };
 
@@ -329,23 +366,30 @@ function createOtlpBatchSender<T>(
 ): (items: T[], signal: AbortSignal) => Promise<void> {
   const send = async (items: T[], signal: AbortSignal): Promise<void> => {
     const body = serializer.serializeRequest(items);
+
     if (!body || body.byteLength === 0) return;
+
     if (body.byteLength > MAX_BODY_BYTES) {
       if (items.length > 1) {
         const mid = Math.ceil(items.length / 2);
         await send(items.slice(0, mid), signal);
         await send(items.slice(mid), signal);
+
         return;
       }
+
       // A single record beyond the limit can never be accepted; drop it instead of wedging the batch.
       reportError(
         transport.onError,
         new Error(`telemetry.dev: ${label} record exceeds max export size, dropped`),
       );
+
       return;
     }
+
     await postSerialized(body, target, transport, label, postOtlp, signal);
   };
+
   return send;
 }
 
@@ -356,7 +400,9 @@ export function createTraceExporter(target: OtlpTarget, transport: Transport): S
     transport,
     "trace",
   );
+
   const lifecycle = createExportLifecycle(transport);
+
   return {
     export(spans, resultCallback) {
       lifecycle.exportBatch((signal) => send(spans, signal), resultCallback);
@@ -373,7 +419,9 @@ export function createLogExporter(target: OtlpTarget, transport: Transport): Log
     transport,
     "log",
   );
+
   const lifecycle = createExportLifecycle(transport);
+
   return {
     export(logs, resultCallback) {
       lifecycle.exportBatch((signal) => send(logs, signal), resultCallback);
@@ -385,15 +433,18 @@ export function createLogExporter(target: OtlpTarget, transport: Transport): Log
 
 export function createMetricExporter(target: OtlpTarget, transport: Transport): PushMetricExporter {
   const lifecycle = createExportLifecycle(transport);
+
   return {
     export(resourceMetrics: ResourceMetrics, resultCallback) {
       lifecycle.exportBatch(async (signal) => {
         const hasData = resourceMetrics.scopeMetrics.some((scope) =>
           scope.metrics.some((metric) => metric.dataPoints.length > 0),
         );
+
         const body = hasData
           ? ProtobufMetricsSerializer.serializeRequest(resourceMetrics)
           : undefined;
+
         if (body !== undefined && body.byteLength > 0) {
           await postSerialized(body, target, transport, "metric", postOtlp, signal);
         }

--- a/packages/otel/tests/otel-byo.test.ts
+++ b/packages/otel/tests/otel-byo.test.ts
@@ -36,15 +36,18 @@ afterEach(() => {
 
 function byoSetup(options?: ConstructorParameters<typeof TelemetrySpanProcessor>[0]) {
   const exporter = new InMemorySpanExporter();
+
   const processor = new TelemetrySpanProcessor({
     exportMode: "immediate",
     spanExporter: exporter,
     ...options,
   });
+
   const provider = new BasicTracerProvider({
     sampler: sessionSampler(),
     spanProcessors: [processor],
   });
+
   return { exporter, processor, provider, tracer: provider.getTracer("user-app") };
 }
 
@@ -88,6 +91,7 @@ test("spanFilter narrows what gets exported", async () => {
   const { exporter, processor, tracer } = byoSetup({
     spanFilter: (span) => span.name.startsWith("keep"),
   });
+
   tracer.startSpan("keep-me").end();
   tracer.startSpan("drop-me").end();
   await processor.forceFlush();
@@ -97,6 +101,7 @@ test("spanFilter narrows what gets exported", async () => {
 test("without an api key or exporter override the processor is a silent no-op", async () => {
   const previous = process.env.TELEMETRY_DEV_API_KEY;
   delete process.env.TELEMETRY_DEV_API_KEY;
+
   try {
     const processor = new TelemetrySpanProcessor();
     const provider = new BasicTracerProvider({ spanProcessors: [processor] });
@@ -117,30 +122,38 @@ test("forceFlush and shutdown resolve", async () => {
 test("createTelemetrySpanExporter is a no-op without a key and real otherwise", async () => {
   const previous = process.env.TELEMETRY_DEV_API_KEY;
   delete process.env.TELEMETRY_DEV_API_KEY;
+
   try {
     const noop = createTelemetrySpanExporter();
+
     const code = await new Promise<number>((resolve) =>
       noop.export([], (result) => resolve(result.code)),
     );
+
     expect(code).toBe(0);
     await noop.shutdown();
 
     const calls: Array<{ url: string; method?: string }> = [];
+
     const fetchImpl: typeof fetch = (input, init) => {
       calls.push({
         url: input instanceof URL ? input.href : input instanceof Request ? input.url : input,
         method: init?.method,
       });
+
       return Promise.resolve(new Response(null, { status: 200 }));
     };
+
     const exporter = createTelemetrySpanExporter({
       apiKey: "td_live_x",
       baseUrl: "https://ingest.example/",
       fetch: fetchImpl,
     });
+
     const provider = new BasicTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(exporter)],
     });
+
     try {
       provider.getTracer("public-exporter").startSpan("exported").end();
       await provider.forceFlush();
@@ -155,22 +168,28 @@ test("createTelemetrySpanExporter is a no-op without a key and real otherwise", 
 
 test("createTelemetrySpanExporter honors a timeout beyond the default", async () => {
   vi.useFakeTimers();
+
   try {
     let signal: AbortSignal | undefined;
     const results: number[] = [];
     const source = new InMemorySpanExporter();
+
     const provider = new BasicTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(source)],
     });
+
     provider.getTracer("timeout-source").startSpan("exported").end();
+
     const exporter = createTelemetrySpanExporter({
       apiKey: "td_live_x",
       exportTimeoutMillis: 35_000,
       fetch: (_input, init) => {
         signal = init!.signal!;
+
         return new Promise(() => undefined);
       },
     });
+
     exporter.export(source.getFinishedSpans(), (result) => results.push(result.code));
     await Promise.resolve();
     await Promise.resolve();
@@ -191,19 +210,26 @@ test("createTelemetrySpanExporter honors a timeout beyond the default", async ()
 test("metrics are skipped without an api key even when enabled", async () => {
   const previous = process.env.TELEMETRY_DEV_API_KEY;
   delete process.env.TELEMETRY_DEV_API_KEY;
+
   try {
     const calls: string[] = [];
+
     const fetchImpl: typeof fetch = (input) => {
       calls.push(input instanceof URL ? input.href : input instanceof Request ? input.url : input);
+
       return Promise.resolve(new Response(null, { status: 200 }));
     };
+
     const exporter = new InMemorySpanExporter();
+
     const processor = new TelemetrySpanProcessor({
       spanExporter: exporter,
       metrics: true,
       fetch: fetchImpl,
     });
+
     const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+
     try {
       const span = provider.getTracer("x").startSpan("chat");
       span.setAttribute("gen_ai.operation.name", "chat");
@@ -222,6 +248,7 @@ test("metrics are skipped without an api key even when enabled", async () => {
 test("global tracer interop: registered provider receives raw OTel API spans", async () => {
   const { exporter, processor, provider } = byoSetup();
   trace.setGlobalTracerProvider(provider);
+
   try {
     trace.getTracer("third-party").startSpan("via-global").end();
     await processor.forceFlush();
@@ -235,6 +262,7 @@ test("sha256 matches the FIPS vector", () => {
   const hex = Array.from(sha256(new TextEncoder().encode("abc")), (b) =>
     b.toString(16).padStart(2, "0"),
   ).join("");
+
   expect(hex).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
 });
 
@@ -265,6 +293,7 @@ test("sessionRootTracerProvider keeps roots for missing inputs and callback erro
   const errors: Error[] = [];
   const noKey = sessionRootTracerProvider(provider, undefined, () => "s1");
   const noSession = sessionRootTracerProvider(provider, "td_live_k", () => "");
+
   const broken = sessionRootTracerProvider(
     provider,
     "td_live_k",
@@ -287,6 +316,7 @@ test("sessionRootTracerProvider keeps roots for missing inputs and callback erro
     "broken",
     "active-broken",
   ]);
+
   for (const span of finished) expect(span.parentSpanContext).toBeUndefined();
   expect(errors.map((error) => error.message)).toEqual([
     "session root failed",
@@ -302,11 +332,14 @@ test("session roots use the BYO root sampler, not the synthetic parent flags", a
   ]) {
     const policy = new ParentBasedSampler({ root });
     const provider = new BasicTracerProvider({ sampler: sessionSampler(policy) });
+
     try {
       const tracer = provider.getTracer("byo");
+
       for (let i = 0; i < 20; i++) {
         const parent = withSessionParent(ROOT_CONTEXT, `session-${i}`, "td_live_k");
         const id = trace.getSpanContext(parent)!.traceId;
+
         const expected = policy.shouldSample(
           ROOT_CONTEXT,
           id,
@@ -315,6 +348,7 @@ test("session roots use the BYO root sampler, not the synthetic parent flags", a
           {},
           [],
         ).decision;
+
         const span = tracer.startSpan("turn", {}, parent);
         expect(span.isRecording()).toBe(expected !== SamplingDecision.NOT_RECORD);
         expect(span.spanContext().traceFlags & TraceFlags.SAMPLED).toBe(
@@ -331,14 +365,18 @@ test("session roots use the BYO root sampler, not the synthetic parent flags", a
 
 test("session roots and children keep real parent sampling, tracestate, and baggage", async () => {
   context.setGlobalContextManager(new AlsContextManager(als!));
+
   const provider = new BasicTracerProvider({
     sampler: sessionSampler(new ParentBasedSampler({ root: new AlwaysOffSampler() })),
   });
+
   const tracer = sessionRootTracerProvider(provider, "td_live_k", (name) =>
     name === "turn" ? "s1" : undefined,
   ).getTracer("framework");
+
   const baggage = propagation.createBaggage({ tenant: { value: "kept" } });
   const traceState = createTraceState("vendor=kept");
+
   try {
     for (const isRemote of [false, true]) {
       for (const traceFlags of [TraceFlags.NONE, TraceFlags.SAMPLED]) {
@@ -349,6 +387,7 @@ test("session roots and children keep real parent sampling, tracestate, and bagg
           isRemote,
           traceState,
         };
+
         const ctx = propagation.setBaggage(trace.setSpanContext(ROOT_CONTEXT, parent), baggage);
         expect(withSessionParent(ctx, "s1", "td_live_k")).toBe(ctx);
         context.with(ctx, () =>
@@ -387,6 +426,7 @@ test("session roots and children keep real parent sampling, tracestate, and bagg
 
 test("session sampling keeps baggage changed after attaching the session parent", async () => {
   const exporter = new InMemorySpanExporter();
+
   const provider = new BasicTracerProvider({
     sampler: sessionSampler(
       new ParentBasedSampler({
@@ -405,21 +445,26 @@ test("session sampling keeps baggage changed after attaching the session parent"
     ),
     spanProcessors: [new SimpleSpanProcessor(exporter)],
   });
+
   try {
     const tracer = provider.getTracer("byo");
+
     const before = propagation.setBaggage(
       ROOT_CONTEXT,
       propagation.createBaggage({
         tenant: { value: "denied" },
       }),
     );
+
     const parent = withSessionParent(before, "s1", "td_live_k");
+
     const allowed = propagation.setBaggage(
       parent,
       propagation.createBaggage({
         tenant: { value: "allowed" },
       }),
     );
+
     tracer.startSpan("allowed", {}, allowed).end();
     tracer.startSpan("denied", {}, parent).end();
     tracer.startSpan("removed", {}, propagation.deleteBaggage(allowed)).end();
@@ -451,10 +496,12 @@ test("session samplers keep record-only results, attributes, and tracestate", as
       },
     ],
   });
+
   try {
     const span = provider
       .getTracer("byo")
       .startSpan("turn", {}, withSessionParent(ROOT_CONTEXT, "s1", "td_live_k"));
+
     expect(span.isRecording()).toBe(true);
     expect(span.spanContext().traceFlags & TraceFlags.SAMPLED).toBe(TraceFlags.NONE);
     expect(span.spanContext().traceState?.serialize()).toBe("vendor=record");
@@ -477,6 +524,7 @@ test.each([
   vi.stubEnv("OTEL_TRACES_SAMPLER", mode);
   vi.stubEnv("OTEL_TRACES_SAMPLER_ARG", arg);
   const provider = new BasicTracerProvider({ sampler: sessionSampler() });
+
   try {
     const tracer = provider.getTracer("byo");
     const ordinary = tracer.startSpan("ordinary", {}, ROOT_CONTEXT);
@@ -486,6 +534,7 @@ test.each([
     expect(span.isRecording()).toBe(root);
     expect(span.spanContext().traceId).toBe("9e21d32713f05502cf537dba02d3d6fe");
     span.end();
+
     for (const [traceFlags, expected] of [
       [TraceFlags.NONE, unsampled],
       [TraceFlags.SAMPLED, sampled],
@@ -496,6 +545,7 @@ test.each([
         traceFlags,
         isRemote: true,
       });
+
       const child = tracer.startSpan("child", {}, withSessionParent(ctx, "s1", "td_live_k"));
       expect(child.isRecording()).toBe(expected);
       child.end();
@@ -511,10 +561,12 @@ test.each([undefined, "", "NaN", "Infinity", "-0.1", "1.1"])(
     vi.stubEnv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio");
     vi.stubEnv("OTEL_TRACES_SAMPLER_ARG", arg);
     const provider = new BasicTracerProvider({ sampler: sessionSampler() });
+
     try {
       const span = provider
         .getTracer("byo")
         .startSpan("turn", {}, withSessionParent(ROOT_CONTEXT, "s1", "td_live_k"));
+
       expect(span.isRecording()).toBe(true);
       span.end();
     } finally {

--- a/packages/otel/tests/transport.test.ts
+++ b/packages/otel/tests/transport.test.ts
@@ -40,6 +40,7 @@ interface Call {
 
 function makeFetch(statuses: number[], headers?: Record<string, string>) {
   const calls: Call[] = [];
+
   const fetchImpl: typeof fetch = (input, init) => {
     if (!init) throw new Error("expected request init");
     calls.push({
@@ -48,23 +49,30 @@ function makeFetch(statuses: number[], headers?: Record<string, string>) {
       body: init.body as Uint8Array,
     });
     const status = statuses[Math.min(calls.length - 1, statuses.length - 1)]!;
+
     return Promise.resolve(new Response(null, { status, headers }));
   };
+
   return { calls, fetchImpl };
 }
 
 function makeSpans(count: number, attrBytes = 0): ReadableSpan[] {
   const exporter = new InMemorySpanExporter();
+
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(exporter)],
     spanLimits: { attributeValueLengthLimit: 10_000_000 },
   });
+
   const tracer = provider.getTracer("test");
+
   for (let i = 0; i < count; i += 1) {
     const span = tracer.startSpan(`span-${i}`);
+
     if (attrBytes > 0) span.setAttribute("payload", "p".repeat(attrBytes));
     span.end();
   }
+
   return exporter.getFinishedSpans();
 }
 
@@ -115,10 +123,12 @@ const exportMetrics = (
 
 test("retries on 429/503 then succeeds", async () => {
   const { calls, fetchImpl } = makeFetch([429, 503, 200]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl },
   );
+
   const code = await exportSpans(exporter, makeSpans(1));
   expect(code).toBe(ExportResultCode.SUCCESS);
   expect(calls).toHaveLength(3);
@@ -130,10 +140,12 @@ test("retries on 429/503 then succeeds", async () => {
 test("does not retry non-retryable statuses and reports the failure", async () => {
   const errors: unknown[] = [];
   const { calls, fetchImpl } = makeFetch([400]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl, onError: (e) => errors.push(e) },
   );
+
   const code = await exportSpans(exporter, makeSpans(1));
   expect(code).toBe(ExportResultCode.FAILED);
   expect(calls).toHaveLength(1);
@@ -142,12 +154,14 @@ test("does not retry non-retryable statuses and reports the failure", async () =
 
 test("gives up after exhausting retries", async () => {
   const { calls, fetchImpl } = makeFetch([503, 503, 503]);
+
   const res = await postOtlp({
     fetchImpl,
     url: "https://ingest.example/v1/traces",
     headers: {},
     body: new Uint8Array([1]),
   });
+
   expect(res.status).toBe(503);
   expect(calls).toHaveLength(3);
 });
@@ -155,10 +169,12 @@ test("gives up after exhausting retries", async () => {
 test("exhausted retries surface as a failed export with onError", async () => {
   const errors: unknown[] = [];
   const { calls, fetchImpl } = makeFetch([503, 503, 503]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl, onError: (e) => errors.push(e) },
   );
+
   const code = await exportSpans(exporter, makeSpans(1));
   expect(code).toBe(ExportResultCode.FAILED);
   expect(calls).toHaveLength(3);
@@ -168,10 +184,12 @@ test("exhausted retries surface as a failed export with onError", async () => {
 test("reports retry-after values beyond the local cap", async () => {
   const errors: unknown[] = [];
   const { calls, fetchImpl } = makeFetch([429, 200], { "retry-after": "60" });
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl, onError: (error) => errors.push(error) },
   );
+
   const code = await exportSpans(exporter, makeSpans(1));
   expect(code).toBe(ExportResultCode.FAILED);
   expect(calls).toHaveLength(1);
@@ -188,12 +206,14 @@ describe("retry-after", () => {
 
   const startPost = (statuses: number[], headers: Record<string, string>) => {
     const { calls, fetchImpl } = makeFetch(statuses, headers);
+
     const pending = postOtlp({
       fetchImpl,
       url: "https://ingest.example/v1/traces",
       headers: {},
       body: new Uint8Array([1]),
     });
+
     return { calls, pending };
   };
 
@@ -223,9 +243,11 @@ describe("retry-after", () => {
 
   test("an HTTP date sets the delay relative to now", async () => {
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
     const { calls, pending } = startPost([503, 200], {
       "retry-after": new Date(Date.now() + 1000).toUTCString(),
     });
+
     await vi.advanceTimersByTimeAsync(999);
     expect(calls).toHaveLength(1);
     await vi.advanceTimersByTimeAsync(1);
@@ -277,6 +299,7 @@ describe("retry-after", () => {
 
 test("a missing CompressionStream ships large bodies uncompressed", async () => {
   vi.stubGlobal("CompressionStream", undefined);
+
   try {
     const original = new TextEncoder().encode("a".repeat(5000));
     const { body, contentEncoding } = await maybeGzip(original);
@@ -292,6 +315,7 @@ test("bodies above the threshold are gzipped and round-trip", async () => {
   const { body, contentEncoding } = await maybeGzip(original);
   expect(contentEncoding).toBe("gzip");
   expect(body.byteLength).toBeLessThan(original.byteLength);
+
   const decompressed = new Uint8Array(
     await new Response(
       new Blob([body as Uint8Array<ArrayBuffer>])
@@ -299,6 +323,7 @@ test("bodies above the threshold are gzipped and round-trip", async () => {
         .pipeThrough(new DecompressionStream("gzip")),
     ).arrayBuffer(),
   );
+
   expect(decompressed).toEqual(original);
 });
 
@@ -311,20 +336,24 @@ test("small bodies are not compressed", async () => {
 
 test("exported batches send a content-encoding gzip header for large payloads", async () => {
   const { calls, fetchImpl } = makeFetch([200]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl },
   );
+
   await exportSpans(exporter, makeSpans(1, 10_000));
   expect(calls[0]!.headers["content-encoding"]).toBe("gzip");
 });
 
 test("oversized batches split into multiple POSTs", async () => {
   const { calls, fetchImpl } = makeFetch([200]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl },
   );
+
   // Two ~2 MB spans: combined serialization exceeds the 3.5 MB guard, each half fits.
   const code = await exportSpans(exporter, makeSpans(2, 2_000_000));
   expect(code).toBe(ExportResultCode.SUCCESS);
@@ -334,10 +363,12 @@ test("oversized batches split into multiple POSTs", async () => {
 test("a single span beyond the limit is dropped with onError, not wedged", async () => {
   const errors: unknown[] = [];
   const { calls, fetchImpl } = makeFetch([200]);
+
   const exporter = createTraceExporter(
     { url: "https://ingest.example/v1/traces", headers: otlpHeaders("td_live_x") },
     { fetchImpl, onError: (e) => errors.push(e) },
   );
+
   const code = await exportSpans(exporter, makeSpans(1, 4_000_000));
   expect(code).toBe(ExportResultCode.SUCCESS);
   expect(calls).toHaveLength(0);
@@ -346,10 +377,12 @@ test("a single span beyond the limit is dropped with onError, not wedged", async
 
 test("metric exporter skips POSTs when every data point set is empty", async () => {
   const { calls, fetchImpl } = makeFetch([200]);
+
   const exporter = createMetricExporter(
     { url: "https://ingest.example/v1/metrics", headers: otlpHeaders("td_live_x") },
     { fetchImpl },
   );
+
   const code = await exportMetrics(exporter, makeGaugeMetrics([]));
   expect(code).toBe(ExportResultCode.SUCCESS);
   expect(calls).toHaveLength(0);
@@ -357,10 +390,12 @@ test("metric exporter skips POSTs when every data point set is empty", async () 
 
 test.each([429, 503])("metric exporter retries status %s", async (status) => {
   const { calls, fetchImpl } = makeFetch([status, 200]);
+
   const exporter = createMetricExporter(
     { url: "https://ingest.example/v1/metrics", headers: otlpHeaders("td_live_x") },
     { fetchImpl },
   );
+
   const code = await exportMetrics(exporter, makeGaugeMetrics([GAUGE_POINT]));
   expect(code).toBe(ExportResultCode.SUCCESS);
   expect(calls).toHaveLength(2);
@@ -370,14 +405,18 @@ test.each([429, 503])("metric exporter retries status %s", async (status) => {
 test("metric exporter exhausts retries for a network failure", async () => {
   const errors: unknown[] = [];
   let calls = 0;
+
   const fetchImpl: typeof fetch = () => {
     calls += 1;
+
     return Promise.reject(new Error("connection reset"));
   };
+
   const exporter = createMetricExporter(
     { url: "https://ingest.example/v1/metrics", headers: otlpHeaders("td_live_x") },
     { fetchImpl, onError: (e) => errors.push(e) },
   );
+
   const code = await exportMetrics(exporter, makeGaugeMetrics([GAUGE_POINT]));
   expect(code).toBe(ExportResultCode.FAILED);
   expect(calls).toBe(3);
@@ -410,17 +449,21 @@ const lifecycleCases = [
 describe.each(lifecycleCases)("$name exporter lifecycle", ({ create, start }) => {
   test("shutdown waits for active sends and rejects later exports", async () => {
     let resolveFetch: ((response: Response) => void) | undefined;
+
     const fetchImpl: typeof fetch = () =>
       new Promise((resolve) => {
         resolveFetch = resolve;
       });
+
     const exporter = create(fetchImpl);
     const events: string[] = [];
     start(exporter as never, (code) => events.push(`active:${code}`));
     await vi.waitFor(() => expect(resolveFetch).toBeDefined());
+
     const shutdown = exporter.shutdown().then(() => {
       events.push("shutdown");
     });
+
     await Promise.resolve();
     expect(events).toEqual([]);
     start(exporter as never, (code) => events.push(`late:${code}`));
@@ -436,18 +479,22 @@ describe.each(lifecycleCases)("$name exporter lifecycle", ({ create, start }) =>
 
   test("forceFlush resolves after every send active when it begins", async () => {
     const resolvers: Array<(response: Response) => void> = [];
+
     const fetchImpl: typeof fetch = () =>
       new Promise((resolve) => {
         resolvers.push(resolve);
       });
+
     const exporter = create(fetchImpl);
     const events: string[] = [];
     start(exporter as never, (code) => events.push(`first:${code}`));
     start(exporter as never, (code) => events.push(`second:${code}`));
     await vi.waitFor(() => expect(resolvers).toHaveLength(2));
+
     const flush = exporter.forceFlush!().then(() => {
       events.push("flush");
     });
+
     resolvers[0]!(new Response(null, { status: 200 }));
     await vi.waitFor(() => expect(events).toEqual([`first:${ExportResultCode.SUCCESS}`]));
     resolvers[1]!(new Response(null, { status: 200 }));
@@ -462,14 +509,17 @@ describe.each(lifecycleCases)("$name exporter lifecycle", ({ create, start }) =>
 
 test("forceFlush waits through a retry delay", async () => {
   vi.useFakeTimers();
+
   try {
     const { calls, fetchImpl } = makeFetch([503, 200]);
     const exporter = createTraceExporter(target, { fetchImpl });
     exporter.export(makeSpans(1), () => undefined);
     let flushed = false;
+
     const flush = exporter.forceFlush!().then(() => {
       flushed = true;
     });
+
     await vi.advanceTimersByTimeAsync(99);
     expect(calls).toHaveLength(1);
     expect(flushed).toBe(false);
@@ -508,6 +558,7 @@ test("callback and onError throws do not strand lifecycle state", async () => {
       throw new Error("onError failed");
     },
   });
+
   exporter.export(makeSpans(1), () => {
     throw new Error("callback failed");
   });
@@ -518,13 +569,17 @@ test("callback and onError throws do not strand lifecycle state", async () => {
 test("never-settling sends time out once and release lifecycle state", async () => {
   const spans = makeSpans(1);
   vi.useFakeTimers();
+
   try {
     const signals: AbortSignal[] = [];
     const results: ExportResultCode[][] = [[], []];
+
     const fetchImpl: typeof fetch = (_input, init) => {
       signals.push(init!.signal!);
+
       return new Promise(() => undefined);
     };
+
     const exporter = createTraceExporter(target, {
       fetchImpl,
       exportTimeoutMillis: 100,
@@ -532,6 +587,7 @@ test("never-settling sends time out once and release lifecycle state", async () 
         throw new Error("onError failed");
       },
     });
+
     exporter.export(spans, (result) => {
       results[0]!.push(result.code);
       throw new Error("callback failed");
@@ -564,16 +620,20 @@ test.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
   "invalid export timeout %s uses the default",
   async (exportTimeoutMillis) => {
     vi.useFakeTimers();
+
     try {
       const signals: AbortSignal[] = [];
       const results: ExportResultCode[] = [];
+
       const exporter = createTraceExporter(target, {
         fetchImpl: (_input, init) => {
           signals.push(init!.signal!);
+
           return new Promise(() => undefined);
         },
         exportTimeoutMillis,
       });
+
       exporter.export(makeSpans(1), (result) => results.push(result.code));
       await Promise.resolve();
       await Promise.resolve();

--- a/packages/pi/src/extension.ts
+++ b/packages/pi/src/extension.ts
@@ -47,26 +47,32 @@ export interface TelemetryDevExtensionHost {
 export type TelemetryDevExtension = (pi: TelemetryDevExtensionHost) => void;
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 type JsonRecord = { [key: string]: JsonValue };
+
 type Attrs = NonNullable<LogOptions["attributes"]>;
 
 function asRecord(cause: unknown): JsonRecord | undefined {
   if (cause === null || cause instanceof Function || Object(cause) !== cause) return undefined;
+
   return cause as JsonRecord;
 }
 
 function stringField(record: JsonRecord | undefined, key: string): string | undefined {
   const value = record?.[key];
+
   return value?.constructor === String && value.length > 0 ? value : undefined;
 }
 
 function numberField(record: JsonRecord | undefined, key: string): number | undefined {
   const value = record?.[key];
+
   return value?.constructor === Number && Number.isFinite(value) ? value : undefined;
 }
 
 function booleanField(record: JsonRecord | undefined, key: string): boolean | undefined {
   const value = record?.[key];
+
   return value?.constructor === Boolean ? value : undefined;
 }
 
@@ -80,6 +86,7 @@ function reportError(onError: Function | undefined, cause: unknown): void {
 
 function sessionId(ctx: TelemetryDevExtensionContext): string | undefined {
   const id = ctx.sessionManager.getSessionId();
+
   return id?.constructor === String && id.length > 0 ? id : undefined;
 }
 
@@ -87,16 +94,21 @@ function sessionId(ctx: TelemetryDevExtensionContext): string | undefined {
 function textContent(content: JsonValue | undefined): string | undefined {
   if (!Array.isArray(content)) return undefined;
   const parts: string[] = [];
+
   for (const block of content) {
     const record = asRecord(block);
+
     if (record?.type === "text" && record.text?.constructor === String) parts.push(record.text);
   }
+
   return parts.length > 0 ? parts.join("\n") : undefined;
 }
 
 function usageFields(message: JsonRecord): TokenUsage | undefined {
   const usage = asRecord(message.usage);
+
   if (!usage) return undefined;
+
   return {
     inputTokens: numberField(usage, "input"),
     outputTokens: numberField(usage, "output"),
@@ -111,6 +123,7 @@ function usageFields(message: JsonRecord): TokenUsage | undefined {
 function failureError(name: string, message: string | undefined): Error {
   const error = new Error(message ?? name);
   error.name = name;
+
   return error;
 }
 
@@ -179,6 +192,7 @@ export function telemetryDevExtension(
 
     function spanAttributes(ctx: TelemetryDevExtensionContext): Record<string, string> {
       const id = sessionId(ctx);
+
       return id ? { "gen_ai.conversation.id": id } : {};
     }
 
@@ -186,6 +200,7 @@ export function telemetryDevExtension(
       for (const span of toolSpans.values()) {
         span.end({ error: failureError("incomplete", "tool execution did not complete") });
       }
+
       toolSpans.clear();
       chatSpanByToolCall.clear();
     }
@@ -254,10 +269,13 @@ export function telemetryDevExtension(
     on("agent_end", (event: { messages: JsonValue[] }, _ctx) => {
       const messages = Array.isArray(event.messages) ? event.messages : [];
       let lastAssistant: JsonRecord | undefined;
+
       for (const message of messages) {
         const record = asRecord(message);
+
         if (record?.role === "assistant") lastAssistant = record;
       }
+
       const stopReason = stringField(lastAssistant, "stopReason");
       const errorMessage = stringField(lastAssistant, "errorMessage");
       // agent_end only closes one low-level run; pi may remove a retryable
@@ -279,11 +297,13 @@ export function telemetryDevExtension(
 
     on("message_start", (event: { message: JsonValue }, _ctx) => {
       const message = asRecord(event.message);
+
       if (message?.role === "assistant") assistantStartedAt = Date.now();
     });
 
     on("message_end", (event: { message: JsonValue }, ctx) => {
       const message = asRecord(event.message);
+
       if (message?.role !== "assistant") return;
       const startTime = assistantStartedAt;
       assistantStartedAt = undefined;
@@ -292,6 +312,7 @@ export function telemetryDevExtension(
       const responseModel = stringField(message, "responseModel") ?? model;
       const errorMessage = stringField(message, "errorMessage");
       const stopReason = stringField(message, "stopReason");
+
       const span = startSpan(model ? `chat ${model}` : "chat", {
         type: "generation",
         parent: agentSpan,
@@ -309,14 +330,18 @@ export function telemetryDevExtension(
         error: stopReason === "error" ? failureError(stopReason, errorMessage) : undefined,
         attributes: spanAttributes(ctx),
       });
+
       request = undefined;
       systemPrompt = undefined;
+
       for (const block of Array.isArray(message.content) ? message.content : []) {
         const record = asRecord(block);
+
         if (record?.type === "toolCall" && record.id?.constructor === String) {
           chatSpanByToolCall.set(record.id, span);
         }
       }
+
       span.end({ endTime });
     });
 
@@ -331,6 +356,7 @@ export function telemetryDevExtension(
           input: event.args,
           attributes: spanAttributes(ctx),
         });
+
         chatSpanByToolCall.delete(event.toolCallId);
         toolSpans.set(event.toolCallId, span);
       },
@@ -343,6 +369,7 @@ export function telemetryDevExtension(
         _ctx,
       ) => {
         const span = toolSpans.get(event.toolCallId);
+
         if (!span) return;
         toolSpans.delete(event.toolCallId);
         const resultText = textContent(asRecord(event.result)?.content);
@@ -399,6 +426,7 @@ export function telemetryDevExtension(
             endAgentSpan(lastRunResult ?? { finishReason: "incomplete" });
             lastRunResult = undefined;
           }
+
           endSessionSpan();
           emit("session_shutdown", ctx, "info", "Session shutdown", {
             "pi.session.reason": event.reason,

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,4 +1,5 @@
 export type { TelemetryDevPiOptions } from "./config.ts";
+
 export {
   telemetryDevExtension,
   type TelemetryDevExtension,

--- a/packages/pi/tests/pi.test.ts
+++ b/packages/pi/tests/pi.test.ts
@@ -31,6 +31,7 @@ interface Exporters extends ClientOverrides {
 function makeExporters(): Exporters {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
+
   return { logRecordExporter: logs, logs, spanExporter: spans, spans };
 }
 
@@ -45,8 +46,11 @@ function telemetryOptions(options?: TelemetryDevExtensionOptions): TelemetryDevE
 }
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 type JsonRecord = { [key: string]: JsonValue };
+
 type Event = { type: string; [key: string]: JsonValue };
+
 type EmitFn = (event: Event, ctx?: ExtensionContext) => Promise<void>;
 
 interface Harness {
@@ -66,13 +70,17 @@ function makeContext(sessionId = "session-1"): ExtensionContext {
       getSessionFile: () => undefined,
     },
   };
+
   return context as ExtensionContext;
 }
 
 function makeHarness(options?: TelemetryDevExtensionOptions): Harness {
   const exporters = makeExporters();
+
   type Handler = (event: Event, ctx: ExtensionContext) => void | Promise<void>;
+
   const handlers = new Map<string, Handler[]>();
+
   const api = {
     on(type: string, handler: Handler) {
       const list = handlers.get(type) ?? [];
@@ -85,11 +93,13 @@ function makeHarness(options?: TelemetryDevExtensionOptions): Harness {
   factory(api);
 
   const defaultCtx = makeContext();
+
   const emit: EmitFn = async (event, ctx = defaultCtx) => {
     for (const handler of handlers.get(event.type) ?? []) {
       await handler(event, ctx);
     }
   };
+
   return { emit, exporters };
 }
 
@@ -121,6 +131,7 @@ function assistantMessage(overrides?: JsonRecord) {
     timestamp: 1_700_000_000_000,
     ...overrides,
   };
+
   return message;
 }
 
@@ -141,6 +152,7 @@ async function runAgentLoop(
 function spanByName(exporters: Exporters, name: string): ReadableSpan {
   const span = exporters.spans.getFinishedSpans().find((candidate) => candidate.name === name);
   expect(span, `expected span ${name}`).toBeDefined();
+
   return span as ReadableSpan;
 }
 
@@ -185,6 +197,7 @@ test("automatic retries keep one invoke_agent span until the run settles", async
   const agents = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "invoke_agent");
+
   expect(agents).toHaveLength(1);
   const agent = agents[0] as ReadableSpan;
   expect(agent.status.code).not.toBe(SpanStatusCode.ERROR);
@@ -204,6 +217,7 @@ test("all prompts of a pi session share one trace under a session root span", as
   const networkFetch = vi
     .spyOn(globalThis, "fetch")
     .mockRejectedValue(new Error("unexpected network"));
+
   const harness = makeHarness({ apiKey: "td_test_key" });
   await harness.emit({ type: "session_start", reason: "startup" });
   await runAgentLoop(harness);
@@ -239,6 +253,7 @@ test("a session switch closes the trace and the next prompt starts a new one", a
   const roots = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "session");
+
   expect(roots).toHaveLength(2);
   expect(roots[0]?.spanContext().traceId).not.toBe(roots[1]?.spanContext().traceId);
 });
@@ -247,6 +262,7 @@ test("assistant lifecycle produces a timed chat span with model, usage, and cost
   const networkFetch = vi
     .spyOn(globalThis, "fetch")
     .mockRejectedValue(new Error("unexpected network"));
+
   let now = 1_700_000_000_000;
   vi.spyOn(Date, "now").mockImplementation(() => now);
   const harness = makeHarness();
@@ -286,11 +302,13 @@ test("assistant lifecycle produces a timed chat span with model, usage, and cost
 test("chat spans carry the system prompt, the model context, and every reply block", async () => {
   const harness = makeHarness();
   const context: JsonValue[] = [{ role: "user", content: [{ type: "text", text: "fix the bug" }] }];
+
   const content: JsonValue[] = [
     { type: "thinking", thinking: "Look first." },
     { type: "text", text: "Reading." },
     { type: "toolCall", id: "call-1", name: "read", arguments: { path: "a.ts" } },
   ];
+
   const message = assistantMessage({ stopReason: "toolUse", content });
   await harness.emit({
     type: "before_agent_start",
@@ -324,9 +342,11 @@ test("chat spans carry the system prompt, the model context, and every reply blo
 
 test("request capture follows host conversion and later context and system-prompt replacements", async () => {
   const directory = await mkdtemp(join(tmpdir(), "telemetry-pi-capture-"));
+
   try {
     const exporters = makeExporters();
     const runtime = createExtensionRuntime();
+
     function extension(path: string): Extension {
       return {
         path,
@@ -340,6 +360,7 @@ test("request capture follows host conversion and later context and system-promp
         shortcuts: new Map(),
       };
     }
+
     const telemetry = extension("telemetry");
     telemetryDevExtension(
       telemetryOptions(),
@@ -351,6 +372,7 @@ test("request capture follows host conversion and later context and system-promp
         telemetry.handlers.set(type, handlers);
       },
     });
+
     const original: Parameters<typeof convertToLlm>[0] = [
       { role: "user", content: "obsolete context", timestamp: 1 },
       {
@@ -381,6 +403,7 @@ test("request capture follows host conversion and later context and system-promp
         timestamp: 5,
       },
     ];
+
     const later = extension("later");
     later.handlers.set("context", [
       async () => ({
@@ -400,6 +423,7 @@ test("request capture follows host conversion and later context and system-promp
     later.handlers.set("before_agent_start", [
       async () => ({ systemPrompt: "Effective system instructions." }),
     ]);
+
     const runner = new ExtensionRunner(
       [telemetry, later],
       runtime,
@@ -409,6 +433,7 @@ test("request capture follows host conversion and later context and system-promp
         await ModelRuntime.create({ authPath: join(directory, "auth.json"), modelsPath: null }),
       ),
     );
+
     let systemPrompt = "Base system instructions.";
     runner.bindCore(runtime, {
       getModel: () => undefined,
@@ -422,19 +447,23 @@ test("request capture follows host conversion and later context and system-promp
       compact: () => {},
       getSystemPrompt: () => systemPrompt,
     });
+
     const beforeStart = await runner.emitBeforeAgentStart("fix the bug", undefined, systemPrompt, {
       cwd: directory,
     });
+
     systemPrompt = beforeStart?.systemPrompt ?? systemPrompt;
     await runner.emit({ type: "agent_start" });
     const messages = convertToLlm(await runner.emitContext(original));
     await runner.emitBeforeProviderRequest({ messages });
+
     const message = {
       ...assistantMessage(),
       role: "assistant" as const,
       content: [{ type: "text" as const, text: "All done." }],
       stopReason: "stop" as const,
     };
+
     await runner.emit({ type: "message_start", message });
     await runner.emitMessageEnd({ type: "message_end", message });
     await runner.emit({ type: "agent_end", messages: [message] });
@@ -468,9 +497,11 @@ test("request capture follows host conversion and later context and system-promp
       }),
     );
     expect(chat.attributes["gen_ai.system_instructions"]).toBe("Effective system instructions.");
+
     const captured = JSON.stringify(
       exporters.spans.getFinishedSpans().map((span) => span.attributes),
     );
+
     expect(captured).not.toContain("PRIVATE_TOKEN");
     expect(captured).not.toContain("private-shell-output");
     expect(captured).not.toContain("private-custom-details");
@@ -515,6 +546,7 @@ test("provider request and effective system instructions pass through SDK maskin
     mask: (_value, { key }) =>
       key === "gen_ai.system_instructions" ? "[masked instructions]" : "[masked content]",
   });
+
   await harness.emit({ type: "agent_start" });
   await harness.emit({
     type: "before_provider_request",
@@ -584,6 +616,7 @@ test("tool executions produce successful and failed execute_tool spans", async (
   const spans = harness.exporters.spans
     .getFinishedSpans()
     .filter((span) => span.name === "execute_tool bash");
+
   expect(spans).toHaveLength(2);
   expect(spans[0]?.attributes).toMatchObject({
     "gen_ai.conversation.id": "session-1",
@@ -662,12 +695,14 @@ test("model_select logs the previous and selected model", async () => {
 test("malformed events never throw and report through onError", async () => {
   const errors: unknown[] = [];
   const harness = makeHarness({ onError: (error) => errors.push(error) });
+
   const poisoned = {
     type: "message_end",
     get message(): never {
       throw new Error("poisoned event");
     },
   };
+
   await expect(harness.emit(poisoned)).resolves.toBeUndefined();
   expect(errors).toHaveLength(1);
 
@@ -689,10 +724,12 @@ test("each event reads the current session id", async () => {
 test("tool spans nest under the chat span that issued the tool call", async () => {
   const harness = makeHarness();
   await harness.emit({ type: "agent_start" });
+
   const message = assistantMessage({
     stopReason: "toolUse",
     content: [{ type: "toolCall", id: "call-9", name: "bash", arguments: { command: "ls" } }],
   });
+
   await harness.emit({ type: "message_start", message });
   await harness.emit({ type: "message_end", message });
   await harness.emit({

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -77,7 +77,8 @@ The SDK installs the [session sampling wrapper](../otel/README.md#correlation-at
 - `observe(fn, options?)` — wrap a sync/async function: args → input, return → output, errors
   captured and rethrown; activates context for nesting.
 - `startSpan(name, options?)` — manual handle; does **not** activate context. `handle.update()`,
-  `handle.end()`, `handle.traceparent`, `handle.span` (raw OTel span).
+  `handle.end()`, `handle.recordOutputChunk(timestampMs?)`, `handle.traceparent`, `handle.span`
+  (raw OTel span).
 - `startActiveSpan(name, options?, fn)` — callback-scoped; activates context, auto-ends.
 - `updateActiveSpan(fields)` — update the innermost active span.
 - `propagateAttributes({ userId, sessionId, metadata }, fn)` — stamps `user.id`,
@@ -98,6 +99,18 @@ GenAI semantic conventions; cost is computed server-side from usage unless `cost
 
 Duration and token-usage histograms (`gen_ai.client.operation.duration`,
 `gen_ai.client.token.usage`) are recorded automatically for generation/agent/embedding/tool spans.
+
+Generation spans also emit `gen_ai.client.operation.time_to_first_chunk` when a valid
+`timeToFirstChunkMs` is supplied. `handle.recordOutputChunk()` records each nonempty output chunk's
+arrival; after the first chunk, intervals contribute to
+`gen_ai.client.operation.time_per_output_chunk`. Both histograms use seconds and are emitted only
+after the ended span passes `spanFilter`, including interrupted streams. Chunk timing uses bounded
+histogram state and does not retain individual intervals. Pull-based timing includes consumer delay
+between reads. An explicit timestamp uses the same monotonic millisecond clock for every chunk.
+
+Provider integrations feature-detect chunk recording. With an older core SDK that lacks
+`recordOutputChunk`, streams and existing tracing continue normally, but chunk-interval metrics are
+unavailable. Upgrade the core SDK with provider integrations to enable the new metric.
 
 ## Serverless
 

--- a/packages/sdk/src/attrs.ts
+++ b/packages/sdk/src/attrs.ts
@@ -126,32 +126,42 @@ export function fieldsToAttributes(
 
   if (fields.systemInstructions !== undefined && cfg.captureInput) {
     const value = prepareCaptureValue("gen_ai.system_instructions", fields.systemInstructions, cfg);
+
     if (value !== undefined) attrs["gen_ai.system_instructions"] = value;
   }
+
   if (fields.input !== undefined && cfg.captureInput) {
     const key = inputKeyFor(type);
     const value = prepareCaptureValue(key, fields.input, cfg);
+
     if (value !== undefined) attrs[key] = value;
   }
+
   if (fields.output !== undefined && cfg.captureOutput) {
     const key = outputKeyFor(type);
     const value = prepareCaptureValue(key, fields.output, cfg);
+
     if (value !== undefined) attrs[key] = value;
   }
+
   if (fields.metadata) {
     for (const [key, value] of Object.entries(fields.metadata)) {
       if (RESERVED_METADATA_KEYS.has(key)) {
         diag.debug(`metadata key "${key}" is reserved; pass it via propagateAttributes instead`);
         continue;
       }
+
       const attr = typeof value === "string" ? value : jsonAttr(value);
+
       if (attr !== undefined) {
         attrs[`td.metadata.${key}`] = truncate(attr, cfg.maxAttributeLength);
       }
     }
   }
+
   if (fields.attributes) {
     Object.assign(attrs, omitUndefined(fields.attributes));
   }
+
   return attrs;
 }

--- a/packages/sdk/src/capture.ts
+++ b/packages/sdk/src/capture.ts
@@ -13,6 +13,7 @@ export interface CaptureConfig {
 
 export function truncate(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
+
   // Total stays within maxLength so the provider's attributeValueLengthLimit backstop
   // (set to the same cap) never slices the marker off.
   return value.slice(0, Math.max(maxLength - TRUNCATION_MARKER.length, 0)) + TRUNCATION_MARKER;
@@ -25,15 +26,20 @@ export function prepareCaptureValue(
   cfg: CaptureConfig,
 ): string | undefined {
   let masked = value;
+
   if (cfg.mask) {
     try {
       masked = cfg.mask(value, { key });
     } catch (error) {
       reportError(cfg.onError, error instanceof Error ? error : new Error(String(error)));
+
       return undefined;
     }
   }
+
   const serialized = jsonAttr(masked);
+
   if (serialized === undefined) return undefined;
+
   return truncate(serialized, cfg.maxAttributeLength);
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -89,6 +89,7 @@ export function init(options?: TelemetryOptions, overrides?: ClientOverrides): T
   } catch (error) {
     reportError(options?.onError, error instanceof Error ? error : new Error(String(error)));
     activeClient = NOOP_CLIENT;
+
     return NOOP_CLIENT;
   }
 }
@@ -104,11 +105,14 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
   }
 
   const enabled = config.enabled && Boolean(config.apiKey ?? overrides?.spanExporter);
+
   if (!enabled) {
     if (config.enabled && !config.apiKey) {
       diag.debug("no api key (apiKey option or TELEMETRY_DEV_API_KEY); telemetry disabled");
     }
+
     activeClient = NOOP_CLIENT;
+
     return NOOP_CLIENT;
   }
 
@@ -119,6 +123,7 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
     "deployment.environment.name": config.environment,
     ...config.resourceAttributes,
   });
+
   const transport: Transport = { fetchImpl: config.fetchImpl, onError: config.onError };
   const headers = config.apiKey ? otlpHeaders(config.apiKey, config.sdkName) : undefined;
 
@@ -131,6 +136,7 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
     (headers
       ? createMetricExporter({ url: `${config.baseUrl}/v1/metrics`, headers }, transport)
       : undefined);
+
   const metrics = metricExporter
     ? createMetricsPipeline({
         resource,
@@ -161,21 +167,26 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
     spanProcessors: [processor],
     spanLimits: { attributeValueLengthLimit: config.maxAttributeLength },
   });
+
   const tracer = provider.getTracer(SCOPE_NAME, SCOPE_VERSION);
 
   let registeredTrace = false;
   let registeredContext = false;
   let registeredPropagation = false;
+
   if (config.registerGlobal) {
     registeredTrace = trace.setGlobalTracerProvider(
       config.sessionRootOf
         ? sessionRootTracerProvider(provider, config.apiKey, config.sessionRootOf, config.onError)
         : provider,
     );
+
     if (als) {
       registeredContext = apiContext.setGlobalContextManager(new AlsContextManager(als));
     }
+
     registeredPropagation = propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
     if (!registeredTrace) {
       diag.warn(
         "a global TracerProvider is already registered; attach the TelemetrySpanProcessor from '@telemetry-dev/otel' to your own provider instead",
@@ -188,43 +199,56 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
     (headers
       ? createLogExporter({ url: `${config.baseUrl}/v1/logs`, headers }, transport)
       : undefined);
+
   // Lazy: the log pipeline only exists once log() is first called.
   let logs: { logger: Logger; forceFlush(): Promise<void>; shutdown(): Promise<void> } | undefined;
+
   const ensureLogger = (): Logger | undefined => {
     if (!logExporter) return undefined;
+
     if (!logs) {
       const logProcessor =
         config.exportMode === "immediate"
           ? new SimpleLogRecordProcessor(logExporter)
           : new BatchLogRecordProcessor(logExporter);
+
       const loggerProvider = new LoggerProvider({
         resource,
         logRecordLimits: { attributeValueLengthLimit: config.maxAttributeLength },
         processors: [logProcessor],
       });
+
       logs = {
         logger: loggerProvider.getLogger(SCOPE_NAME, SCOPE_VERSION),
         forceFlush: () => loggerProvider.forceFlush(),
         shutdown: () => loggerProvider.shutdown(),
       };
     }
+
     return logs.logger;
   };
 
   let torn = false;
+
   const collect = (op: "forceFlush" | "shutdown"): Promise<void> => {
     const parts: Promise<void>[] = [provider[op]()];
+
     if (logs) parts.push(logs[op]());
+
     if (metrics) parts.push(metrics[op]());
+
     return Promise.all(parts)
       .then(() => undefined)
       .catch((error: Error) => reportError(config.onError, error));
   };
+
   const handoff = (p: Promise<void>): Promise<void> => {
     if (config.waitUntil) {
       config.waitUntil(p);
+
       return Promise.resolve();
     }
+
     return p;
   };
 
@@ -236,14 +260,20 @@ function initInner(options?: TelemetryOptions, overrides?: ClientOverrides): Tel
     shutdown: () => {
       if (torn) return Promise.resolve();
       torn = true;
+
       if (registeredTrace) trace.disable();
+
       if (registeredContext) apiContext.disable();
+
       if (registeredPropagation) propagation.disable();
       handle.core = undefined;
+
       return handoff(collect("shutdown"));
     },
   };
+
   handle.core = { config, tracer, ensureLogger };
   activeClient = handle;
+
   return handle;
 }

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -95,6 +95,7 @@ export const DEFAULT_MAX_ATTRIBUTE_LENGTH = 65536;
 
 export function resolveConfig(options: TelemetryOptions = {}): ResolvedConfig {
   const env = resolveEnv();
+
   if (
     options.sessionMode !== undefined &&
     options.sessionMode !== "explicit" &&
@@ -102,10 +103,12 @@ export function resolveConfig(options: TelemetryOptions = {}): ResolvedConfig {
   ) {
     throw new TypeError(`Invalid sessionMode: ${String(options.sessionMode)}`);
   }
+
   const baseUrl = (options.baseUrl ?? env.TELEMETRY_DEV_BASE_URL ?? DEFAULT_BASE_URL).replace(
     /\/+$/,
     "",
   );
+
   return {
     apiKey: options.apiKey ?? env.TELEMETRY_DEV_API_KEY,
     baseUrl,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,7 +6,9 @@ export type {
   TokenUsage,
   ToolFields,
 } from "./attrs.ts";
+
 export { type ClientOverrides, flush, init, shutdown, type TelemetryClient } from "./client.ts";
+
 export type {
   BatchOptions,
   ExportMode,
@@ -15,6 +17,7 @@ export type {
   SdkLogLevel,
   TelemetryOptions,
 } from "./config.ts";
+
 export {
   propagateAttributes,
   type PropagatedAttributes,
@@ -22,8 +25,11 @@ export {
   TelemetrySpanProcessor,
   type TelemetrySpanProcessorOptions,
 } from "@telemetry-dev/otel";
+
 export { log, type LogOptions } from "./logs.ts";
+
 export { observe, type ObserveOptions } from "./observe.ts";
+
 export {
   activeContext,
   extractW3cContext,

--- a/packages/sdk/src/logs.ts
+++ b/packages/sdk/src/logs.ts
@@ -34,26 +34,33 @@ export interface LogOptions {
  */
 export function log(message: string, options?: LogOptions): void {
   const core = currentClient().core;
+
   if (!core) return;
+
   try {
     const logger = core.ensureLogger();
+
     if (!logger) return;
     const cfg = core.config;
+
     const captureCfg = {
       mask: cfg.mask,
       maxAttributeLength: cfg.maxAttributeLength,
       onError: cfg.onError,
     };
+
     const severity = SEVERITIES[options?.level ?? "info"];
     const active = activeContext();
     const explicitSession = options?.attributes?.["gen_ai.conversation.id"];
     const propagatedSession = propagatedFromContext(active)?.["gen_ai.conversation.id"];
+
     const sessionId =
       explicitSession !== undefined
         ? undefined
         : typeof propagatedSession === "string"
           ? propagatedSession
           : cfg.processSessionId;
+
     const ctx =
       sessionId === undefined
         ? active
@@ -63,16 +70,22 @@ export function log(message: string, options?: LogOptions): void {
           });
 
     const attributes: Record<string, AttributeValue> = {};
+
     for (const [key, value] of Object.entries(options?.attributes ?? {})) {
       if (value === undefined) continue;
+
       if (typeof value === "number" || typeof value === "boolean") {
         attributes[key] = value;
         continue;
       }
+
       const prepared = prepareCaptureValue(key, value, captureCfg);
+
       if (prepared !== undefined) attributes[key] = prepared;
     }
+
     const propagated = propagatedFromContext(ctx);
+
     if (propagated) {
       for (const [key, value] of Object.entries(propagated)) {
         if (value !== undefined) {

--- a/packages/sdk/src/noop.ts
+++ b/packages/sdk/src/noop.ts
@@ -13,5 +13,6 @@ export const NOOP_SPAN_HANDLE: SpanHandle = {
   traceparent: null,
   isRecording: false,
   update: () => NOOP_SPAN_HANDLE,
+  recordOutputChunk: () => {},
   end: () => {},
 };

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -19,11 +19,14 @@ export function observe<TThis, TArgs extends unknown[], TReturn>(
 ): (...args: TArgs) => TReturn {
   const wrapped = function (this: TThis, ...args: TArgs): TReturn {
     const core = currentClient().core;
+
     if (!core) return fn.apply(this, args);
 
     let handle: SpanHandle;
+
     try {
       const name = options?.name ?? (fn.name || "anonymous");
+
       const input =
         options?.input !== undefined
           ? options.input
@@ -32,18 +35,22 @@ export function observe<TThis, TArgs extends unknown[], TReturn>(
             : args.length === 1
               ? args[0]
               : args;
+
       handle = createSpanHandle(core, name, { ...options, input });
     } catch (error) {
       reportError(core.config.onError, error instanceof Error ? error : new Error(String(error)));
+
       return fn.apply(this, args);
     }
 
     try {
       const result = withContext(handle.context, () => fn.apply(this, args));
+
       if (isThenable(result)) {
         return result.then(
           (value) => {
             handle.end({ output: value });
+
             return value;
           },
           (error: Error) => {
@@ -52,13 +59,17 @@ export function observe<TThis, TArgs extends unknown[], TReturn>(
           },
         ) as TReturn;
       }
+
       handle.end({ output: result });
+
       return result;
     } catch (error) {
       handle.end({ error: error instanceof Error ? error : new Error(String(error)) });
       throw error;
     }
   };
+
   Object.defineProperty(wrapped, "name", { value: fn.name || "anonymous", configurable: true });
+
   return wrapped;
 }

--- a/packages/sdk/src/span.ts
+++ b/packages/sdk/src/span.ts
@@ -19,7 +19,10 @@ import {
 
 import {
   activeContext,
+  DURATION_BUCKETS,
   omitUndefined,
+  OUTPUT_CHUNK_HISTOGRAM,
+  type OutputChunkHistogram,
   PROPAGATED_KEY,
   propagatedFromContext,
   reportError,
@@ -67,6 +70,8 @@ export interface SpanHandle {
   readonly traceparent: string | null;
   readonly isRecording: boolean;
   update(fields: SpanFields): SpanHandle;
+  /** Records an output chunk arrival. Pull-based streams include consumer delay between pulls. */
+  recordOutputChunk(timestampMs?: number): void;
   end(fields?: SpanFields & { endTime?: Date | number }): void;
 }
 
@@ -205,6 +210,7 @@ export function createSpanHandle(
   if (options.error !== undefined) applyError(span, options.error);
 
   const spanContext = span.spanContext();
+  let previousOutputChunkTime: number | undefined;
   const flags = (spanContext.traceFlags & 0xff).toString(16).padStart(2, "0");
   const handle: SpanHandle = {
     span,
@@ -222,6 +228,41 @@ export function createSpanHandle(
         reportError(meta.onError, error instanceof Error ? error : new Error(String(error)));
       }
       return handle;
+    },
+    recordOutputChunk(timestampMs) {
+      const now = timestampMs ?? performance.now();
+
+      if (
+        !span.isRecording() ||
+        !Number.isFinite(now) ||
+        (previousOutputChunkTime !== undefined && now < previousOutputChunkTime)
+      )
+        return;
+
+      if (previousOutputChunkTime !== undefined) {
+        const seconds = Math.max(0, now - previousOutputChunkTime) / 1000;
+
+        const target = span as Span & {
+          [OUTPUT_CHUNK_HISTOGRAM]?: OutputChunkHistogram;
+        };
+
+        const histogram = (target[OUTPUT_CHUNK_HISTOGRAM] ??= {
+          count: 0,
+          sum: 0,
+          min: seconds,
+          max: seconds,
+          bucketCounts: Array.from({ length: DURATION_BUCKETS.length + 1 }, () => 0),
+        });
+
+        histogram.count++;
+        histogram.sum += seconds;
+        histogram.min = Math.min(histogram.min, seconds);
+        histogram.max = Math.max(histogram.max, seconds);
+        const bucket = DURATION_BUCKETS.findIndex((boundary) => seconds <= boundary);
+        histogram.bucketCounts[bucket < 0 ? DURATION_BUCKETS.length : bucket]++;
+      }
+
+      previousOutputChunkTime = now;
     },
     end(fields) {
       try {

--- a/packages/sdk/src/span.ts
+++ b/packages/sdk/src/span.ts
@@ -109,25 +109,35 @@ function isSpanHandle(value: Exclude<ParentRef, string>): value is SpanHandle {
 function withAmbientPropagated(ctx: Context): Context {
   if (propagatedFromContext(ctx)) return ctx;
   const ambient = propagatedFromContext(activeContext());
+
   return ambient ? ctx.setValue(PROPAGATED_KEY, ambient) : ctx;
 }
 
 function resolveParent(parent: ParentRef | undefined): Context {
   const base = activeContext();
+
   if (parent === undefined) return base;
+
   if (typeof parent === "string") {
     const parsed = parseTraceParent(parent);
+
     if (!parsed) return base;
+
     return trace.setSpanContext(base, { ...parsed, isRemote: true });
   }
+
   const ref = parent as Exclude<ParentRef, string>;
+
   if (isSpanHandle(ref)) return withAmbientPropagated(ref.context);
+
   if (isContext(ref)) return withAmbientPropagated(ref);
+
   return trace.setSpanContext(base, ref);
 }
 
 function applyError(span: Span, error: unknown): void {
   const err = error instanceof Error ? error : undefined;
+
   // Prefer the specific subclass name (Python parity: type(error).__name__) — many SDK
   // error classes (e.g. openai's BadRequestError) never override the inherited "Error" name.
   const errorType =
@@ -136,6 +146,7 @@ function applyError(span: Span, error: unknown): void {
       : err.name !== "Error" && err.name.length > 0
         ? err.name
         : (err.constructor?.name ?? "Error") || "Error";
+
   const message = err?.message ?? String(error);
   span.setStatus({ code: SpanStatusCode.ERROR });
   span.setAttribute("error.type", errorType);
@@ -153,12 +164,15 @@ function applyError(span: Span, error: unknown): void {
 function applyFields(span: Span, meta: SpanMeta, fields: SpanFields): void {
   if (fields.name) span.updateName(fields.name);
   const attrs = fieldsToAttributes(fields, meta.type, meta.capture);
+
   if (Object.keys(attrs).length > 0) span.setAttributes(attrs);
+
   if (fields.error !== undefined) applyError(span, fields.error);
 }
 
 function metaFor(core: ClientCore, options?: StartSpanOptions): SpanMeta {
   const cfg = core.config;
+
   return {
     type: options?.type ?? "span",
     capture: {
@@ -180,6 +194,7 @@ export function createSpanHandle(
   const meta = metaFor(core, options);
   const resolved = resolveParent(options.parent);
   const sessionId = sessionIdOf(resolved, options.attributes) ?? core.config.processSessionId;
+
   const sessionContext =
     sessionId === undefined
       ? resolved
@@ -187,8 +202,10 @@ export function createSpanHandle(
           ...propagatedFromContext(resolved),
           "gen_ai.conversation.id": sessionId,
         });
+
   const parentCtx = withSessionParent(sessionContext, sessionId, core.config.apiKey);
   const attrs = fieldsToAttributes(options, meta.type, meta.capture);
+
   const span = core.tracer.startSpan(
     name,
     {
@@ -203,15 +220,20 @@ export function createSpanHandle(
     },
     parentCtx,
   );
+
   SPAN_META.set(span, meta);
+
   // The processor stamps propagation on start; explicit fields still win.
   if (Object.keys(attrs).length > 0) span.setAttributes(attrs);
+
   if (options.name) span.updateName(options.name);
+
   if (options.error !== undefined) applyError(span, options.error);
 
   const spanContext = span.spanContext();
   let previousOutputChunkTime: number | undefined;
   const flags = (spanContext.traceFlags & 0xff).toString(16).padStart(2, "0");
+
   const handle: SpanHandle = {
     span,
     context: trace.setSpan(parentCtx, span),
@@ -227,6 +249,7 @@ export function createSpanHandle(
       } catch (error) {
         reportError(meta.onError, error instanceof Error ? error : new Error(String(error)));
       }
+
       return handle;
     },
     recordOutputChunk(timestampMs) {
@@ -270,20 +293,25 @@ export function createSpanHandle(
       } catch (error) {
         reportError(meta.onError, error instanceof Error ? error : new Error(String(error)));
       }
+
       span.end(fields?.endTime);
     },
   };
+
   return handle;
 }
 
 /** Start a span WITHOUT activating context; the caller must call .end(). */
 export function startSpan(name: string, options?: StartSpanOptions): SpanHandle {
   const core = currentClient().core;
+
   if (!core) return NOOP_SPAN_HANDLE;
+
   try {
     return createSpanHandle(core, name, options);
   } catch (error) {
     reportError(core.config.onError, error instanceof Error ? error : new Error(String(error)));
+
     return NOOP_SPAN_HANDLE;
   }
 }
@@ -291,10 +319,12 @@ export function startSpan(name: string, options?: StartSpanOptions): SpanHandle 
 export function runWithHandle<T>(handle: SpanHandle, fn: (span: SpanHandle) => T): T {
   try {
     const result = withContext(handle.context, () => fn(handle));
+
     if (isThenable(result)) {
       return result.then(
         (value) => {
           handle.end();
+
           return value;
         },
         (error: unknown) => {
@@ -303,7 +333,9 @@ export function runWithHandle<T>(handle: SpanHandle, fn: (span: SpanHandle) => T
         },
       ) as T;
     }
+
     handle.end();
+
     return result;
   } catch (error) {
     handle.end({ error });
@@ -326,16 +358,21 @@ export function startActiveSpan<T>(
   const fn = isFn ? optionsOrFn : maybeFn!;
   const options = isFn ? undefined : optionsOrFn;
   const handle = startSpan(name, options);
+
   if (handle === NOOP_SPAN_HANDLE) return fn(handle);
+
   return runWithHandle(handle, fn);
 }
 
 /** Update the innermost active span; no-op when none is recording. */
 export function updateActiveSpan(fields: SpanFields): void {
   const core = currentClient().core;
+
   if (!core) return;
+
   try {
     const span = trace.getSpan(activeContext());
+
     if (!span?.isRecording()) return;
     const meta = SPAN_META.get(span) ?? metaFor(core);
     applyFields(span, meta, fields);
@@ -345,6 +382,7 @@ export function updateActiveSpan(fields: SpanFields): void {
 }
 
 const TRACE_CONTEXT_PROPAGATOR = new W3CTraceContextPropagator();
+
 const W3C_PROPAGATOR = new CompositePropagator({
   propagators: [TRACE_CONTEXT_PROPAGATOR, new W3CBaggagePropagator()],
 });
@@ -357,6 +395,7 @@ export function extractW3cContext(
   options: { includeBaggage?: boolean } = {},
 ): Context {
   const propagator = options.includeBaggage === true ? W3C_PROPAGATOR : TRACE_CONTEXT_PROPAGATOR;
+
   return propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
 }
 
@@ -367,12 +406,17 @@ export function injectW3cContext(
   options: { includeBaggage?: boolean } = {},
 ): void {
   const propagator = options.includeBaggage === true ? W3C_PROPAGATOR : TRACE_CONTEXT_PROPAGATOR;
+
   for (const key of Object.keys(carrier)) {
     const normalized = key.toLowerCase();
+
     if (normalized === "traceparent" || normalized === "tracestate" || normalized === "baggage") {
-      delete carrier[key];
+      if (!Reflect.deleteProperty(carrier, key)) {
+        throw new TypeError(`Cannot delete stale W3C carrier property: ${key}`);
+      }
     }
   }
+
   propagator.inject(context, carrier, defaultTextMapSetter);
 }
 
@@ -380,5 +424,6 @@ export function injectW3cContext(
 export function getTraceparent(): string | null {
   const carrier = { traceparent: undefined };
   TRACE_CONTEXT_PROPAGATOR.inject(activeContext(), carrier, defaultTextMapSetter);
+
   return carrier.traceparent ?? null;
 }

--- a/packages/sdk/tests/capture.test.ts
+++ b/packages/sdk/tests/capture.test.ts
@@ -10,13 +10,17 @@ afterEach(async () => {
 
 test("mask receives the structured value and the attribute key before stringification", async () => {
   const calls: Array<{ key: string; value: unknown }> = [];
+
   const { spans } = setup({
     mask: (value, ctx) => {
       calls.push({ key: ctx.key, value });
+
       if (ctx.key === "gen_ai.input.messages") return { redacted: true };
+
       return value;
     },
   });
+
   startSpan("masked", {
     type: "generation",
     input: { prompt: "secret", ssn: "123-45-6789" },
@@ -45,6 +49,7 @@ test("a throwing mask drops content but never the span", async () => {
     },
     onError: () => {},
   });
+
   startSpan("survives", { input: "content" }).end();
   await flush();
   const span = spans.getFinishedSpans()[0]!;

--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -24,10 +24,12 @@ test("primitives are safe no-ops before init", async () => {
 
 test("enabled:false yields a no-op client even with a key", () => {
   const spans = new InMemorySpanExporter();
+
   const client = init(
     { apiKey: "td_live_test", enabled: false, logLevel: "silent" },
     { spanExporter: spans },
   );
+
   expect(client.enabled).toBe(false);
   startSpan("nope").end();
   expect(spans.getFinishedSpans()).toHaveLength(0);
@@ -36,6 +38,7 @@ test("enabled:false yields a no-op client even with a key", () => {
 test("missing api key disables the client", () => {
   const previous = process.env.TELEMETRY_DEV_API_KEY;
   delete process.env.TELEMETRY_DEV_API_KEY;
+
   try {
     const client = init({ logLevel: "silent" });
     expect(client.enabled).toBe(false);
@@ -49,6 +52,7 @@ test("missing api key disables the client", () => {
 test("an exporter override enables the client without an api key", async () => {
   const previous = process.env.TELEMETRY_DEV_API_KEY;
   delete process.env.TELEMETRY_DEV_API_KEY;
+
   try {
     const spans = new InMemorySpanExporter();
     const client = init({ exportMode: "immediate", logLevel: "silent" }, { spanExporter: spans });
@@ -93,9 +97,11 @@ test("concurrent flush calls both resolve and export the span exactly once", asy
 test("waitUntil receives the flush promise instead of awaiting", async () => {
   let resultCallback: Parameters<SpanExporter["export"]>[1] | undefined;
   let resolveExportStarted!: () => void;
+
   const exportStarted = new Promise<void>((resolve) => {
     resolveExportStarted = resolve;
   });
+
   const exporter: SpanExporter = {
     export: (_spans, callback) => {
       resultCallback = callback;
@@ -103,6 +109,7 @@ test("waitUntil receives the flush promise instead of awaiting", async () => {
     },
     shutdown: () => Promise.resolve(),
   };
+
   let handoff: Promise<unknown> | undefined;
   setup(
     {
@@ -119,9 +126,11 @@ test("waitUntil receives the flush promise instead of awaiting", async () => {
 
   const exportPromise = handoff;
   const callback = resultCallback;
+
   try {
     expect(exportPromise).toBeDefined();
     expect(callback).toBeDefined();
+
     if (!exportPromise || !callback) {
       throw new Error("waitUntil did not receive an in-flight export");
     }
@@ -175,6 +184,7 @@ test("resource carries service name and environment", async () => {
   expect(span.resource.attributes["deployment.environment.name"]).toBe("test");
   expect(span.instrumentationScope.name).toBe("@telemetry-dev/sdk");
 });
+
 test("OTLP requests identify the calling SDK package", async () => {
   const requests: Request[] = [];
   init({
@@ -184,6 +194,7 @@ test("OTLP requests identify the calling SDK package", async () => {
     sdkName: "@telemetry-dev/cursor",
     fetch: async (input, init) => {
       requests.push(new Request(input, init));
+
       return new Response(null, { status: 200 });
     },
   });

--- a/packages/sdk/tests/helpers.ts
+++ b/packages/sdk/tests/helpers.ts
@@ -18,6 +18,7 @@ export interface Setup {
 export function setup(options?: TelemetryOptions, overrides?: ClientOverrides): Setup {
   const spans = new InMemorySpanExporter();
   const logs = new InMemoryLogRecordExporter();
+
   const client = init(
     {
       apiKey: "td_live_test",
@@ -30,11 +31,13 @@ export function setup(options?: TelemetryOptions, overrides?: ClientOverrides): 
     },
     { spanExporter: spans, logRecordExporter: logs, ...overrides },
   );
+
   return { client, spans, logs };
 }
 
 export function makeMetricCapture() {
   const batches: ResourceMetrics[] = [];
+
   const exporter: PushMetricExporter = {
     export: (resourceMetrics, resultCallback) => {
       batches.push(resourceMetrics);
@@ -44,5 +47,6 @@ export function makeMetricCapture() {
     forceFlush: () => Promise.resolve(),
     shutdown: () => Promise.resolve(),
   };
+
   return { batches, exporter };
 }

--- a/packages/sdk/tests/logs.test.ts
+++ b/packages/sdk/tests/logs.test.ts
@@ -79,6 +79,7 @@ test("the message passes through the mask hook", async () => {
   const { logs } = setup({
     mask: (value, ctx) => (ctx.key === "log.message" ? "[redacted]" : value),
   });
+
   log("user email is foo@bar.com");
   await flush();
   expect(logs.getFinishedLogRecords()[0]!.body).toBe("[redacted]");

--- a/packages/sdk/tests/metrics.test.ts
+++ b/packages/sdk/tests/metrics.test.ts
@@ -12,6 +12,114 @@ afterEach(async () => {
   await shutdown();
 });
 
+test("streaming generations record first-chunk seconds without inventing missing timings", async () => {
+  const { batches, exporter } = makeMetricCapture();
+  setup({}, { metricExporter: exporter });
+  startSpan("stream", { type: "generation", model: "gpt-4o", provider: "openai" }).end({
+    timeToFirstChunkMs: 250,
+    error: new Error("failed after first chunk"),
+  });
+  startSpan("instant", { type: "generation", timeToFirstChunkMs: 0 }).end();
+  startSpan("nonstream", { type: "generation" }).end();
+
+  for (const timeToFirstChunkMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    startSpan("invalid", { type: "generation", timeToFirstChunkMs }).end();
+  }
+
+  startSpan("tool", { type: "tool", timeToFirstChunkMs: 900 }).end();
+  startSpan("agent", { type: "agent", timeToFirstChunkMs: 800 }).end();
+  await flush();
+
+  const points = histogramPoints(batches, "gen_ai.client.operation.time_to_first_chunk");
+  expect(points).toHaveLength(2);
+  const streamed = points.find((p) => p.attributes["gen_ai.request.model"] === "gpt-4o")!;
+  expect(streamed.value.count).toBe(1);
+  expect(streamed.value.sum).toBe(0.25);
+  expect(streamed.attributes).toEqual({
+    "gen_ai.operation.name": "chat",
+    "gen_ai.request.model": "gpt-4o",
+    "gen_ai.provider.name": "openai",
+  });
+  expect(points.find((p) => p !== streamed)!.value.sum).toBe(0);
+});
+
+test("output chunk intervals export their bounded aggregate only after an accepted span ends", async () => {
+  const { batches, exporter } = makeMetricCapture();
+  setup({ spanFilter: (span) => span.name !== "rejected" }, { metricExporter: exporter });
+  const kept = startSpan("kept", { type: "generation", model: "model", provider: "provider" });
+  kept.recordOutputChunk(0);
+  kept.recordOutputChunk(15);
+  kept.recordOutputChunk(55);
+  await flush();
+  expect(histogramPoints(batches, "gen_ai.client.operation.time_per_output_chunk")).toHaveLength(0);
+  kept.end();
+
+  const rejected = startSpan("rejected", { type: "generation" });
+  rejected.recordOutputChunk(100);
+  rejected.recordOutputChunk(200);
+  rejected.end();
+  startSpan("zero", { type: "generation" }).end();
+  const one = startSpan("one", { type: "generation" });
+  one.recordOutputChunk();
+  one.end();
+  await flush();
+
+  const points = histogramPoints(batches, "gen_ai.client.operation.time_per_output_chunk");
+  expect(points).toHaveLength(1);
+  expect(points[0]!.attributes).toEqual({
+    "gen_ai.operation.name": "chat",
+    "gen_ai.provider.name": "provider",
+    "gen_ai.request.model": "model",
+  });
+  expect(points[0]!.value).toEqual({
+    count: 2,
+    sum: 0.055,
+    min: 0.015,
+    max: 0.04,
+    buckets: {
+      boundaries: [
+        0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+      ],
+      counts: [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+  });
+});
+
+test("output chunks merge series, cap cardinality, and reset after collection", async () => {
+  const { batches, exporter } = makeMetricCapture();
+  setup({}, { metricExporter: exporter });
+
+  for (let index = 0; index < 2001; index++) {
+    const span = startSpan("stream", { type: "generation", model: `model-${index}` });
+    span.recordOutputChunk(100);
+    span.recordOutputChunk(110);
+    span.end();
+    span.recordOutputChunk(1000);
+  }
+
+  const same = startSpan("same", { type: "generation", model: "model-0" });
+
+  for (const timestamp of [100, 100, Number.NaN, 90, Number.POSITIVE_INFINITY, 140]) {
+    same.recordOutputChunk(timestamp);
+  }
+
+  same.end({ error: new Error("stream interrupted") });
+  await flush();
+  const points = histogramPoints(batches, "gen_ai.client.operation.time_per_output_chunk");
+  expect(points).toHaveLength(2000);
+  const merged = points.find((point) => point.attributes["gen_ai.request.model"] === "model-0")!;
+  expect(merged.value.count).toBe(3);
+  expect(merged.value.sum).toBeCloseTo(0.05);
+  expect(merged.value.min).toBe(0);
+  expect(merged.value.max).toBe(0.04);
+  expect(merged.value.buckets.counts.slice(0, 3)).toEqual([2, 0, 1]);
+  expect(merged.attributes["error.type"]).toBeUndefined();
+  expect(points.find((point) => point.attributes["otel.metric.overflow"])!.value.count).toBe(2);
+  batches.length = 0;
+  await flush();
+  expect(histogramPoints(batches, "gen_ai.client.operation.time_per_output_chunk")).toHaveLength(0);
+});
+
 function histogramPoints(batches: ReturnType<typeof makeMetricCapture>["batches"], name: string) {
   return batches
     .flatMap((rm) => rm.scopeMetrics)
@@ -119,13 +227,19 @@ test("filter-rejected spans record no metrics", async () => {
     { spanFilter: (span) => span.name !== "rejected" },
     { metricExporter: exporter },
   );
-  startSpan("rejected", { type: "generation", usage: { inputTokens: 5 } }).end();
+
+  startSpan("rejected", {
+    type: "generation",
+    usage: { inputTokens: 5 },
+    timeToFirstChunkMs: 300,
+  }).end();
   startSpan("kept", { type: "generation", usage: { inputTokens: 3 } }).end();
   await flush();
   expect(spans.getFinishedSpans().map((s) => s.name)).toEqual(["kept"]);
   const tokens = histogramPoints(batches, "gen_ai.client.token.usage");
   expect(tokens).toHaveLength(1);
   expect(tokens[0]!.value.sum).toBe(3);
+  expect(histogramPoints(batches, "gen_ai.client.operation.time_to_first_chunk")).toHaveLength(0);
 });
 
 test("quiet intervals collect zero data points", async () => {

--- a/packages/sdk/tests/metrics.test.ts
+++ b/packages/sdk/tests/metrics.test.ts
@@ -166,6 +166,7 @@ test("failed spans add error.type to the duration histogram only", async () => {
   expect(durations[0]!.attributes["error.type"]).toBe("TypeError");
   const tokens = histogramPoints(batches, "gen_ai.client.token.usage");
   expect(tokens).toHaveLength(2);
+
   for (const point of tokens) {
     expect(point.attributes["error.type"]).toBeUndefined();
   }
@@ -207,10 +208,12 @@ test("histograms use DELTA temporality and the GenAI bucket boundaries", async (
   setup({}, { metricExporter: exporter });
   startSpan("gen", { type: "generation", usage: { inputTokens: 10 } }).end();
   await flush();
+
   const metric = batches
     .flatMap((rm) => rm.scopeMetrics)
     .flatMap((sm) => sm.metrics)
     .find((m) => m.descriptor.name === "gen_ai.client.token.usage")!;
+
   expect(metric.aggregationTemporality).toBe(AggregationTemporality.DELTA);
   expect(metric.dataPointType).toBe(DataPointType.HISTOGRAM);
   const point = metric.dataPoints[0]!;
@@ -223,6 +226,7 @@ test("histograms use DELTA temporality and the GenAI bucket boundaries", async (
 
 test("filter-rejected spans record no metrics", async () => {
   const { batches, exporter } = makeMetricCapture();
+
   const { spans } = setup(
     { spanFilter: (span) => span.name !== "rejected" },
     { metricExporter: exporter },
@@ -246,9 +250,11 @@ test("quiet intervals collect zero data points", async () => {
   const { batches, exporter } = makeMetricCapture();
   setup({}, { metricExporter: exporter });
   await flush();
+
   const pointCount = batches
     .flatMap((rm) => rm.scopeMetrics)
     .flatMap((sm) => sm.metrics)
     .reduce((total, metric) => total + metric.dataPoints.length, 0);
+
   expect(pointCount).toBe(0);
 });

--- a/packages/sdk/tests/observe.test.ts
+++ b/packages/sdk/tests/observe.test.ts
@@ -10,9 +10,11 @@ afterEach(async () => {
 
 test("sync function: name, single-arg input, return output", async () => {
   const { spans } = setup();
+
   const double = observe(function double(n: number) {
     return n * 2;
   });
+
   expect(double(21)).toBe(42);
   await flush();
   const span = spans.getFinishedSpans()[0]!;
@@ -40,13 +42,16 @@ test("multiple args are captured as an array; zero args capture nothing", async 
 
 test("async function ends after resolution with output", async () => {
   const { spans } = setup();
+
   const fetchData = observe(
     async function fetchData() {
       await Promise.resolve();
+
       return { items: [1, 2] };
     },
     { type: "tool", toolName: "fetch-data" },
   );
+
   await fetchData();
   await flush();
   const span = spans.getFinishedSpans()[0]!;
@@ -56,9 +61,11 @@ test("async function ends after resolution with output", async () => {
 
 test("sync throw is recorded and rethrown", async () => {
   const { spans } = setup();
+
   const boom = observe(function boom(): never {
     throw new RangeError("sync fail");
   });
+
   expect(() => boom()).toThrow("sync fail");
   await flush();
   const span = spans.getFinishedSpans()[0]!;
@@ -68,10 +75,12 @@ test("sync throw is recorded and rethrown", async () => {
 
 test("async rejection is recorded and rethrown", async () => {
   const { spans } = setup();
+
   const boom = observe(async function asyncBoom() {
     await Promise.resolve();
     throw new Error("async fail");
   });
+
   await expect(boom()).rejects.toThrow("async fail");
   await flush();
   expect(spans.getFinishedSpans()[0]!.status.code).toBe(SpanStatusCode.ERROR);
@@ -79,14 +88,19 @@ test("async rejection is recorded and rethrown", async () => {
 
 test("nested observes parent correctly across await", async () => {
   const { spans } = setup();
+
   const inner = observe(async function inner() {
     await Promise.resolve();
+
     return "inner-done";
   });
+
   const outer = observe(async function outer() {
     await Promise.resolve();
+
     return inner();
   });
+
   await outer();
   await flush();
   const exported = spans.getFinishedSpans();
@@ -100,6 +114,7 @@ test("wrapping before init works; the client is resolved at call time", async ()
   const wrapped = observe(function early(x: string) {
     return x.toUpperCase();
   });
+
   expect(wrapped("pre-init")).toBe("PRE-INIT");
   const { spans } = setup();
   wrapped("post-init");

--- a/packages/sdk/tests/process-session.test.ts
+++ b/packages/sdk/tests/process-session.test.ts
@@ -59,9 +59,11 @@ test("explicit sessions win and remain consistent on nested spans and logs", asy
     },
   );
   await flush();
+
   for (const span of spans.getFinishedSpans()) {
     expect(span.attributes["gen_ai.conversation.id"]).toBe(span.name.split("-")[0]);
   }
+
   for (const record of logs.getFinishedLogRecords()) {
     expect(typeof record.body).toBe("string");
     expect(record.attributes["gen_ai.conversation.id"]).toBe((record.body as string).split("-")[0]);
@@ -70,12 +72,14 @@ test("explicit sessions win and remain consistent on nested spans and logs", asy
 
 test("process mode honors an existing remote parent", async () => {
   const { spans } = setup({ sessionMode: "process" });
+
   const parent = {
     traceId: "0123456789abcdef0123456789abcdef",
     spanId: "0123456789abcdef",
     traceFlags: TraceFlags.SAMPLED,
     isRemote: true,
   };
+
   startSpan("joined", { parent }).end();
   await flush();
   const span = spans.getFinishedSpans()[0]!;
@@ -99,12 +103,14 @@ test("reinitializing process mode generates a new session", async () => {
 
 test("invalid mode fails open through onError", () => {
   const errors: Error[] = [];
+
   const client = init({
     apiKey: "td_live_test",
     sessionMode: "invalid" as "process",
     onError: (error) => errors.push(error),
     logLevel: "silent",
   });
+
   expect(client.enabled).toBe(false);
   expect(errors[0]).toBeInstanceOf(TypeError);
 });

--- a/packages/sdk/tests/propagate.test.ts
+++ b/packages/sdk/tests/propagate.test.ts
@@ -27,10 +27,13 @@ afterEach(async () => {
 
 test("stamps user.id, gen_ai.conversation.id, and td.metadata.* on every span in scope", async () => {
   const { spans } = setup();
+
   const traced = observe(function worker() {
     startSpan("manual-in-scope").end();
+
     return "ok";
   });
+
   propagateAttributes(
     { userId: "u_1", sessionId: "conv_9", metadata: { plan: "pro", flags: { beta: true } } },
     () => {
@@ -42,6 +45,7 @@ test("stamps user.id, gen_ai.conversation.id, and td.metadata.* on every span in
   await flush();
   const exported = spans.getFinishedSpans();
   expect(exported).toHaveLength(3);
+
   for (const span of exported) {
     expect(span.attributes["user.id"]).toBe("u_1");
     expect(span.attributes["gen_ai.conversation.id"]).toBe("conv_9");
@@ -155,6 +159,7 @@ test("root spans of one session share the deterministic session trace", async ()
   await flush();
   const exported = spans.getFinishedSpans();
   expect(exported).toHaveLength(3);
+
   for (const span of exported) {
     expect(span.spanContext().traceId).toBe(session.traceId);
     expect(span.parentSpanContext?.spanId).toBe(session.spanId);
@@ -201,12 +206,15 @@ test("session roots obey configured root sampling and retain deterministic trace
     const sampler = new ParentBasedSampler({ root });
     const { spans } = setup({ sampler });
     const expected: string[] = [];
+
     for (let i = 0; i < 20; i++) {
       const sessionId = `session-${i}`;
       const traceId = sessionSpanContext("td_live_test", sessionId).traceId;
+
       const sampled =
         sampler.shouldSample(ROOT_CONTEXT, traceId, "turn", SpanKind.INTERNAL, {}, []).decision ===
         SamplingDecision.RECORD_AND_SAMPLED;
+
       propagateAttributes({ sessionId }, () => {
         startActiveSpan("turn", (span) => {
           expect(span.isRecording).toBe(sampled);
@@ -217,8 +225,10 @@ test("session roots obey configured root sampling and retain deterministic trace
           child.end();
         });
       });
+
       if (sampled) expected.push(traceId, traceId);
     }
+
     await flush();
     expect(spans.getFinishedSpans().map((span) => span.spanContext().traceId)).toEqual(expected);
     await shutdown();
@@ -227,12 +237,14 @@ test("session roots obey configured root sampling and retain deterministic trace
 
 test("an unsampled explicit parent stays active for children inside a session", async () => {
   const { spans } = setup({ sampler: new ParentBasedSampler({ root: new AlwaysOnSampler() }) });
+
   const parent = {
     traceId: "12345678901234567890123456789012",
     spanId: "1234567890123456",
     traceFlags: TraceFlags.NONE,
     isRemote: true,
   };
+
   propagateAttributes({ sessionId: "s1" }, () => {
     startActiveSpan("turn", { parent }, (span) => {
       expect(span.isRecording).toBe(false);
@@ -254,6 +266,7 @@ test.each([
   "root sampling sees safe initial attributes ($sessionId, capture $captureInput)",
   async ({ sessionId, captureInput }) => {
     let masked = 0;
+
     const { spans } = setup({
       captureInput: false,
       captureOutput: false,
@@ -270,6 +283,7 @@ test.each([
               attributes["gen_ai.conversation.id"] === sessionId &&
               attributes["gen_ai.input.messages"] === (captureInput ? "masked-1" : undefined) &&
               attributes["gen_ai.output.messages"] === undefined;
+
             return {
               decision: accepted
                 ? SamplingDecision.RECORD_AND_SAMPLED
@@ -280,6 +294,7 @@ test.each([
         },
       }),
     });
+
     propagateAttributes(
       { userId: "inherited-user", sessionId, metadata: { plan: "inherited-plan" } },
       () => {

--- a/packages/sdk/tests/span.test.ts
+++ b/packages/sdk/tests/span.test.ts
@@ -22,6 +22,7 @@ afterEach(async () => {
 
 test("each span type maps to its gen_ai.operation.name", async () => {
   const { spans } = setup();
+
   const expected = {
     span: "function",
     generation: "chat",
@@ -29,12 +30,15 @@ test("each span type maps to its gen_ai.operation.name", async () => {
     agent: "invoke_agent",
     embedding: "embeddings",
   } satisfies Record<SpanType, string>;
+
   for (const type of ["span", "generation", "tool", "agent", "embedding"] satisfies SpanType[]) {
     startSpan(type, { type }).end();
   }
+
   await flush();
   const exported = spans.getFinishedSpans();
   expect(exported).toHaveLength(5);
+
   for (const [type, operation] of Object.entries(expected)) {
     const span = exported.find((s) => s.name === type)!;
     expect(span.attributes["gen_ai.operation.name"]).toBe(operation);
@@ -64,11 +68,13 @@ test("kind can be overridden without changing defaults", async () => {
 
 test("passes span links through unchanged", async () => {
   const { spans } = setup();
+
   const linked = {
     traceId: "0af7651916cd43dd8448eb211c80319c",
     spanId: "b7ad6b7169203331",
     traceFlags: 1,
   };
+
   startSpan("linked", { links: [{ context: linked, attributes: { reason: "ambient" } }] }).end();
   await flush();
   expect(spans.getFinishedSpans()[0]?.links).toEqual([
@@ -220,12 +226,14 @@ test("handle.traceparent and getTraceparent round-trip", async () => {
 test("W3C propagation omits baggage unless enabled", () => {
   setup();
   let parentTraceId = "";
+
   const carrier = {
     traceparent: undefined as string | undefined,
     tracestate: undefined as string | undefined,
     baggage: "tenant=stale" as string | undefined,
     Baggage: "tenant=uppercase" as string | undefined,
   };
+
   const baggageCarrier = { ...carrier };
   startActiveSpan("parent", (parent) => {
     parentTraceId = parent.traceId;
@@ -256,8 +264,19 @@ test("W3C propagation omits baggage unless enabled", () => {
     TRACESTATE: "vendor=stale",
     Baggage: "tenant=stale",
   };
+
   injectW3cContext(extractW3cContext({}), staleCarrier);
   expect(staleCarrier).toEqual({});
+
+  const sealedCarrier = {};
+  Object.defineProperty(sealedCarrier, "TraceParent", {
+    configurable: false,
+    enumerable: true,
+    value: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+  });
+  expect(() => injectW3cContext(extractW3cContext({}), sealedCarrier)).toThrow(
+    "Cannot delete stale W3C carrier property: TraceParent",
+  );
 });
 
 test("W3C extraction does not inherit ambient context", () => {

--- a/packages/tanstack-ai/src/config.ts
+++ b/packages/tanstack-ai/src/config.ts
@@ -34,10 +34,12 @@ const DEFAULT_BASE_URL = "https://ingest.telemetry.dev";
 
 export function resolveConfig(options: TelemetryDevOptions = {}): ResolvedConfig {
   const env = globalThis.process?.env ?? {};
+
   const baseUrl = (options.baseUrl ?? env.TELEMETRY_DEV_BASE_URL ?? DEFAULT_BASE_URL).replace(
     /\/+$/,
     "",
   );
+
   return {
     apiKey: options.apiKey ?? env.TELEMETRY_DEV_API_KEY,
     baseUrl,

--- a/packages/tanstack-ai/src/index.ts
+++ b/packages/tanstack-ai/src/index.ts
@@ -1,2 +1,3 @@
 export { telemetryDev } from "./middleware.ts";
+
 export type { TelemetryDevOptions } from "./config.ts";

--- a/packages/tanstack-ai/src/middleware.ts
+++ b/packages/tanstack-ai/src/middleware.ts
@@ -41,9 +41,10 @@ type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
-const isString = (value: unknown): value is string => typeof value === "string";
-const isNumber = (value: unknown): value is number => typeof value === "number";
-const isBigInt = (value: unknown): value is bigint => typeof value === "bigint";
+const isString = <T>(value: T): value is T & string => typeof value === "string";
+const isNumber = <T>(value: T): value is T & number => typeof value === "number";
+const isBigInt = <T>(value: T): value is T & bigint => typeof value === "bigint";
+
 const isObject = <T>(value: T): value is T & { [key: string]: JsonValue } =>
   value !== null && typeof value === "object";
 
@@ -51,9 +52,11 @@ function readId<T>(value: T): string | null {
   if (isString(value)) {
     return value.length > 0 ? value : null;
   }
+
   if (isNumber(value) || isBigInt(value)) {
     return value.toString();
   }
+
   return null;
 }
 
@@ -63,25 +66,33 @@ function firstNumber<T>(...candidates: T[]): number | undefined {
       return candidate;
     }
   }
+
   return undefined;
 }
 
 function errorTypeName<T>(err: T): string {
   if (err instanceof Error) return err.name || "Error";
+
   if (err && isObject(err) && "name" in err) {
     const n = (err as { name?: unknown }).name;
+
     if (isString(n) && n.length > 0) return n;
   }
+
   return "Error";
 }
 
 function errorMessage<T>(err: T): string {
   if (err instanceof Error) return err.message;
+
   if (isString(err)) return err;
+
   if (err && isObject(err) && "message" in err) {
     const m = (err as { message?: unknown }).message;
+
     if (isString(m)) return m;
   }
+
   return String(err);
 }
 
@@ -103,10 +114,12 @@ const MAX_TOKENS_KEYS = [
 // among the known spellings (including Ollama's nested `options`) for the gen_ai.request.* attrs.
 function samplingAttributes(modelOptions: Record<string, JsonValue> | undefined): Attributes {
   const sampling = modelOptions ?? {};
+
   const nested =
     sampling["options"] && isObject(sampling["options"])
       ? (sampling["options"] as Record<string, JsonValue>)
       : undefined;
+
   return omitUndefined({
     "gen_ai.request.temperature": firstNumber(sampling["temperature"], nested?.["temperature"]),
     "gen_ai.request.top_p": firstNumber(sampling["top_p"], sampling["topP"], nested?.["top_p"]),
@@ -175,6 +188,7 @@ export function telemetryDev(
   }
 
   const onError = config.onError;
+
   const emitter = createGenerationEmitter(
     {
       ...config,
@@ -185,10 +199,12 @@ export function telemetryDev(
     },
     overrides,
   );
+
   const states = new WeakMap<ChatMiddlewareContext, RunState>();
 
   const closeIteration = (state: RunState): void => {
     const iteration = state.iteration;
+
     if (!iteration) return;
     const endedAt = new Date();
     const usage = iteration.usage;
@@ -215,9 +231,11 @@ export function telemetryDev(
       inputTokens: usage?.promptTokens ?? null,
       outputTokens: usage?.completionTokens ?? null,
     });
+
     if (iteration.structured && iteration.outputText !== null) {
       state.structuredOutput = iteration.outputText;
     }
+
     state.iteration = null;
   };
 
@@ -237,9 +255,11 @@ export function telemetryDev(
         ...state.rootSampling,
       }),
     );
+
     if (state.restMetadata) {
       for (const [key, value] of Object.entries(state.restMetadata)) {
         const attr = isString(value) ? value : jsonAttr(value);
+
         if (attr !== undefined) {
           state.rootSpan.setAttribute(`td.metadata.${key}`, attr);
         }
@@ -269,12 +289,16 @@ export function telemetryDev(
       "gen_ai.request.model": state.requestModel,
       "gen_ai.response.model": state.responseModel ?? undefined,
     });
+
     for (const m of state.iterationMetrics) {
       const attrs: Attributes = { ...metricBase, "gen_ai.operation.name": "chat" };
       emitter.recordDuration(m.durationSec, attrs);
+
       if (m.inputTokens !== null) emitter.recordTokens("input", m.inputTokens, attrs);
+
       if (m.outputTokens !== null) emitter.recordTokens("output", m.outputTokens, attrs);
     }
+
     for (const t of state.toolMetrics) {
       emitter.recordDuration(t.durationSec, {
         ...metricBase,
@@ -292,7 +316,9 @@ export function telemetryDev(
       entry.span.end();
       state.childSpans.push(entry.span);
     }
+
     state.openTools.clear();
+
     if (state.iteration) {
       state.iteration.span.setStatus({ code: SpanStatusCode.ERROR, message });
       state.iteration.span.setAttribute("error.type", errType);
@@ -306,20 +332,25 @@ export function telemetryDev(
     onStart(ctx) {
       try {
         const rawMetadata = ctx.options?.["metadata"];
+
         const metadata =
           rawMetadata && isObject(rawMetadata)
             ? (rawMetadata as Record<string, JsonValue>)
             : undefined;
+
         const userId = readId(metadata?.["userId"]);
         const sessionId = readId(metadata?.["sessionId"]) ?? ctx.threadId;
         let restMetadata: Record<string, JsonValue> | undefined;
+
         if (metadata) {
           const rest: Record<string, JsonValue> = {};
+
           for (const [key, value] of Object.entries(metadata)) {
             if (key !== "userId" && key !== "sessionId") {
               rest[key] = value;
             }
           }
+
           restMetadata = Object.keys(rest).length > 0 ? rest : undefined;
         }
 
@@ -329,6 +360,7 @@ export function telemetryDev(
           { startTime: new Date(), kind: SpanKind.INTERNAL },
           withSessionParent(otelContext.active(), sessionId ?? undefined, config.apiKey),
         );
+
         states.set(ctx, {
           rootSpan,
           rootCtx: trace.setSpan(ROOT_CONTEXT, rootSpan),
@@ -360,8 +392,10 @@ export function telemetryDev(
       // `chat({ outputSchema })` on adapters without native combined support. The latter needs
       // its own span — otherwise its onUsage would overwrite the last iteration's usage.
       if (ctx.phase !== "beforeModel" && ctx.phase !== "structuredOutput") return undefined;
+
       try {
         const state = states.get(ctx);
+
         if (!state) return undefined;
 
         // The previous iteration's span stays open through tool execution and onUsage so tool
@@ -369,19 +403,24 @@ export function telemetryDev(
         closeIteration(state);
 
         const inputMessages: Array<{ role: string; content: unknown }> = [];
+
         for (const prompt of chatConfig.systemPrompts) {
           inputMessages.push({
             role: "system",
             content: isString(prompt) ? prompt : prompt.content,
           });
         }
+
         for (const message of chatConfig.messages) {
           inputMessages.push({ role: message.role, content: message.content });
         }
+
         const inputJson = jsonAttr(inputMessages);
+
         const sampling = samplingAttributes(
           (chatConfig.modelOptions ?? ctx.modelOptions) as Record<string, JsonValue> | undefined,
         );
+
         if (!state.rootCaptured) {
           state.rootCaptured = true;
           state.rootInput = inputJson;
@@ -389,6 +428,7 @@ export function telemetryDev(
         }
 
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "chat",
           {
@@ -405,6 +445,7 @@ export function telemetryDev(
           },
           state.rootCtx,
         );
+
         state.iteration = {
           span,
           otelCtx: trace.setSpan(state.rootCtx, span),
@@ -418,42 +459,54 @@ export function telemetryDev(
       } catch (err) {
         onError?.(err);
       }
+
       return undefined;
     },
 
     onChunk(ctx, chunk) {
       if (chunk.type !== "RUN_FINISHED" && chunk.type !== "CUSTOM") return undefined;
+
       try {
         const state = states.get(ctx);
         const iteration = state?.iteration;
+
         if (!state || !iteration) return undefined;
+
         if (chunk.type === "CUSTOM") {
           // The finalization stream reports its JSON via this event; `ctx.accumulatedContent`
           // still holds the agent loop's text, so this is the structured span's only output.
           if (iteration.structured && chunk.name === "structured-output.complete") {
             const raw = (chunk.value as { raw?: unknown } | null | undefined)?.raw;
+
             if (isString(raw)) iteration.outputText = raw;
           }
+
           return undefined;
         }
+
         iteration.finishReason = chunk.finishReason ?? null;
+
         if (chunk.model) {
           iteration.responseModel = chunk.model;
           state.responseModel = chunk.model;
         }
+
         if (chunk.usage) iteration.usage = chunk.usage;
+
         if (!iteration.structured) {
           iteration.outputText = ctx.accumulatedContent.length > 0 ? ctx.accumulatedContent : null;
         }
       } catch (err) {
         onError?.(err);
       }
+
       return undefined;
     },
 
     onUsage(ctx, usage: UsageInfo) {
       try {
         const state = states.get(ctx);
+
         if (state?.iteration) {
           state.iteration.usage = usage;
         }
@@ -465,8 +518,10 @@ export function telemetryDev(
     onBeforeToolCall(ctx, hookCtx: ToolCallHookContext) {
       try {
         const state = states.get(ctx);
+
         if (!state) return undefined;
         const startedAt = new Date();
+
         const span = emitter.tracer.startSpan(
           "execute_tool",
           {
@@ -482,11 +537,13 @@ export function telemetryDev(
           },
           state.iteration?.otelCtx ?? state.rootCtx,
         );
+
         state.openTools.set(hookCtx.toolCallId, { span, startedAt });
         state.hasToolSpan = true;
       } catch (err) {
         onError?.(err);
       }
+
       return undefined;
     },
 
@@ -494,12 +551,14 @@ export function telemetryDev(
       try {
         const state = states.get(ctx);
         const entry = state?.openTools.get(info.toolCallId);
+
         if (!state || !entry) return;
         state.openTools.delete(info.toolCallId);
         const { span } = entry;
 
         if (info.ok) {
           const result = jsonAttr(info.result ?? null);
+
           if (result !== undefined) {
             span.setAttribute("gen_ai.tool.call.result", result);
           }
@@ -526,8 +585,10 @@ export function telemetryDev(
     async onToolPhaseComplete(ctx, info: ToolPhaseCompleteInfo) {
       // Ordinary tool phases finalize through the terminal hooks; only the wait path needs us.
       if (info.needsApproval.length === 0 && info.needsClientExecution.length === 0) return;
+
       try {
         const state = states.get(ctx);
+
         if (!state) return;
         states.delete(ctx);
 
@@ -539,6 +600,7 @@ export function telemetryDev(
           entry.span.end();
           state.childSpans.push(entry.span);
         }
+
         state.openTools.clear();
         const finishReason = state.iteration?.finishReason ?? "tool_calls";
         closeIteration(state);
@@ -559,6 +621,7 @@ export function telemetryDev(
         const waitingTools = [...info.needsApproval, ...info.needsClientExecution]
           .map((t) => t.toolName)
           .join(", ");
+
         addSummaryEvent(state, false, `Generation paused awaiting tools (${waitingTools})`);
 
         state.rootSpan.end();
@@ -572,6 +635,7 @@ export function telemetryDev(
     async onFinish(ctx, info: FinishInfo) {
       try {
         const state = states.get(ctx);
+
         if (!state) return;
         states.delete(ctx);
 
@@ -581,6 +645,7 @@ export function telemetryDev(
           entry.span.end();
           state.childSpans.push(entry.span);
         }
+
         state.openTools.clear();
         closeIteration(state);
 
@@ -593,21 +658,27 @@ export function telemetryDev(
         );
 
         const finishReason = info.finishReason ?? "unknown";
+
         const inputTokens = state.iterationMetrics.reduce(
           (sum, m) => sum + (m.inputTokens ?? 0),
           0,
         );
+
         const outputTokens = state.iterationMetrics.reduce(
           (sum, m) => sum + (m.outputTokens ?? 0),
           0,
         );
+
         const tokenParts: string[] = [];
+
         if (state.iterationMetrics.some((m) => m.inputTokens !== null)) {
           tokenParts.push(`${inputTokens} in`);
         }
+
         if (state.iterationMetrics.some((m) => m.outputTokens !== null)) {
           tokenParts.push(`${outputTokens} out`);
         }
+
         const tokenText = tokenParts.length > 0 ? `: ${tokenParts.join(" / ")} tokens` : "";
         addSummaryEvent(state, false, `Generation completed (${finishReason})${tokenText}`);
 
@@ -622,6 +693,7 @@ export function telemetryDev(
     async onError(ctx, info: ErrorInfo) {
       try {
         const state = states.get(ctx);
+
         if (!state) return;
         states.delete(ctx);
 
@@ -650,6 +722,7 @@ export function telemetryDev(
     async onAbort(ctx, info: AbortInfo) {
       try {
         const state = states.get(ctx);
+
         if (!state) return;
         states.delete(ctx);
 

--- a/packages/tanstack-ai/tests/middleware.test.ts
+++ b/packages/tanstack-ai/tests/middleware.test.ts
@@ -35,6 +35,7 @@ interface MetricRecord {
 function makeCapture() {
   const spanBatches: ReadableSpan[][] = [];
   const metrics: MetricRecord[] = [];
+
   const overrides = {
     sendSpans: async (spans: ReadableSpan[]) => {
       spanBatches.push(spans);
@@ -46,6 +47,7 @@ function makeCapture() {
       metrics.push({ metric: "tokens", tokenType, value, attributes });
     },
   };
+
   return { spanBatches, metrics, overrides };
 }
 
@@ -91,8 +93,10 @@ const chatConfig = (over?: Record<string, TestValue>) =>
 
 const spanId = (s: ReadableSpan) => s.spanContext().spanId;
 const traceId = (s: ReadableSpan) => s.spanContext().traceId;
+
 const byOperation = (spans: ReadableSpan[], operation: string) =>
   spans.filter((s) => s.attributes["gen_ai.operation.name"] === operation);
+
 const event = (s: ReadableSpan, name: string) => s.events.find((ev) => ev.name === name);
 
 const middleware = (overrides: ReturnType<typeof makeCapture>["overrides"]) =>
@@ -217,9 +221,11 @@ test("bigint metadata IDs populate user and conversation attributes", async () =
   await mw.onFinish?.(ctx, { finishReason: "stop", duration: 5, content: "ok" } as never);
 
   const spans = spanBatches[0]!;
+
   for (const s of spans) {
     expect(s.attributes["gen_ai.conversation.id"]).toBe("9");
   }
+
   const root = spans.find((s) => s.kind === SpanKind.INTERNAL)!;
   expect(root.attributes["user.id"]).toBe("2");
   // Reserved keys never leak into td.metadata.*.
@@ -238,9 +244,11 @@ test("string metadata IDs override threadId and populate user attributes", async
   await mw.onFinish?.(ctx, { finishReason: "stop", duration: 5, content: "ok" } as never);
 
   const spans = spanBatches[0]!;
+
   for (const span of spans) {
     expect(span.attributes["gen_ai.conversation.id"]).toBe("sess_9");
   }
+
   const root = spans.find((span) => span.kind === SpanKind.INTERNAL)!;
   expect(root.attributes["user.id"]).toBe("u2");
 });
@@ -341,9 +349,11 @@ test("a failed tool call records ERROR status and an exception event", async () 
   const tools = byOperation(spans, "execute_tool");
   const iteration = spans.find((s) => s.kind === SpanKind.CLIENT)!;
   expect(tools).toHaveLength(2);
+
   for (const t of tools) {
     expect(t.parentSpanContext?.spanId).toBe(spanId(iteration));
   }
+
   const failed = tools.find((t) => t.attributes["gen_ai.tool.name"] === "t2")!;
   expect(failed.status.code).toBe(SpanStatusCode.ERROR);
   expect(failed.attributes["error.type"]).toBe("Error");
@@ -445,29 +455,35 @@ test("one middleware instance handles concurrent chats independently", async () 
 test("chats on one thread share one trace under the session parent", async () => {
   const { spanBatches, overrides } = makeCapture();
   const mw = middleware(overrides);
+
   const run = async (ctx: ChatMiddlewareContext) => {
     await mw.onStart?.(ctx);
     await mw.onConfig?.(ctx, chatConfig());
     await mw.onChunk?.(ctx, { type: "RUN_FINISHED", finishReason: "stop" } as never);
     await mw.onFinish?.(ctx, { finishReason: "stop", duration: 5, content: "ok" } as never);
   };
+
   await run(makeCtx({ runId: "run_1" }));
   await run(makeCtx({ runId: "run_2" }));
   await run(makeCtx({ threadId: "thread_other" }));
 
   const session = sessionSpanContext("td_live_test", "thread_1");
   const [batch1, batch2, batch3] = spanBatches;
+
   for (const s of [...batch1!, ...batch2!]) expect(s.spanContext().traceId).toBe(session.traceId);
+
   for (const batch of [batch1!, batch2!]) {
     const root = batch.find((s) => s.kind === SpanKind.INTERNAL)!;
     expect(root.parentSpanContext?.spanId).toBe(session.spanId);
   }
+
   expect(batch3![0]!.spanContext().traceId).not.toBe(session.traceId);
 });
 
 test("export failure reaches onError even on the waitUntil path", async () => {
   const errors: unknown[] = [];
   let handed: Promise<unknown> | undefined;
+
   const mw = telemetryDev(
     {
       apiKey: "td_live_test",
@@ -488,6 +504,7 @@ test("export failure reaches onError even on the waitUntil path", async () => {
       recordTokens: () => {},
     },
   );
+
   const ctx = makeCtx();
 
   await mw.onStart?.(ctx);
@@ -506,21 +523,27 @@ test("export failure reaches onError even on the waitUntil path", async () => {
 test("metric export retries a transient ingest failure", async () => {
   const errors: unknown[] = [];
   let metricCalls = 0;
+
   const mw = telemetryDev({
     apiKey: "td_live_metric_retry",
     environment: "test",
     serviceName: "metric-retry",
     fetch: async (url: string | Request | URL, _init?: RequestInit) => {
-      if (String(url).endsWith("/v1/metrics")) {
+      const href = url instanceof Request ? url.url : url.toString();
+
+      if (href.endsWith("/v1/metrics")) {
         metricCalls += 1;
+
         return new Response(null, { status: metricCalls === 1 ? 503 : 200 });
       }
+
       return new Response(null, { status: 200 });
     },
     onError: (e) => {
       errors.push(e);
     },
   });
+
   const ctx = makeCtx();
 
   await mw.onStart?.(ctx);
@@ -642,6 +665,7 @@ test("structured output finalization records a separate iteration span", async (
   const structuredIteration = iterations.find(
     (s) => s.attributes["gen_ai.output.type"] === "json",
   )!;
+
   expect(structuredIteration.attributes["gen_ai.usage.input_tokens"]).toBe(7);
   expect(structuredIteration.attributes["gen_ai.usage.output_tokens"]).toBe(3);
   expect(structuredIteration.attributes["gen_ai.output.messages"]).toBe('{"a":1}');
@@ -653,6 +677,7 @@ test("structured output finalization records a separate iteration span", async (
   const inputTokens = metrics
     .filter((m) => m.metric === "tokens" && m.tokenType === "input")
     .map((m) => m.value);
+
   expect(inputTokens).toEqual([10, 7]);
 });
 
@@ -870,10 +895,12 @@ test("session chats export spans only when the configured sampler selects them",
     new TraceIdRatioBasedSampler(0.5),
     { shouldSample: () => ({ decision: SamplingDecision.RECORD }), toString: () => "RecordOnly" },
   ];
+
   for (const root of roots) {
     const sampler = new ParentBasedSampler({ root });
     const { spanBatches, overrides } = makeCapture();
     const errors: unknown[] = [];
+
     const mw = telemetryDev(
       {
         apiKey: "td_live_test",
@@ -883,10 +910,13 @@ test("session chats export spans only when the configured sampler selects them",
       },
       overrides,
     );
+
     const expected: string[] = [];
+
     for (let i = 0; i < 20; i++) {
       const threadId = `session-${i}`;
       const id = sessionSpanContext("td_live_test", threadId).traceId;
+
       if (
         sampler.shouldSample(ROOT_CONTEXT, id, "chat", SpanKind.INTERNAL, {}, []).decision ===
         SamplingDecision.RECORD_AND_SAMPLED
@@ -898,6 +928,7 @@ test("session chats export spans only when the configured sampler selects them",
       await mw.onChunk?.(ctx, { type: "RUN_FINISHED", finishReason: "stop" } as never);
       await mw.onFinish?.(ctx, { finishReason: "stop", duration: 5, content: "ok" } as never);
     }
+
     expect(spanBatches.flat().map(traceId)).toEqual(expected);
     expect(errors).toEqual([]);
   }

--- a/sdks/python-anthropic/src/telemetry_dev_anthropic/__init__.py
+++ b/sdks/python-anthropic/src/telemetry_dev_anthropic/__init__.py
@@ -366,6 +366,24 @@ def _record_stream_event(event: Any, state: _StreamState) -> dict[str, Any]:
     return update
 
 
+def _stream_event_has_output(event: Any) -> bool:
+    event_type = _string(_field(event, "type"))
+    value = (
+        _field(event, "delta")
+        if event_type == "content_block_delta"
+        else _field(event, "content_block")
+    )
+    if event_type not in ("content_block_start", "content_block_delta"):
+        return False
+    if any(
+        isinstance(_field(value, key), str) and bool(_field(value, key))
+        for key in ("text", "thinking", "partial_json")
+    ):
+        return True
+    input_value = _field(value, "input")
+    return input_value not in (None, "", [], {})
+
+
 class _InstrumentedStream:
     def __init__(self, inner: Any, handle: telemetry_dev.SpanHandle, started_at: float) -> None:
         self._inner = inner
@@ -397,6 +415,7 @@ class _InstrumentedStream:
             while True:
                 try:
                     event = next(self._inner)
+                    received_at = time.perf_counter()
                 except StopIteration:
                     break
                 except BaseException as exc:
@@ -409,6 +428,10 @@ class _InstrumentedStream:
                     if client is not None:
                         client.report("failed to map Anthropic stream event", exc)
                     update = {}
+                if _stream_event_has_output(event):
+                    record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+                    if callable(record_output_chunk):
+                        record_output_chunk(received_at * 1000)
                 self._update_first(update)
                 yield event
         finally:
@@ -476,6 +499,7 @@ class _InstrumentedAsyncStream:
             while True:
                 try:
                     event = await self._inner.__anext__()
+                    received_at = time.perf_counter()
                 except StopAsyncIteration:
                     break
                 except BaseException as exc:
@@ -488,6 +512,10 @@ class _InstrumentedAsyncStream:
                     if client is not None:
                         client.report("failed to map Anthropic stream event", exc)
                     update = {}
+                if _stream_event_has_output(event):
+                    record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+                    if callable(record_output_chunk):
+                        record_output_chunk(received_at * 1000)
                 self._update_first(update)
                 yield event
         finally:

--- a/sdks/python-anthropic/tests/test_anthropic.py
+++ b/sdks/python-anthropic/tests/test_anthropic.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import anthropic
 import httpx
 import pytest
+import telemetry_dev
 from anthropic import Anthropic, AsyncAnthropic
 from anthropic.resources.messages import AsyncMessages, Messages
 from anthropic.types import MessageParam, TextBlock
@@ -446,7 +447,21 @@ def test_tool_use_response_output_is_preserved(memory: SimpleNamespace) -> None:
     assert json.loads(str(a["gen_ai.input.messages"])) == {"messages": MESSAGES, "tools": [tool]}
 
 
-def test_create_streaming_preserves_events_and_records_aggregate(memory: SimpleNamespace) -> None:
+def test_create_streaming_preserves_events_and_records_aggregate(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    timestamps: list[float] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        timestamps.append(timestamp_ms)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+
     def handler(request: httpx.Request) -> httpx.Response:
         assert request_json(request)["stream"] is True
         return named_sse_response(stream_events())
@@ -468,6 +483,7 @@ def test_create_streaming_preserves_events_and_records_aggregate(memory: SimpleN
     assert a["gen_ai.response.model"] == "claude-sonnet-4-6"
     assert list(cast(Any, a["gen_ai.response.finish_reasons"])) == ["end_turn"]
     assert isinstance(a["gen_ai.response.time_to_first_chunk"], float)
+    assert len(timestamps) == 2
 
 
 def test_stream_mapping_error_reports_and_still_yields_provider_event(make: Any) -> None:
@@ -524,7 +540,21 @@ def test_streaming_response_helper_preserves_api_response(memory: SimpleNamespac
     assert memory.span_exporter.get_finished_spans() == ()
 
 
-async def test_async_create_streaming_matches_sync(memory: SimpleNamespace) -> None:
+async def test_async_create_streaming_matches_sync(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    timestamps: list[float] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        timestamps.append(timestamp_ms)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request_json(request)["stream"] is True
         return named_sse_response(stream_events())
@@ -537,6 +567,7 @@ async def test_async_create_streaming_matches_sync(memory: SimpleNamespace) -> N
     await client.close()
 
     assert [event.type for event in events] == [event["type"] for event in stream_events()]
+    assert len(timestamps) == 2
     a = attrs(only_span(memory))
     assert json.loads(str(a["gen_ai.output.messages"])) == [
         {"role": "assistant", "content": [{"type": "text", "text": "Hello world"}]}

--- a/sdks/python-bedrock/src/telemetry_dev_bedrock/_instrument.py
+++ b/sdks/python-bedrock/src/telemetry_dev_bedrock/_instrument.py
@@ -164,7 +164,9 @@ def _call_with_span(
 
         return {
             **response,
-            stream_key: InstrumentedEventStream(response[stream_key], state, finish, started_at),
+            stream_key: InstrumentedEventStream(
+                response[stream_key], state, finish, started_at, handle
+            ),
         }
 
     end(**merge_fields(metadata_fields(response), spec.response_fields(api_params, response)))

--- a/sdks/python-bedrock/src/telemetry_dev_bedrock/_streams.py
+++ b/sdks/python-bedrock/src/telemetry_dev_bedrock/_streams.py
@@ -12,11 +12,53 @@ from ._messages import normalize_content_block
 
 
 class StreamState:
-    def feed(self, event: Any) -> None:
+    def feed(self, event: Any) -> bool | None:
         raise NotImplementedError
 
     def finish(self, *, partial: bool) -> dict[str, Any]:
         raise NotImplementedError
+
+
+def _event_has_output(event: Any) -> bool:
+    if not isinstance(event, dict):
+        return False
+    output = event.get("output") if isinstance(event.get("output"), dict) else {}
+    if isinstance(output.get("text"), str) and output["text"]:
+        return True
+    block = (
+        event.get("contentBlockDelta") if isinstance(event.get("contentBlockDelta"), dict) else {}
+    )
+    delta = block.get("delta") if isinstance(block.get("delta"), dict) else {}
+    reasoning = (
+        delta.get("reasoningContent") if isinstance(delta.get("reasoningContent"), dict) else {}
+    )
+    tool_use = delta.get("toolUse") if isinstance(delta.get("toolUse"), dict) else {}
+    if any(
+        isinstance(value, str) and bool(value)
+        for value in (delta.get("text"), reasoning.get("text"), tool_use.get("input"))
+    ):
+        return True
+    chunk = event.get("chunk") if isinstance(event.get("chunk"), dict) else {}
+    raw = chunk.get("bytes")
+    if isinstance(raw, bytes | bytearray):
+        text = bytes(raw).decode("utf-8", errors="replace")
+    elif isinstance(raw, str):
+        text = raw
+    else:
+        return False
+    if not text:
+        return False
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return True
+    if isinstance(parsed, dict) and isinstance(parsed.get("delta"), dict):
+        if any(
+            isinstance(value, str) and bool(value)
+            for value in (parsed["delta"].get("thinking"), parsed["delta"].get("partial_json"))
+        ):
+            return True
+    return bool(_text_from_provider_chunk(parsed))
 
 
 class ConverseStreamState(StreamState):
@@ -215,9 +257,9 @@ class InvokeModelStreamState(StreamState):
         self.usage: dict[str, int] = {}
         self.finish_reason: str | None = None
 
-    def feed(self, event: Any) -> None:
+    def feed(self, event: Any) -> bool:
         if not isinstance(event, dict):
-            return
+            return False
         chunk = event.get("chunk") if isinstance(event.get("chunk"), dict) else {}
         raw = chunk.get("bytes")
         if isinstance(raw, bytes | bytearray):
@@ -225,11 +267,11 @@ class InvokeModelStreamState(StreamState):
         elif isinstance(raw, str):
             text = raw
         else:
-            return
+            return False
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:
-            return
+            return bool(text)
         if self.budget.accept(parsed):
             self.chunks.append(parsed)
         if isinstance(parsed, dict):
@@ -282,6 +324,14 @@ class InvokeModelStreamState(StreamState):
                     }
                 )
             )
+        if isinstance(parsed, dict) and isinstance(parsed.get("delta"), dict):
+            delta = parsed["delta"]
+            if any(
+                isinstance(value, str) and bool(value)
+                for value in (delta.get("thinking"), delta.get("partial_json"))
+            ):
+                return True
+        return bool(_text_from_provider_chunk(parsed))
 
     def finish(self, *, partial: bool) -> dict[str, Any]:
         del partial
@@ -499,27 +549,40 @@ class InstrumentedEventStream:
         state: StreamState,
         finish: Callable[[dict[str, Any]], None],
         started_at: float,
+        handle: Any,
     ) -> None:
         self._stream = stream
         self._state = state
         self._finish_callback = finish
         self._started_at = started_at
+        self._handle = handle
         self._ended = False
         self._first = False
+        self._track_output_chunks = isinstance(state, ConverseStreamState | InvokeModelStreamState)
 
     def __iter__(self) -> Iterator[Any]:
         completed = False
         try:
             for event in self._stream:
+                received_at = time.perf_counter()
                 if not self._first:
                     self._first = True
                     self._finish_callback(
-                        {"time_to_first_chunk_ms": (time.perf_counter() - self._started_at) * 1000}
+                        {"time_to_first_chunk_ms": (received_at - self._started_at) * 1000}
                     )
                 try:
-                    self._state.feed(event)
+                    state_has_output = self._state.feed(event)
                 except Exception:
-                    pass
+                    state_has_output = None
+                if self._track_output_chunks and (
+                    state_has_output if state_has_output is not None else _event_has_output(event)
+                ):
+                    try:
+                        record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+                        if callable(record_output_chunk):
+                            record_output_chunk(received_at * 1000)
+                    except Exception:
+                        pass
                 yield event
             completed = True
         except GeneratorExit:

--- a/sdks/python-bedrock/tests/test_bedrock.py
+++ b/sdks/python-bedrock/tests/test_bedrock.py
@@ -14,6 +14,7 @@ from botocore.client import BaseClient
 from botocore.exceptions import ClientError, EventStreamError
 from botocore.response import StreamingBody
 
+import telemetry_dev_bedrock._streams as bedrock_streams
 from telemetry_dev_bedrock import instrument_bedrock, uninstrument_bedrock, wrap_bedrock
 
 
@@ -305,6 +306,41 @@ def test_converse_stream_bounds_retained_state_without_dropping_events(
     assert list(span.attributes["gen_ai.response.finish_reasons"]) == ["max_tokens"]
 
 
+def test_chunk_timing_includes_reasoning_and_tool_arguments_not_usage(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[float | None] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        calls.append(timestamp_ms)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    events = [
+        {"chunk": {"bytes": _body(payload)}}
+        for payload in [
+            {"message": {"usage": {"input_tokens": 2}}},
+            {"delta": {"thinking": "reasoning"}},
+            {"delta": {"signature": "signature"}},
+            {"delta": {"partial_json": '{"city":'}},
+            {"delta": {"partial_json": ""}},
+        ]
+    ]
+    client = _client("bedrock-runtime")
+    _stub_api_call(client, [{"body": FakeEventStream(events)}], monkeypatch)
+    wrap_bedrock(client)
+    response = cast(Any, client).invoke_model_with_response_stream(
+        modelId="anthropic.claude-3-haiku",
+        contentType="application/json",
+        body=_body({"messages": [], "max_tokens": 10}),
+    )
+    assert list(response["body"]) == events
+    assert len(calls) == 2
+
+
 def test_invoke_model_stream_bounds_content_but_keeps_terminal_metadata(
     memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -526,6 +562,37 @@ def test_invoke_model_provider_native_and_streaming_body(
     assert mistral_span.attributes["gen_ai.usage.output_tokens"] == 12
     assert failed_read_span.attributes["gen_ai.response.id"] == "invoke-read-failed"
     assert _json_attr(stream_span, "gen_ai.output.messages")[0]["finish_reason"] == "end_turn"
+
+
+def test_invoke_stream_decodes_once_and_delivers_malformed_payload(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = [
+        {"chunk": {"bytes": _body({"delta": {"text": "hi"}})}},
+        {"chunk": {"bytes": b"not-json"}},
+    ]
+    client = _client("bedrock-runtime")
+    _stub_api_call(client, [{"body": FakeEventStream(events)}], monkeypatch)
+    loads = bedrock_streams.json.loads
+    calls = 0
+
+    def counting_loads(value: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return loads(value)
+
+    monkeypatch.setattr(bedrock_streams.json, "loads", counting_loads)
+    wrap_bedrock(client)
+    response = client.invoke_model_with_response_stream(  # type: ignore[attr-defined]
+        modelId="anthropic.claude-3-haiku",
+        contentType="application/json",
+        body=_body({"messages": [], "max_tokens": 10}),
+    )
+    before = calls
+
+    assert list(response["body"]) == events
+    assert calls - before == 2
+    assert len(memory.span_exporter.get_finished_spans()) == 1
 
 
 def test_invoke_model_streaming_body_preserves_read_all_and_context_manager(

--- a/sdks/python-google-genai/src/telemetry_dev_google_genai/__init__.py
+++ b/sdks/python-google-genai/src/telemetry_dev_google_genai/__init__.py
@@ -735,6 +735,49 @@ def _first_chunk_update(chunk: Any, handle: telemetry_dev.SpanHandle, started_at
         return
 
 
+def _chunk_has_output(chunk: Any) -> bool:
+    for candidate in _sequence_items(_field(chunk, "candidates")):
+        content = _field(candidate, "content")
+        for part in _sequence_items(_field(content, "parts")):
+            text = _field(part, "text")
+            function_call = _field(part, "function_call") or _field(part, "functionCall")
+            args = _field(function_call, "args")
+            partial_args = _field(function_call, "partial_args") or _field(
+                function_call, "partialArgs"
+            )
+            inline_data = _field(part, "inline_data") or _field(part, "inlineData")
+            mime_type = _string(_field(inline_data, "mime_type")) or _string(
+                _field(inline_data, "mimeType")
+            )
+            data = _field(inline_data, "data")
+            has_partial_arg_value = any(
+                isinstance(_field(partial_arg, "bool_value"), bool)
+                or isinstance(_field(partial_arg, "boolValue"), bool)
+                or isinstance(_field(partial_arg, "number_value"), int | float)
+                or isinstance(_field(partial_arg, "numberValue"), int | float)
+                or bool(
+                    _string(_field(partial_arg, "string_value"))
+                    or _string(_field(partial_arg, "stringValue"))
+                )
+                or _field(partial_arg, "null_value") == "NULL_VALUE"
+                or _field(partial_arg, "nullValue") == "NULL_VALUE"
+                for partial_arg in _sequence_items(partial_args)
+            )
+            if (
+                (isinstance(text, str) and bool(text))
+                or args not in (None, "", [], {})
+                or has_partial_arg_value
+                or (
+                    mime_type is not None
+                    and mime_type.startswith("audio/")
+                    and isinstance(data, str | bytes)
+                    and bool(data)
+                )
+            ):
+                return True
+    return False
+
+
 class _ObservedStream:
     def __init__(
         self,
@@ -792,6 +835,7 @@ class _ObservedStream:
         )
         try:
             chunk = pull()
+            received_at = time.perf_counter()
         except StopIteration:
             self._end(**_clean_fields(self._fields()))
             raise
@@ -802,6 +846,10 @@ class _ObservedStream:
         finally:
             if token is not None:
                 _AFC_USAGE_STATE.reset(token)
+        if _chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             _first_chunk_update(chunk, self._handle, self._started_at)
@@ -875,6 +923,7 @@ class _ObservedAsyncStream:
         )
         try:
             chunk = await pull()
+            received_at = time.perf_counter()
         except StopAsyncIteration:
             self._end(**_clean_fields(self._fields()))
             raise
@@ -885,6 +934,10 @@ class _ObservedAsyncStream:
         finally:
             if token is not None:
                 _AFC_USAGE_STATE.reset(token)
+        if _chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             _first_chunk_update(chunk, self._handle, self._started_at)

--- a/sdks/python-google-genai/tests/test_google_genai.py
+++ b/sdks/python-google-genai/tests/test_google_genai.py
@@ -71,6 +71,8 @@ class FakeTransport:
         self.calls.append(request_dict)
         payloads = self._next()
         for payload in payloads:
+            if isinstance(payload, BaseException):
+                raise payload
             yield types.HttpResponse(headers={}, body=json.dumps(payload))
 
     async def async_request(
@@ -94,6 +96,8 @@ class FakeTransport:
 
         async def async_generator() -> AsyncIterator[types.HttpResponse]:
             for payload in payloads:
+                if isinstance(payload, BaseException):
+                    raise payload
                 yield types.HttpResponse(headers={}, body=json.dumps(payload))
 
         return async_generator()
@@ -448,6 +452,142 @@ def test_streaming_aggregates_output_usage_and_first_chunk(
         {"role": "model", "parts": [{"text": "Hello world"}]}
     ]
     assert a["gen_ai.usage.total_tokens"] == 7
+
+
+@pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("interrupted", [False, True], ids=["completed", "interrupted"])
+@pytest.mark.parametrize(
+    "partial_args",
+    [
+        [{"jsonPath": "$.enabled", "boolValue": False}],
+        [{"jsonPath": "$.retries", "numberValue": 0}],
+        [
+            {"jsonPath": "$.enabled", "boolValue": False},
+            {"jsonPath": "$.retries", "numberValue": 0},
+        ],
+    ],
+)
+def test_vertex_streaming_counts_partial_function_argument_values(
+    memory: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    async_mode: bool,
+    interrupted: bool,
+    partial_args: list[dict[str, Any]],
+) -> None:
+    recorded: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        recorded.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    shell = {
+        "candidates": [
+            {
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "set_flags",
+                                "partialArgs": [
+                                    {"jsonPath": "$.enabled", "willContinue": True},
+                                    {"jsonPath": "$.label", "stringValue": ""},
+                                ],
+                            }
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    partial_values = {
+        "candidates": [
+            {
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "set_flags",
+                                "partialArgs": partial_args,
+                            }
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    null_value = {
+        "candidates": [
+            {
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "set_flags",
+                                "partialArgs": [
+                                    {"jsonPath": "$.fallback", "nullValue": "NULL_VALUE"}
+                                ],
+                            }
+                        }
+                    ],
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+    payloads: list[dict[str, Any] | RuntimeError] = [shell, partial_values, null_value]
+    if interrupted:
+        payloads.append(RuntimeError("stream interrupted"))
+    client = genai.Client(api_key="test", vertexai=True)
+    transport = FakeTransport([payloads])
+    client._api_client.request_streamed = transport.request_streamed
+    client._api_client.async_request_streamed = transport.async_request_streamed
+    wrapped = wrap_google_genai(client)
+    chunks: list[Any] = []
+
+    if async_mode:
+        import asyncio
+
+        async def run() -> list[Any]:
+            stream = await wrapped.aio.models.generate_content_stream(
+                model="gemini-2.5-flash", contents=USER_CONTENT
+            )
+            return [chunk async for chunk in stream]
+
+        if interrupted:
+            with pytest.raises(RuntimeError, match="stream interrupted"):
+                asyncio.run(run())
+        else:
+            chunks = asyncio.run(run())
+    else:
+        stream = wrapped.models.generate_content_stream(
+            model="gemini-2.5-flash", contents=USER_CONTENT
+        )
+        if interrupted:
+            with pytest.raises(RuntimeError, match="stream interrupted"):
+                list(stream)
+        else:
+            chunks = list(stream)
+
+    assert len(recorded) == 2
+    if not interrupted:
+        decoded_partial_args = chunks[1].candidates[0].content.parts[0].function_call.partial_args
+        assert decoded_partial_args == [
+            types.PartialArg.model_validate(part) for part in partial_args
+        ]
+    span = only_span(memory)
+    assert attrs(span)["gen_ai.provider.name"] == "gcp.vertex_ai"
+    assert span.status.status_code == (StatusCode.ERROR if interrupted else StatusCode.UNSET)
 
 
 @pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])

--- a/sdks/python-litellm/src/telemetry_dev_litellm/__init__.py
+++ b/sdks/python-litellm/src/telemetry_dev_litellm/__init__.py
@@ -415,13 +415,14 @@ class _InstrumentedStream:
     def __next__(self) -> Any:
         try:
             chunk = next(self._inner)
+            received_at = time.perf_counter()
         except StopIteration:
             self.close()
             raise
         except BaseException as exc:
             self._finish(error=exc)
             raise
-        self._record(chunk)
+        self._record(chunk, received_at)
         return chunk
 
     def __aiter__(self) -> AsyncIterator[Any]:
@@ -430,13 +431,14 @@ class _InstrumentedStream:
     async def __anext__(self) -> Any:
         try:
             chunk = await self._inner.__anext__()
+            received_at = time.perf_counter()
         except StopAsyncIteration:
             await self.aclose()
             raise
         except BaseException as exc:
             self._finish(error=exc)
             raise
-        self._record(chunk)
+        self._record(chunk, received_at)
         return chunk
 
     def __enter__(self) -> _InstrumentedStream:
@@ -469,7 +471,7 @@ class _InstrumentedStream:
             return bool(await _maybe_await(exit_method(exc_type, exc, tb)))
         return False
 
-    def _record(self, chunk: Any) -> None:
+    def _record(self, chunk: Any, received_at: float) -> None:
         response_id = _string(_field(chunk, "id"))
         if self._response_id is None and response_id is not None:
             self._response_id = response_id
@@ -479,13 +481,42 @@ class _InstrumentedStream:
         usage = _usage_from(_field(chunk, "usage"))
         if usage is not None:
             self._usage = usage
+        has_output = False
         for fallback_index, choice in enumerate(_sequence_items(_field(chunk, "choices"))):
+            delta = _field(choice, "delta")
+            has_output = (
+                has_output
+                or any(
+                    isinstance(value, str) and bool(value)
+                    for value in (
+                        _field(delta, "content"),
+                        _field(delta, "reasoning_content"),
+                        _field(delta, "refusal"),
+                        _field(_field(delta, "audio"), "data"),
+                    )
+                )
+                or (
+                    isinstance(_field(_field(delta, "function_call"), "arguments"), str)
+                    and bool(_field(_field(delta, "function_call"), "arguments"))
+                )
+                or any(
+                    isinstance(arguments, str) and bool(arguments)
+                    for arguments in (
+                        _field(_field(tool, "function"), "arguments")
+                        for tool in _sequence_items(_field(delta, "tool_calls"))
+                    )
+                )
+            )
             finish_reason = _string(_field(choice, "finish_reason"))
             if finish_reason is not None:
                 choice_index = _number(_field(choice, "index"))
                 self._finish_reasons[
                     int(choice_index) if choice_index is not None else fallback_index
                 ] = finish_reason
+        if has_output:
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(

--- a/sdks/python-litellm/tests/test_litellm.py
+++ b/sdks/python-litellm/tests/test_litellm.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import litellm
 import pytest
+import telemetry_dev
 from litellm.exceptions import MidStreamFallbackError
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.trace import StatusCode
@@ -284,6 +285,17 @@ def test_streaming_accumulates_content_ttfc_and_usage(memory: SimpleNamespace) -
 def test_streaming_bounds_retained_chunks_without_dropping_output(
     memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    calls: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        calls.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
     chunks = [
         SimpleNamespace(
             id=None,
@@ -298,6 +310,38 @@ def test_streaming_bounds_retained_chunks_without_dropping_output(
         )
         for _ in range(1100)
     ]
+    chunks.extend(
+        [
+            SimpleNamespace(
+                id=None,
+                model=None,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        delta=SimpleNamespace(
+                            content=None,
+                            function_call=SimpleNamespace(name="lookup", arguments=""),
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            SimpleNamespace(
+                id=None,
+                model=None,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        delta=SimpleNamespace(
+                            content=None,
+                            function_call=SimpleNamespace(name=None, arguments='{"city":'),
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+            ),
+        ]
+    )
     chunks.append(
         SimpleNamespace(
             id="bounded-stream",
@@ -305,7 +349,7 @@ def test_streaming_bounds_retained_chunks_without_dropping_output(
             choices=[
                 SimpleNamespace(
                     index=0,
-                    delta=SimpleNamespace(content=None),
+                    delta=SimpleNamespace(content="tail"),
                     finish_reason="length",
                 ),
                 SimpleNamespace(
@@ -345,6 +389,7 @@ def test_streaming_bounds_retained_chunks_without_dropping_output(
     assert a["gen_ai.usage.input_tokens"] == 11
     assert a["gen_ai.usage.output_tokens"] == 7
     assert a["gen_ai.usage.total_tokens"] == 18
+    assert len(calls) == 1102
 
 
 def test_streaming_exposes_litellm_stream_attributes(memory: SimpleNamespace) -> None:
@@ -482,7 +527,20 @@ def test_streaming_mid_stream_error_records_error(memory: SimpleNamespace) -> No
     assert a["gen_ai.provider.name"] == "anthropic"
 
 
-async def test_async_completion_and_stream(memory: SimpleNamespace) -> None:
+async def test_async_completion_and_stream(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    timestamps: list[float] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        timestamps.append(timestamp_ms)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
     instrument_litellm()
     completion = await llm.acompletion(
         model="gpt-4o-mini",
@@ -504,6 +562,7 @@ async def test_async_completion_and_stream(memory: SimpleNamespace) -> None:
     assert json_attr(attrs(stream_span)["gen_ai.output.messages"]) == [
         {"content": "Async stream", "role": "assistant"}
     ]
+    assert timestamps
 
 
 async def test_async_streaming_bounds_retained_chunks_without_dropping_output(

--- a/sdks/python-openai/src/telemetry_dev_openai/__init__.py
+++ b/sdks/python-openai/src/telemetry_dev_openai/__init__.py
@@ -360,6 +360,46 @@ def _synthetic_usage_chunk(chunk: Any) -> bool:
     return _field(chunk, "usage") is not None and len(choices) == 0
 
 
+def _chat_chunk_has_output(chunk: Any) -> bool:
+    for choice in _sequence_items(_field(chunk, "choices")):
+        delta = _field(choice, "delta")
+        for key in ("content", "refusal"):
+            value = _field(delta, key)
+            if isinstance(value, str) and value:
+                return True
+        audio = _field(delta, "audio")
+        if isinstance(_field(audio, "data"), str) and _field(audio, "data"):
+            return True
+        legacy_arguments = _field(_field(delta, "function_call"), "arguments")
+        if isinstance(legacy_arguments, str) and legacy_arguments:
+            return True
+        for tool_call in _sequence_items(_field(delta, "tool_calls")):
+            arguments = _field(_field(tool_call, "function"), "arguments")
+            if isinstance(arguments, str) and arguments:
+                return True
+    return False
+
+
+def _response_event_has_output(event: Any) -> bool:
+    event_type = _string(_field(event, "type")) or ""
+    if event_type not in {
+        "response.output_text.delta",
+        "response.refusal.delta",
+        "response.reasoning_text.delta",
+        "response.reasoning_summary_text.delta",
+        "response.function_call_arguments.delta",
+        "response.custom_tool_call_input.delta",
+        "response.code_interpreter_call_code.delta",
+        "response.mcp_call_arguments.delta",
+        "response.output_audio.delta",
+        "response.audio.delta",
+        "response.audio.transcript.delta",
+    }:
+        return False
+    delta = _field(event, "delta")
+    return isinstance(delta, str) and bool(delta)
+
+
 def _response_failed_error(response: Any) -> RuntimeError:
     error = _field(response, "error")
     if error is None:
@@ -449,6 +489,7 @@ class _InstrumentedStream:
                 self._in_next = True
                 try:
                     chunk = next(self._inner)
+                    received_at = time.perf_counter()
                 except StopIteration:
                     break
                 except BaseException as exc:
@@ -456,7 +497,7 @@ class _InstrumentedStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(chunk)
+                self._record(chunk, received_at)
                 if self._injected_usage and _synthetic_usage_chunk(chunk):
                     continue
                 yield chunk
@@ -502,8 +543,12 @@ class _InstrumentedStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, chunk: Any) -> None:
+    def _record(self, chunk: Any, received_at: float) -> None:
         update = _record_chat_chunk(chunk, self._states, self._budget)
+        if _chat_chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -542,6 +587,7 @@ class _InstrumentedAsyncStream:
                 self._in_next = True
                 try:
                     chunk = await self._inner.__anext__()
+                    received_at = time.perf_counter()
                 except StopAsyncIteration:
                     break
                 except BaseException as exc:
@@ -549,7 +595,7 @@ class _InstrumentedAsyncStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(chunk)
+                self._record(chunk, received_at)
                 if self._injected_usage and _synthetic_usage_chunk(chunk):
                     continue
                 yield chunk
@@ -600,8 +646,12 @@ class _InstrumentedAsyncStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, chunk: Any) -> None:
+    def _record(self, chunk: Any, received_at: float) -> None:
         update = _record_chat_chunk(chunk, self._states, self._budget)
+        if _chat_chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -632,6 +682,7 @@ class _InstrumentedResponsesStream:
                 self._in_next = True
                 try:
                     event = next(self._inner)
+                    received_at = time.perf_counter()
                 except StopIteration:
                     break
                 except BaseException as exc:
@@ -639,7 +690,7 @@ class _InstrumentedResponsesStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(event)
+                self._record(event, received_at)
                 yield event
         finally:
             self.close()
@@ -683,7 +734,11 @@ class _InstrumentedResponsesStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, event: Any) -> None:
+    def _record(self, event: Any, received_at: float) -> None:
+        if _response_event_has_output(event):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -734,6 +789,7 @@ class _InstrumentedAsyncResponsesStream:
                 self._in_next = True
                 try:
                     event = await self._inner.__anext__()
+                    received_at = time.perf_counter()
                 except StopAsyncIteration:
                     break
                 except BaseException as exc:
@@ -741,7 +797,7 @@ class _InstrumentedAsyncResponsesStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(event)
+                self._record(event, received_at)
                 yield event
         finally:
             await self.close()
@@ -790,7 +846,11 @@ class _InstrumentedAsyncResponsesStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, event: Any) -> None:
+    def _record(self, event: Any, received_at: float) -> None:
+        if _response_event_has_output(event):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(

--- a/sdks/python-openai/tests/test_openai.py
+++ b/sdks/python-openai/tests/test_openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterator, Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any, cast
@@ -12,6 +13,7 @@ from openai import AsyncOpenAI, OpenAI
 from openai.resources.chat.completions.completions import AsyncCompletions, Completions
 from openai.resources.embeddings import AsyncEmbeddings, Embeddings
 from openai.resources.responses.responses import AsyncResponses, Responses
+from openai.types.chat import ChatCompletionChunk
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.trace import StatusCode
 from pydantic import BaseModel
@@ -487,6 +489,289 @@ def test_chat_streaming_injects_usage_when_opted_in_and_filters_synthetic_chunk(
     assert a["gen_ai.usage.input_tokens"] == 5
     assert a["gen_ai.usage.output_tokens"] == 2
     assert list(cast(Any, a["gen_ai.response.finish_reasons"])) == ["stop"]
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_chunk_timing_excludes_control_and_empty_deltas(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, async_mode: bool
+) -> None:
+    calls: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        calls.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    deltas: list[dict[str, Any]] = [
+        {"role": "assistant"},
+        {"content": "A"},
+        {"content": None},
+        {"content": ""},
+        {"tool_calls": []},
+        {"tool_calls": [{"index": 0, "function": {"arguments": '{"city":'}}]},
+        {"tool_calls": [{"index": 0, "function": {"arguments": ""}}]},
+        {"tool_calls": [{"index": 0, "function": {"arguments": '"Paris"}'}}]},
+        {"function_call": {"name": "lookup", "arguments": ""}},
+        {"function_call": {"name": "lookup"}},
+        {"function_call": {"arguments": '{"city":'}},
+        {"content": "once", "function_call": {"arguments": '"Paris"}'}},
+        {"content": "B"},
+        {},
+    ]
+    events: list[dict[str, Any]] = [
+        {
+            "id": "chatcmpl_timing",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": delta}],
+        }
+        for delta in deltas
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    if async_mode:
+        async_wrapped = wrap_openai(async_client(async_handler))
+        async_stream = await cast(Any, async_wrapped.chat.completions.create)(
+            model="gpt-4o", messages=CHAT_MESSAGES, stream=True
+        )
+        received = [chunk async for chunk in async_stream]
+        await async_wrapped.close()
+    else:
+        wrapped = wrap_openai(sync_client(handler))
+        stream = cast(Any, wrapped.chat.completions.create)(
+            model="gpt-4o", messages=CHAT_MESSAGES, stream=True
+        )
+        received = list(stream)
+        wrapped.close()
+    assert len(received) == len(events)
+    assert len(calls) == 6
+    assert memory.metric_reader.get_metrics_data() is not None
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_chunk_receipt_time_precedes_mapping(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, async_mode: bool
+) -> None:
+    clock = 12.0
+    recorded: list[float] = []
+    original_record = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float
+    ) -> telemetry_dev.SpanHandle:
+        recorded.append(timestamp_ms)
+        return original_record(handle, timestamp_ms)
+
+    def perf_counter() -> float:
+        return clock
+
+    original_getattribute = ChatCompletionChunk.__getattribute__
+
+    def delayed_choices(chunk: ChatCompletionChunk, name: str) -> Any:
+        nonlocal clock
+        if name == "choices":
+            clock = 47.0
+        return original_getattribute(chunk, name)
+
+    monkeypatch.setattr(time, "perf_counter", perf_counter)
+    monkeypatch.setattr(ChatCompletionChunk, "__getattribute__", delayed_choices)
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    events = [
+        {
+            "id": "chatcmpl_receipt",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": {"content": text}}],
+        }
+        for text in ["hello", " world"]
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    if async_mode:
+        async_wrapped = wrap_openai(async_client(async_handler))
+        async_stream = await async_wrapped.chat.completions.create(
+            model="gpt-4o", messages=[], stream=True
+        )
+        received = [chunk async for chunk in async_stream]
+        await async_wrapped.close()
+    else:
+        wrapped = wrap_openai(sync_client(handler))
+        stream = wrapped.chat.completions.create(model="gpt-4o", messages=[], stream=True)
+        received = list(stream)
+        wrapped.close()
+    assert len(received) == 2
+    assert recorded == [12_000.0, 47_000.0]
+    assert only_span(memory).status.status_code == StatusCode.UNSET
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("interrupted", [False, True])
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "response.custom_tool_call_input",
+        "response.code_interpreter_call_code",
+        "response.mcp_call_arguments",
+        "response.audio.transcript",
+    ],
+)
+async def test_responses_output_timing(
+    memory: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    async_mode: bool,
+    interrupted: bool,
+    event_type: str,
+) -> None:
+    calls: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        calls.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    output_events = [
+        {"type": f"{event_type}.delta", "delta": "first"},
+        {"type": f"{event_type}.delta", "delta": ""},
+        {"type": f"{event_type}.delta", "delta": "second"},
+        {
+            "type": f"{event_type}.done",
+            "input": "firstsecond",
+            "code": "firstsecond",
+            "arguments": "firstsecond",
+        },
+    ]
+    events = [
+        *output_events,
+        {"type": "response.completed", "response": response_payload()},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    if async_mode:
+        client = wrap_openai(async_client(async_handler))
+        stream = await cast(Any, client.responses.create)(
+            model="gpt-4o-mini", input="Run", stream=True
+        )
+        received = [await stream.__anext__() for _ in output_events]
+        if not interrupted:
+            received.extend([event async for event in stream])
+        await stream.close()
+        await client.close()
+    else:
+        client = wrap_openai(sync_client(handler))
+        stream = cast(Any, client.responses.create)(model="gpt-4o-mini", input="Run", stream=True)
+        received = [next(stream) for _ in output_events]
+        if not interrupted:
+            received.extend(stream)
+        stream.close()
+        client.close()
+
+    assert len(received) == len(output_events if interrupted else events)
+    assert received[0].delta == "first"
+    assert received[2].delta == "second"
+    assert len(calls) == 2
+    assert calls[0] is calls[1]
+    assert only_span(memory).status.status_code == StatusCode.UNSET
+
+
+@pytest.mark.parametrize(
+    "stream_kind", ["sync-chat", "async-chat", "sync-responses", "async-responses"]
+)
+async def test_streaming_preserves_tracing_without_output_chunk_support(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, stream_kind: str
+) -> None:
+    monkeypatch.delattr(telemetry_dev.SpanHandle, "record_output_chunk")
+
+    if stream_kind == "sync-chat":
+
+        def sync_chat_handler(request: httpx.Request) -> httpx.Response:
+            return sse_response(chat_stream_events())
+
+        client = wrap_openai(sync_client(sync_chat_handler))
+        received = list(
+            cast(Any, client.chat.completions.create)(
+                model="gpt-4o-mini", messages=CHAT_MESSAGES, stream=True
+            )
+        )
+        client.close()
+    elif stream_kind == "async-chat":
+
+        async def async_chat_handler(request: httpx.Request) -> httpx.Response:
+            return sse_response(chat_stream_events())
+
+        client = wrap_openai(async_client(async_chat_handler))
+        stream = await cast(Any, client.chat.completions.create)(
+            model="gpt-4o-mini", messages=CHAT_MESSAGES, stream=True
+        )
+        received = [chunk async for chunk in stream]
+        await client.close()
+    else:
+        delta = {
+            "type": "response.output_text.delta",
+            "sequence_number": 0,
+            "item_id": "item_old_core",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "Still traced.",
+        }
+        response = {
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response_payload(response_id="resp_old_core", text="Still traced."),
+        }
+        events = [("response.output_text.delta", delta), ("response.completed", response)]
+        if stream_kind == "sync-responses":
+
+            def sync_responses_handler(request: httpx.Request) -> httpx.Response:
+                return named_sse_response(events)
+
+            client = wrap_openai(sync_client(sync_responses_handler))
+            received = list(
+                cast(Any, client.responses.create)(model="gpt-4o-mini", input="stream", stream=True)
+            )
+            client.close()
+        else:
+
+            async def async_responses_handler(request: httpx.Request) -> httpx.Response:
+                return named_sse_response(events)
+
+            client = wrap_openai(async_client(async_responses_handler))
+            stream = await cast(Any, client.responses.create)(
+                model="gpt-4o-mini", input="stream", stream=True
+            )
+            received = [event async for event in stream]
+            await client.close()
+        assert len(received) == 2
+        assert received[0].delta == "Still traced."
+
+    assert received
+    span = only_span(memory)
+    assert span.status.status_code == StatusCode.UNSET
+    assert attrs(span)["gen_ai.response.id"] in {"chatcmpl_stream", "resp_old_core"}
 
 
 def test_chat_streaming_default_leaves_request_unchanged(memory: SimpleNamespace) -> None:

--- a/sdks/python-openrouter/src/telemetry_dev_openrouter/__init__.py
+++ b/sdks/python-openrouter/src/telemetry_dev_openrouter/__init__.py
@@ -446,6 +446,60 @@ def _record_chat_chunk(
     }
 
 
+def _chat_chunk_has_output(chunk: Any) -> bool:
+    for choice in _sequence_items(_field(chunk, "choices")):
+        delta = _field(choice, "delta")
+        if any(
+            isinstance(_field(delta, key), str) and _field(delta, key)
+            for key in ("content", "reasoning", "refusal")
+        ):
+            return True
+        audio = _field(delta, "audio")
+        if isinstance(_field(audio, "data"), str) and _field(audio, "data"):
+            return True
+        reasoning_details = [
+            *_sequence_items(_field(delta, "reasoning_details")),
+            *_sequence_items(_field(delta, "reasoningDetails")),
+        ]
+        if any(
+            isinstance(_field(detail, key), str) and _field(detail, key)
+            for detail in reasoning_details
+            for key in ("text", "summary")
+        ):
+            return True
+        for tool_call in _sequence_items(_field(delta, "tool_calls")):
+            arguments = _field(_field(tool_call, "function"), "arguments")
+            if isinstance(arguments, str) and arguments:
+                return True
+    return False
+
+
+def _response_event_has_output(event: Any) -> bool:
+    event = _response_event(event)
+    event_type = _string(_field(event, "type")) or ""
+    return (
+        event_type
+        in {
+            "response.output_text.delta",
+            "response.refusal.delta",
+            "response.reasoning_text.delta",
+            "response.reasoning_summary_text.delta",
+            "response.function_call_arguments.delta",
+            "response.custom_tool_call_input.delta",
+            "response.code_interpreter_call_code.delta",
+            "response.mcp_call_arguments.delta",
+            "response.apply_patch_call_operation_diff.delta",
+            "response.fusion_call.panel.delta",
+            "response.fusion_call.panel.reasoning.delta",
+            "response.output_audio.delta",
+            "response.audio.delta",
+            "response.audio.transcript.delta",
+        }
+        and isinstance(_field(event, "delta"), str)
+        and bool(_field(event, "delta"))
+    )
+
+
 def _chat_output(states: Mapping[int, _ChatChoice]) -> list[dict[str, Any]]:
     output: list[dict[str, Any]] = []
     for _, state in sorted(states.items()):
@@ -575,6 +629,7 @@ class _InstrumentedStream:
                 self._in_next = True
                 try:
                     chunk = next(self._inner)
+                    received_at = time.perf_counter()
                 except StopIteration:
                     break
                 except BaseException as exc:
@@ -582,7 +637,7 @@ class _InstrumentedStream:
                     raise
                 finally:
                     self._in_next = False
-                if not self._record(chunk):
+                if not self._record(chunk, received_at):
                     self._end(**self._partial(), error=_chunk_error(chunk))
                 yield chunk
         finally:
@@ -628,8 +683,12 @@ class _InstrumentedStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, chunk: Any) -> bool:
+    def _record(self, chunk: Any, received_at: float) -> bool:
         update = _record_chat_chunk(chunk, self._states, self._budget)
+        if _chat_chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -665,6 +724,7 @@ class _InstrumentedAsyncStream:
                 self._in_next = True
                 try:
                     chunk = await self._inner.__anext__()
+                    received_at = time.perf_counter()
                 except StopAsyncIteration:
                     break
                 except BaseException as exc:
@@ -672,7 +732,7 @@ class _InstrumentedAsyncStream:
                     raise
                 finally:
                     self._in_next = False
-                if not self._record(chunk):
+                if not self._record(chunk, received_at):
                     self._end(**self._partial(), error=_chunk_error(chunk))
                 yield chunk
         finally:
@@ -721,8 +781,12 @@ class _InstrumentedAsyncStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, chunk: Any) -> bool:
+    def _record(self, chunk: Any, received_at: float) -> bool:
         update = _record_chat_chunk(chunk, self._states, self._budget)
+        if _chat_chunk_has_output(chunk):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -1213,6 +1277,7 @@ class _InstrumentedResponsesStream:
                 self._in_next = True
                 try:
                     event = next(self._inner)
+                    received_at = time.perf_counter()
                 except StopIteration:
                     break
                 except BaseException as exc:
@@ -1220,7 +1285,7 @@ class _InstrumentedResponsesStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(event)
+                self._record(event, received_at)
                 yield event
         finally:
             self.close()
@@ -1262,7 +1327,11 @@ class _InstrumentedResponsesStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, event: Any) -> None:
+    def _record(self, event: Any, received_at: float) -> None:
+        if _response_event_has_output(event):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(
@@ -1301,6 +1370,7 @@ class _InstrumentedAsyncResponsesStream:
                 self._in_next = True
                 try:
                     event = await self._inner.__anext__()
+                    received_at = time.perf_counter()
                 except StopAsyncIteration:
                     break
                 except BaseException as exc:
@@ -1308,7 +1378,7 @@ class _InstrumentedAsyncResponsesStream:
                     raise
                 finally:
                     self._in_next = False
-                self._record(event)
+                self._record(event, received_at)
                 yield event
         finally:
             await self.close()
@@ -1353,7 +1423,11 @@ class _InstrumentedAsyncResponsesStream:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def _record(self, event: Any) -> None:
+    def _record(self, event: Any, received_at: float) -> None:
+        if _response_event_has_output(event):
+            record_output_chunk = getattr(self._handle, "record_output_chunk", None)
+            if callable(record_output_chunk):
+                record_output_chunk(received_at * 1000)
         if not self._saw_first:
             self._saw_first = True
             self._handle.update(

--- a/sdks/python-openrouter/tests/test_openrouter.py
+++ b/sdks/python-openrouter/tests/test_openrouter.py
@@ -461,6 +461,123 @@ def test_chat_streaming_captures_reasoning_details_and_refusal(memory: SimpleNam
     ]
 
 
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_chat_output_timing_decodes_reasoning_details_once_per_chunk(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, async_mode: bool
+) -> None:
+    calls: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        calls.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    events = [
+        chat_chunk({"role": "assistant", "content": ""}),
+        chat_chunk({"reasoning_details": [{"type": "reasoning.text", "text": "Inspect"}]}),
+        chat_chunk(
+            {
+                "content": "once",
+                "reasoning_details": [{"type": "reasoning.summary", "summary": "Summary"}],
+            }
+        ),
+        chat_chunk(
+            {"reasoning_details": [{"type": "reasoning.summary", "summary": "Summary only"}]}
+        ),
+        chat_chunk({"reasoning_details": [{"type": "reasoning.summary", "summary": ""}]}),
+        chat_chunk(
+            {
+                "reasoning_details": [
+                    {"type": "reasoning.encrypted", "data": "opaque"},
+                    {"type": "reasoning.text", "signature": "signed", "text": ""},
+                ]
+            }
+        ),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    if async_mode:
+        client = wrap_open_router(async_client(async_handler))
+        stream = await cast(Any, client.chat.send_async)(
+            model="openai/gpt-4o-mini", messages=CHAT_MESSAGES, stream=True
+        )
+        assert len([chunk async for chunk in stream]) == len(events)
+    else:
+        client = wrap_open_router(sync_client(handler))
+        stream = cast(Any, client.chat.send)(
+            model="openai/gpt-4o-mini", messages=CHAT_MESSAGES, stream=True
+        )
+        assert len(list(stream)) == len(events)
+
+    assert len(calls) == 3
+    assert len(memory.span_exporter.get_finished_spans()) == 1
+    assert memory.metric_reader.get_metrics_data() is not None
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_responses_output_timing_accepts_code_and_mcp_deltas_until_stream_end(
+    memory: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, async_mode: bool
+) -> None:
+    calls: list[telemetry_dev.SpanHandle] = []
+    original = telemetry_dev.SpanHandle.record_output_chunk
+
+    def record_output_chunk(
+        handle: telemetry_dev.SpanHandle, timestamp_ms: float | None = None
+    ) -> telemetry_dev.SpanHandle:
+        assert timestamp_ms is not None
+        calls.append(handle)
+        return original(handle, timestamp_ms)
+
+    monkeypatch.setattr(telemetry_dev.SpanHandle, "record_output_chunk", record_output_chunk)
+    events = [
+        {"type": "response.code_interpreter_call_code.delta", "delta": "print(1)"},
+        {"type": "response.code_interpreter_call_code.done", "code": "print(1)"},
+        {"type": "response.mcp_call_arguments.delta", "delta": '{"city":"Paris"}'},
+        {"type": "response.mcp_call_arguments.delta", "delta": ""},
+        {"type": "response.mcp_call_arguments.done", "arguments": '{"city":"Paris"}'},
+        {"type": "response.audio.transcript.delta", "delta": "hello"},
+        {"type": "response.audio.transcript.delta", "delta": ""},
+        {"type": "response.audio.transcript.done", "transcript": "hello"},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return sse_response(events)
+
+    if async_mode:
+        client = wrap_open_router(async_client(async_handler))
+        stream = await cast(Any, client.responses.send_async)(
+            model="openai/gpt-4o-mini", input="Run", stream=True
+        )
+        iterator = stream.__aiter__()
+        for _ in events:
+            await iterator.__anext__()
+        await stream.close()
+    else:
+        client = wrap_open_router(sync_client(handler))
+        stream = cast(Any, client.responses.send)(
+            model="openai/gpt-4o-mini", input="Run", stream=True
+        )
+        for _ in events:
+            next(stream)
+        stream.close()
+
+    assert len(calls) == 3
+    assert len(memory.span_exporter.get_finished_spans()) == 1
+    assert memory.metric_reader.get_metrics_data() is not None
+
+
 def test_chat_stream_capture_is_bounded_without_losing_terminal_metadata(
     memory: SimpleNamespace,
 ) -> None:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -75,7 +75,7 @@ later `init()` generates a new ID. It is not persisted across processes.
 | `init(**options) -> Client` | Initialize the SDK (see options below). Calling again replaces the previous client. |
 | `@observe` / `@observe(name=, type=, capture_input=, capture_output=, attributes=)` | Wrap a sync/async function (or generator) in a span. Arguments become `input` (param-name dict, `self`/`cls` dropped), the return value becomes `output`, exceptions are captured and re-raised. |
 | `start_span(name, *, type="span", ...) -> SpanHandle` | Start a span. `with` activates it in the current context; without `with` it is a detached handle you must `.end()`. |
-| `SpanHandle.update(**fields)` / `.end(**fields, end_time=)` / `.traceparent()` | Update attributes, end (accepts the full update field set), or read the W3C traceparent. |
+| `SpanHandle.update(**fields)` / `.end(**fields, end_time=)` / `.record_output_chunk(timestamp_ms=None)` / `.traceparent()` | Update attributes, end, record arrival of a non-empty output chunk, or read the W3C traceparent. |
 | `update_current_span(**fields)` | Apply the update field set to the currently active span (no-op without one). |
 | `propagate_attributes(*, user_id=, session_id=, metadata=)` | Context manager stamping `user.id` / `gen_ai.conversation.id` / `td.metadata.*` on every span and log record started inside (threads/asyncio included via contextvars). |
 | `log(message, *, level="info", event_name=None, attributes=None)` | Emit an OTLP log record to `/v1/logs`, correlated with the current trace. Levels: `debug`/`info`/`warn`/`error` (`"warning"` is accepted as an alias of `warn`). |
@@ -83,6 +83,18 @@ later `init()` generates a new ID. It is not persisted across processes.
 | `flush(timeout_s=10.0)` / `shutdown(timeout_s=10.0)` | Force-flush / tear down traces + logs + metrics. Shutdown also runs atexit unless `disable_atexit=True`. |
 | `TelemetrySpanProcessor` / `telemetry_dev.otel.create_telemetry_span_exporter` | Bring-your-own-OTel helpers (below). |
 | `MaskContext`, `Usage`, `SpanHandle`, `Client`, `NOT_GIVEN` | Supporting types. |
+
+`record_output_chunk()` measures intervals at the point the consumer pulls each chunk. If a
+consumer waits between pulls, that delay is included and cannot be separated from provider latency.
+The exact `gen_ai.client.operation.time_per_output_chunk` histogram is supported by the built-in
+OTLP metric exporter. OpenTelemetry Python does not expose an aggregate-input API for arbitrary
+metric readers, so supplying `metric_reader=` disables this histogram. Duration, token usage, and
+time-to-first-chunk metrics remain available; the first accepted streamed span with two or more
+recorded chunks reports this limitation once through `on_error` and the SDK logger.
+
+Provider integrations feature-detect `record_output_chunk`. Older core SDKs without that method
+continue delivering streams and tracing normally, but do not emit chunk-interval metrics. Upgrade
+the core SDK with provider integrations to enable the new metric.
 
 ### Span types
 
@@ -136,12 +148,17 @@ The built-in Python and TypeScript ratio samplers can select different sessions 
 
 ## Auto-metrics
 
-Ended spans automatically record two histograms (DELTA temporality, exported every 60s):
+Ended spans automatically record histograms (DELTA temporality, exported every 60s):
 
 - `gen_ai.client.operation.duration` (unit `s`) for `chat`, `invoke_agent`, `embeddings`,
   `execute_tool`
 - `gen_ai.client.token.usage` (unit `{token}`, attribute `gen_ai.token.type=input|output`) for
   `chat`, `invoke_agent`, `embeddings`
+- `gen_ai.client.operation.time_to_first_chunk` (unit `s`) for `chat` when a finite, non-negative
+  first-chunk timing is available.
+- `gen_ai.client.operation.time_per_output_chunk` (unit `s`) for `chat` with two or more recorded
+  output chunks, using the built-in OTLP exporter. Filtering applies before either streaming metric
+  is emitted, including streams interrupted after receiving output.
 
 Plain spans (`function`) record no metrics. Quiet intervals produce zero metric requests.
 

--- a/sdks/python/src/telemetry_dev/_client.py
+++ b/sdks/python/src/telemetry_dev/_client.py
@@ -41,7 +41,7 @@ from ._config import (
     resolve_config,
 )
 from ._context import SessionSampler
-from ._metrics import GuardedOTLPMetricExporter, MetricsRecorder
+from ._metrics import GuardedOTLPMetricExporter, MetricsRecorder, OutputChunkAggregation
 from ._processor import ExportMode, StampingSpanProcessor
 from ._semconv import SCOPE_NAME
 from ._serialize import Mask, serialize_content
@@ -160,6 +160,7 @@ class Client:
         self._tracer_provider: TracerProvider | None = None
         self._logger_provider: LoggerProvider | None = None
         self._meter_provider: MeterProvider | None = None
+        self._output_chunks: OutputChunkAggregation | None = None
 
         if not enabled:
             return
@@ -191,6 +192,7 @@ class Client:
         # Without an api key (enabled via a test seam), never construct real network
         # exporters — they would POST to the ingest with a bogus Authorization header.
         if metric_reader is None and config.api_key is not None:
+            self._output_chunks = OutputChunkAggregation()
             metric_exporter = GuardedOTLPMetricExporter(
                 endpoint=f"{config.base_url}/v1/metrics",
                 headers=headers,
@@ -199,6 +201,7 @@ class Client:
                 preferred_temporality={Histogram: AggregationTemporality.DELTA},
                 on_error=on_error,
             )
+            metric_exporter.output_chunks = self._output_chunks
             metric_reader = PeriodicExportingMetricReader(
                 metric_exporter, export_interval_millis=60_000
             )
@@ -208,7 +211,9 @@ class Client:
                 metric_readers=[metric_reader], resource=resource, shutdown_on_exit=False
             )
             meter = self._meter_provider.get_meter(SCOPE_NAME, SDK_VERSION)
-            metrics_recorder = MetricsRecorder(meter, on_error=on_error)
+            metrics_recorder = MetricsRecorder(
+                meter, on_error=on_error, output_chunks=self._output_chunks
+            )
 
         if span_exporter is None:
             span_exporter = _ReportingSpanExporter(

--- a/sdks/python/src/telemetry_dev/_metrics.py
+++ b/sdks/python/src/telemetry_dev/_metrics.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
 
+import math
+import threading
+import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.metrics import Meter
-from opentelemetry.sdk.metrics.export import MetricExportResult, MetricsData
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    Histogram,
+    HistogramDataPoint,
+    Metric,
+    MetricExportResult,
+    MetricsData,
+    ResourceMetrics,
+    ScopeMetrics,
+)
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import INVALID_SPAN_CONTEXT, NonRecordingSpan, set_span_in_context
 
 from ._config import report_error
 from ._semconv import (
     ATTR_ERROR_TYPE,
+    ATTR_TIME_TO_FIRST_CHUNK,
     DURATION_BUCKETS,
     DURATION_METRIC_OPERATIONS,
     METRIC_ATTR_KEYS,
+    SCOPE_NAME,
     TOKEN_BUCKETS,
     TOKEN_METRIC_OPERATIONS,
     USAGE_ATTRS,
@@ -21,6 +37,102 @@ from ._semconv import (
 
 _INPUT_TOKENS_ATTR = USAGE_ATTRS["input_tokens"]
 _OUTPUT_TOKENS_ATTR = USAGE_ATTRS["output_tokens"]
+_MAX_CHUNK_ATTRIBUTE_SETS = 2000
+_CHUNK_METRIC_NAME = "gen_ai.client.operation.time_per_output_chunk"
+
+
+@dataclass
+class _ChunkAggregate:
+    count: int
+    sum: float
+    min: float
+    max: float
+    buckets: list[int]
+
+
+class OutputChunkAggregation:
+    def __init__(self, max_attribute_sets: int = _MAX_CHUNK_ATTRIBUTE_SETS) -> None:
+        self._max_attribute_sets = max_attribute_sets
+        self._values: dict[tuple[tuple[str, Any], ...], _ChunkAggregate] = {}
+        self._lock = threading.Lock()
+        self._collection_start = time.time_ns()
+
+    def add(
+        self,
+        attributes: dict[str, Any],
+        aggregate: tuple[int, float, float, float, tuple[int, ...]],
+    ) -> None:
+        key = tuple(sorted(attributes.items()))
+        with self._lock:
+            if key not in self._values and len(self._values) >= self._max_attribute_sets - 1:
+                key = (("otel.metric.overflow", True),)
+            count, total, minimum, maximum, buckets = aggregate
+            existing = self._values.get(key)
+            if existing is None:
+                self._values[key] = _ChunkAggregate(count, total, minimum, maximum, list(buckets))
+                return
+            existing.count += count
+            existing.sum += total
+            existing.min = min(existing.min, minimum)
+            existing.max = max(existing.max, maximum)
+            for index, value in enumerate(buckets):
+                existing.buckets[index] += value
+
+    def drain_points(self) -> tuple[HistogramDataPoint, ...]:
+        with self._lock:
+            values, self._values = self._values, {}
+            now = time.time_ns()
+            start, self._collection_start = self._collection_start, now
+        return tuple(
+            HistogramDataPoint(
+                attributes=dict(key),
+                start_time_unix_nano=start,
+                time_unix_nano=now,
+                count=value.count,
+                sum=value.sum,
+                bucket_counts=tuple(value.buckets),
+                explicit_bounds=tuple(DURATION_BUCKETS),
+                min=value.min,
+                max=value.max,
+                exemplars=(),
+            )
+            for key, value in values.items()
+        )
+
+
+def _with_output_chunks(
+    metrics_data: MetricsData, aggregation: OutputChunkAggregation
+) -> MetricsData:
+    resource_metrics = list(metrics_data.resource_metrics)
+    target = next(
+        (
+            (resource_index, scope_index)
+            for resource_index, resource in enumerate(resource_metrics)
+            for scope_index, scope in enumerate(resource.scope_metrics)
+            if scope.scope.name == SCOPE_NAME
+        ),
+        None,
+    )
+    if target is None:
+        return metrics_data
+    points = aggregation.drain_points()
+    if not points:
+        return metrics_data
+    metric = Metric(
+        name=_CHUNK_METRIC_NAME,
+        description="Time between consecutive non-empty GenAI output chunks",
+        unit="s",
+        data=Histogram(points, AggregationTemporality.DELTA),
+    )
+    resource_index, scope_index = target
+    resource = resource_metrics[resource_index]
+    scopes = list(resource.scope_metrics)
+    scope = scopes[scope_index]
+    scopes[scope_index] = ScopeMetrics(scope.scope, [*scope.metrics, metric], scope.schema_url)
+    resource_metrics[resource_index] = ResourceMetrics(
+        resource.resource, scopes, resource.schema_url
+    )
+    return MetricsData(resource_metrics)
 
 
 def _has_data_points(metrics_data: MetricsData) -> bool:
@@ -44,6 +156,7 @@ class GuardedOTLPMetricExporter(OTLPMetricExporter):
     ) -> None:
         super().__init__(*args, **kwargs)  # pyright: ignore[reportUnknownMemberType]
         self._td_on_error = on_error
+        self.output_chunks: OutputChunkAggregation | None = None
 
     def export(
         self,
@@ -51,6 +164,8 @@ class GuardedOTLPMetricExporter(OTLPMetricExporter):
         timeout_millis: float | None = 10_000,
         **kwargs: Any,
     ) -> MetricExportResult:
+        if self.output_chunks is not None:
+            metrics_data = _with_output_chunks(metrics_data, self.output_chunks)
         if not _has_data_points(metrics_data):
             return MetricExportResult.SUCCESS
         try:
@@ -77,8 +192,12 @@ class MetricsRecorder:
         meter: Meter,
         *,
         on_error: Callable[[BaseException], None] | None = None,
+        output_chunks: OutputChunkAggregation | None = None,
     ) -> None:
         self._on_error = on_error
+        self._output_chunks = output_chunks
+        self._custom_reader_limitation_reported = False
+        self._custom_reader_limitation_lock = threading.Lock()
         self._duration = meter.create_histogram(
             "gen_ai.client.operation.duration",
             unit="s",
@@ -91,6 +210,11 @@ class MetricsRecorder:
             description="Number of input and output tokens used by GenAI clients",
             explicit_bucket_boundaries_advisory=TOKEN_BUCKETS,
         )
+        self._first_chunk = meter.create_histogram(
+            "gen_ai.client.operation.time_to_first_chunk",
+            unit="s",
+            explicit_bucket_boundaries_advisory=DURATION_BUCKETS,
+        )
 
     def record_span(self, span: ReadableSpan) -> None:
         try:
@@ -99,6 +223,29 @@ class MetricsRecorder:
             if not isinstance(operation, str) or operation not in DURATION_METRIC_OPERATIONS:
                 return
             metric_attrs = {key: attributes[key] for key in METRIC_ATTR_KEYS if key in attributes}
+            if operation == "chat":
+                from ._spans import output_chunk_aggregate
+
+                chunk_aggregate = output_chunk_aggregate(span)
+                if chunk_aggregate is not None:
+                    if self._output_chunks is not None:
+                        self._output_chunks.add(metric_attrs, chunk_aggregate)
+                    else:
+                        with self._custom_reader_limitation_lock:
+                            should_report = not self._custom_reader_limitation_reported
+                            self._custom_reader_limitation_reported = True
+                        if should_report:
+                            report_error(
+                                self._on_error,
+                                "output chunk interval metric is unavailable with a custom "
+                                "metric_reader",
+                                RuntimeError(
+                                    "gen_ai.client.operation.time_per_output_chunk requires the "
+                                    "built-in OTLP metric exporter; ordinary auto-metrics remain "
+                                    "enabled"
+                                ),
+                            )
+            context = set_span_in_context(NonRecordingSpan(span.context or INVALID_SPAN_CONTEXT))
             if span.end_time is not None and span.start_time is not None:
                 duration_s = max(span.end_time - span.start_time, 0) / 1e9
                 error_type = attributes.get(ATTR_ERROR_TYPE)
@@ -107,14 +254,27 @@ class MetricsRecorder:
                     if isinstance(error_type, str)
                     else metric_attrs
                 )
-                self._duration.record(duration_s, duration_attrs)
+                self._duration.record(duration_s, duration_attrs, context=context)
+            first_chunk_seconds = attributes.get(ATTR_TIME_TO_FIRST_CHUNK)
+            if (
+                operation == "chat"
+                and isinstance(first_chunk_seconds, (int, float))
+                and not isinstance(first_chunk_seconds, bool)
+                and math.isfinite(first_chunk_seconds)
+                and first_chunk_seconds >= 0
+            ):
+                self._first_chunk.record(first_chunk_seconds, metric_attrs, context=context)
             if operation not in TOKEN_METRIC_OPERATIONS:
                 return
             input_tokens = attributes.get(_INPUT_TOKENS_ATTR)
             if isinstance(input_tokens, int):
-                self._tokens.record(input_tokens, {**metric_attrs, "gen_ai.token.type": "input"})
+                self._tokens.record(
+                    input_tokens, {**metric_attrs, "gen_ai.token.type": "input"}, context=context
+                )
             output_tokens = attributes.get(_OUTPUT_TOKENS_ATTR)
             if isinstance(output_tokens, int):
-                self._tokens.record(output_tokens, {**metric_attrs, "gen_ai.token.type": "output"})
+                self._tokens.record(
+                    output_tokens, {**metric_attrs, "gen_ai.token.type": "output"}, context=context
+                )
         except BaseException as exc:
             report_error(self._on_error, "failed to record auto-metrics for span", exc)

--- a/sdks/python/src/telemetry_dev/_spans.py
+++ b/sdks/python/src/telemetry_dev/_spans.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import math
+import threading
+import time
 import traceback
+from bisect import bisect_left
 from collections.abc import Callable, Mapping, Sequence
 from contextvars import Token
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, TypedDict
-from weakref import WeakKeyDictionary
+from weakref import WeakKeyDictionary, WeakValueDictionary
 
 from opentelemetry import context as otel_context
 from opentelemetry import trace
@@ -42,6 +46,7 @@ from ._semconv import (
     ATTR_TOOL_CALL_ID,
     ATTR_TOOL_DESCRIPTION,
     ATTR_TOOL_NAME,
+    DURATION_BUCKETS,
     METADATA_PREFIX,
     RESERVED_METADATA_KEYS,
     SAMPLING_ATTRS,
@@ -86,9 +91,42 @@ class _SpanState:
     operation: str
     capture_input: bool
     capture_output: bool
+    output_chunk_last_ms: float | None = None
+    output_chunk_count: int = 0
+    output_chunk_sum_s: float = 0
+    output_chunk_min_s: float | None = None
+    output_chunk_max_s: float | None = None
+    output_chunk_buckets: list[int] | None = None
 
 
 _SPAN_STATES: WeakKeyDictionary[Span, _SpanState] = WeakKeyDictionary()
+_OUTPUT_CHUNK_STATES: WeakValueDictionary[tuple[int, int], _SpanState] = WeakValueDictionary()
+_OUTPUT_CHUNK_STATES_LOCK = threading.Lock()
+
+
+def _span_key(span: Any) -> tuple[int, int]:
+    context = span.get_span_context() if hasattr(span, "get_span_context") else span.context
+    return context.trace_id, context.span_id
+
+
+def output_chunk_aggregate(span: Any) -> tuple[int, float, float, float, tuple[int, ...]] | None:
+    with _OUTPUT_CHUNK_STATES_LOCK:
+        state = _OUTPUT_CHUNK_STATES.pop(_span_key(span), None)
+        if (
+            state is None
+            or state.output_chunk_count == 0
+            or state.output_chunk_min_s is None
+            or state.output_chunk_max_s is None
+            or state.output_chunk_buckets is None
+        ):
+            return None
+        return (
+            state.output_chunk_count,
+            state.output_chunk_sum_s,
+            state.output_chunk_min_s,
+            state.output_chunk_max_s,
+            tuple(state.output_chunk_buckets),
+        )
 
 
 def _to_ns(value: TimeInput) -> int | None:
@@ -413,6 +451,45 @@ class SpanHandle:
             self._client.report("SpanHandle.update failed", exc)
         return self
 
+    def record_output_chunk(self, timestamp_ms: float | None = None) -> SpanHandle:
+        """Record arrival of a non-empty output chunk using a monotonic millisecond timestamp."""
+        if not self._recording():
+            return self
+        assert self._state is not None and self._client is not None
+        try:
+            now = time.perf_counter() * 1000 if timestamp_ms is None else float(timestamp_ms)
+            if not math.isfinite(now):
+                return self
+            with _OUTPUT_CHUNK_STATES_LOCK:
+                if not self._recording():
+                    return self
+                previous = self._state.output_chunk_last_ms
+                if previous is not None and now < previous:
+                    return self
+                self._state.output_chunk_last_ms = now
+                _OUTPUT_CHUNK_STATES[_span_key(self.span)] = self._state
+                if previous is None:
+                    return self
+                interval_s = max(now - previous, 0) / 1000
+                self._state.output_chunk_count += 1
+                self._state.output_chunk_sum_s += interval_s
+                self._state.output_chunk_min_s = (
+                    interval_s
+                    if self._state.output_chunk_min_s is None
+                    else min(self._state.output_chunk_min_s, interval_s)
+                )
+                self._state.output_chunk_max_s = (
+                    interval_s
+                    if self._state.output_chunk_max_s is None
+                    else max(self._state.output_chunk_max_s, interval_s)
+                )
+                if self._state.output_chunk_buckets is None:
+                    self._state.output_chunk_buckets = [0] * (len(DURATION_BUCKETS) + 1)
+                self._state.output_chunk_buckets[bisect_left(DURATION_BUCKETS, interval_s)] += 1
+        except BaseException as exc:
+            self._client.report("SpanHandle.record_output_chunk failed", exc)
+        return self
+
     def end(
         self,
         *,
@@ -480,7 +557,10 @@ class SpanHandle:
             attributes=attributes,
             error=error,
         )
-        self._ended = True
+        with _OUTPUT_CHUNK_STATES_LOCK:
+            if self._ended:
+                return
+            self._ended = True
         self.span.end(_to_ns(end_time))
 
     def traceparent(self) -> str | None:

--- a/sdks/python/tests/e2e_scenarios.py
+++ b/sdks/python/tests/e2e_scenarios.py
@@ -131,14 +131,19 @@ def main() -> int:
             ).end()
             # C16b: mask hook redaction.
             start_span("masked-step", type="generation", input="SECRET stuff").end()
-            start_span(
+            streamed = start_span(
                 "streamed-chat",
                 type="generation",
                 model="gpt-4o",
                 provider="openai",
                 input=[{"role": "user", "content": "Stream please"}],
+            )
+            for timestamp in (1000, 1010, 1050, 1210):
+                streamed.record_output_chunk(timestamp)
+            streamed.end(
                 time_to_first_chunk_ms=250,
-            ).end(output={"role": "assistant", "content": "chunk..."})
+                output={"role": "assistant", "content": "chunk..."},
+            )
 
         # C13: continue the trace from a serialized W3C traceparent.
         start_span("background-job", parent=agent_traceparent).end()

--- a/sdks/python/tests/test_metrics.py
+++ b/sdks/python/tests/test_metrics.py
@@ -1,19 +1,30 @@
 from __future__ import annotations
 
+import gc
+import math
+import threading
 import time
 from types import SimpleNamespace
+from weakref import ref
 
+import pytest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+)
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
+    Histogram,
     HistogramDataPoint,
     Metric,
     PeriodicExportingMetricReader,
 )
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import telemetry_dev
-from telemetry_dev._metrics import GuardedOTLPMetricExporter
+from telemetry_dev._metrics import GuardedOTLPMetricExporter, OutputChunkAggregation
 from tests.conftest import MakeClient
 from tests.otlp_capture import otlp_capture_server
 
@@ -102,6 +113,234 @@ def test_generation_records_duration_and_tokens(memory: SimpleNamespace) -> None
     assert points["input"].explicit_bounds == TOKEN_BUCKETS
 
 
+def test_streaming_first_chunk_seconds(memory: SimpleNamespace) -> None:
+    telemetry_dev.start_span("stream", type="generation", model="gpt-4o", provider="openai").end(
+        time_to_first_chunk_ms=250, error=ValueError("failed after first chunk")
+    )
+    telemetry_dev.start_span("instant", type="generation", time_to_first_chunk_ms=0).end()
+    telemetry_dev.start_span("nonstream", type="generation").end()
+    for timing in [-1, float("nan"), float("inf")]:
+        telemetry_dev.start_span("invalid", type="generation", time_to_first_chunk_ms=timing).end()
+    telemetry_dev.start_span("tool", type="tool", time_to_first_chunk_ms=900).end()
+    telemetry_dev.start_span("agent", type="agent", time_to_first_chunk_ms=800).end()
+    metric = collect_metrics(memory)["gen_ai.client.operation.time_to_first_chunk"]
+    assert metric.unit == "s"
+    assert isinstance(metric.data, Histogram)
+    assert metric.data.aggregation_temporality == AggregationTemporality.DELTA
+    points = histogram_points(metric)
+    assert len(points) == 2
+    streamed = next(
+        p for p in points if (p.attributes or {}).get("gen_ai.request.model") == "gpt-4o"
+    )
+    assert streamed.count == 1
+    assert streamed.sum == 0.25
+    assert streamed.explicit_bounds == DURATION_BUCKETS
+    assert dict(streamed.attributes or {}) == {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "gpt-4o",
+        "gen_ai.provider.name": "openai",
+    }
+    assert next(p for p in points if p is not streamed).sum == 0
+
+
+def test_custom_reader_preserves_ordinary_metrics_and_reports_chunk_limitation_once(
+    make: MakeClient,
+) -> None:
+    errors: list[BaseException] = []
+    env = make(on_error=errors.append)
+    for name in ("first", "second"):
+        handle = telemetry_dev.start_span(name, type="generation")
+        for timestamp in (1000, 1010, 1050, 1210):
+            handle.record_output_chunk(timestamp)
+        handle.end(usage={"input_tokens": 3}, time_to_first_chunk_ms=250)
+
+    metrics = collect_metrics(env)
+    assert "gen_ai.client.operation.duration" in metrics
+    assert "gen_ai.client.token.usage" in metrics
+    assert "gen_ai.client.operation.time_to_first_chunk" in metrics
+    assert "gen_ai.client.operation.time_per_output_chunk" not in metrics
+    assert env.client._output_chunks is None
+    assert len(errors) == 1
+    assert "requires the built-in OTLP metric exporter" in str(errors[0])
+
+
+@pytest.mark.parametrize("ending", ["complete", "failed", "concurrent", "nonmonotonic"])
+def test_builtin_exporter_merges_exact_output_chunk_histogram(
+    monkeypatch: pytest.MonkeyPatch, ending: str
+) -> None:
+    errors: list[BaseException] = []
+
+    def keep(span: ReadableSpan) -> bool:
+        return span.name != "filtered"
+
+    with otlp_capture_server() as server:
+        client = telemetry_dev.init(
+            api_key="td_test_x",
+            base_url=server.url,
+            export_mode="immediate",
+            span_exporter=InMemorySpanExporter(),
+            log_exporter=InMemoryLogRecordExporter(),
+            disable_atexit=True,
+            span_filter=keep,
+            on_error=errors.append,
+        )
+        telemetry_dev.start_span("filtered", type="generation").record_output_chunk(
+            1000
+        ).record_output_chunk(9000).end(error=RuntimeError("filtered failure"))
+        handle = telemetry_dev.start_span(
+            "stream", type="generation", model="gpt-4o", provider="openai"
+        )
+        timestamps = (
+            (1000, 1000, 990, 1010) if ending == "nonmonotonic" else (1000, 1010, 1050, 1210)
+        )
+        for timestamp in timestamps[:-1]:
+            handle.record_output_chunk(timestamp)
+        if ending == "concurrent":
+            import telemetry_dev._spans as span_module
+
+            bucket_started = threading.Event()
+            resume_bucket = threading.Event()
+            close_attempted = threading.Event()
+            close_finished = threading.Event()
+            close_acquired: list[bool] = []
+            lock = threading.Lock()
+            original_bisect = span_module.bisect_left
+
+            class ObservedLock:
+                def __enter__(self) -> None:
+                    acquired = lock.acquire(blocking=False)
+                    if threading.current_thread() is closer:
+                        close_acquired.append(acquired)
+                        close_attempted.set()
+                    if not acquired:
+                        lock.acquire()
+
+                def __exit__(self, *args: object) -> None:
+                    lock.release()
+
+            def paused_bucket(boundaries: tuple[float, ...], interval: float) -> int:
+                bucket_started.set()
+                assert resume_bucket.wait(5)
+                return original_bisect(boundaries, interval)
+
+            def close() -> None:
+                handle.end()
+                close_finished.set()
+
+            recorder = threading.Thread(target=handle.record_output_chunk, args=(timestamps[-1],))
+            closer = threading.Thread(target=close)
+            monkeypatch.setattr(span_module, "_OUTPUT_CHUNK_STATES_LOCK", ObservedLock())
+            monkeypatch.setattr(span_module, "bisect_left", paused_bucket)
+            try:
+                recorder.start()
+                assert bucket_started.wait(5)
+                closer.start()
+                assert close_attempted.wait(5)
+                if close_acquired[0]:
+                    assert close_finished.wait(5)
+            finally:
+                resume_bucket.set()
+                recorder.join(timeout=5)
+                if closer.ident is not None:
+                    closer.join(timeout=5)
+            assert not recorder.is_alive() and not closer.is_alive()
+            assert close_finished.is_set()
+        else:
+            handle.record_output_chunk(timestamps[-1])
+            handle.end(error=RuntimeError("stream failed") if ending == "failed" else None)
+        handle.record_output_chunk(9999)
+        client.flush()
+
+        (request,) = server.requests_for("/v1/metrics")
+        decoded = ExportMetricsServiceRequest()
+        decoded.ParseFromString(request.decompressed())
+        matching = [
+            (scope_metrics.scope, metric)
+            for resource_metrics in decoded.resource_metrics
+            for scope_metrics in resource_metrics.scope_metrics
+            for metric in scope_metrics.metrics
+            if metric.name == "gen_ai.client.operation.time_per_output_chunk"
+        ]
+        [(scope, metric)] = matching
+        assert scope.name == "telemetry_dev"
+        assert len(metric.histogram.data_points) == 1
+        point = metric.histogram.data_points[0]
+        if ending == "nonmonotonic":
+            assert point.count == 2
+            assert math.isclose(point.sum, 0.01)
+            assert point.min == 0
+            assert point.max == 0.01
+            assert tuple(point.bucket_counts[:5]) == (2, 0, 0, 0, 0)
+        else:
+            assert point.count == 3
+            assert math.isclose(point.sum, 0.21)
+            assert point.min == 0.01
+            assert point.max == 0.16
+            assert tuple(point.bucket_counts[:5]) == (1, 0, 1, 0, 1)
+        assert tuple(point.explicit_bounds) == DURATION_BUCKETS
+        assert point.exemplars == []
+        assert point.count == sum(point.bucket_counts)
+        assert errors == []
+        client.shutdown()
+
+
+def test_output_chunk_zero_or_one_and_filter_rejection_emit_nothing(make: MakeClient) -> None:
+    def keep(span: ReadableSpan) -> bool:
+        return span.name != "rejected"
+
+    errors: list[BaseException] = []
+    env = make(span_filter=keep, on_error=errors.append)
+    telemetry_dev.start_span("zero", type="generation").end()
+    one = telemetry_dev.start_span("one", type="generation")
+    one.record_output_chunk(1000).end()
+    rejected = telemetry_dev.start_span("rejected", type="generation")
+    rejected.record_output_chunk(1000).record_output_chunk(1020).end()
+
+    assert env.client._output_chunks is None
+    assert errors == []
+
+
+def test_rejected_chunk_state_does_not_retain_abandoned_handles(make: MakeClient) -> None:
+    def reject(span: ReadableSpan) -> bool:
+        return False
+
+    make(span_filter=reject)
+    handle = telemetry_dev.start_span("rejected", type="generation")
+    state = ref(vars(handle)["_state"])
+    handle.record_output_chunk(0).end()
+    del handle
+    gc.collect()
+    assert state() is None
+
+
+def test_output_chunk_attribute_cardinality_is_bounded() -> None:
+    aggregation = OutputChunkAggregation(max_attribute_sets=2)
+    value = (1, 0.01, 0.01, 0.01, (1, *([0] * len(DURATION_BUCKETS))))
+    for model in ("a", "b", "c", "d"):
+        aggregation.add({"gen_ai.request.model": model}, value)
+
+    points = aggregation.drain_points()
+    assert len(points) == 2
+    overflow = next(point for point in points if point.attributes == {"otel.metric.overflow": True})
+    assert overflow.count == 3
+
+
+def test_ended_child_metrics_reference_child_not_active_parent(memory: SimpleNamespace) -> None:
+    with telemetry_dev.start_span("parent", type="agent"):
+        telemetry_dev.start_span("child", type="generation").end(
+            usage={"input_tokens": 11, "output_tokens": 7}, time_to_first_chunk_ms=250
+        )
+        child = memory.span_exporter.get_finished_spans()[0].context
+        assert child is not None
+        metrics = collect_metrics(memory)
+        for metric in metrics.values():
+            for point in histogram_points(metric):
+                assert len(point.exemplars) == 1
+                exemplar = point.exemplars[0]
+                assert exemplar.trace_id == child.trace_id
+                assert exemplar.span_id == child.span_id
+
+
 def test_agent_and_embedding_record_both_histograms(memory: SimpleNamespace) -> None:
     telemetry_dev.start_span("agent", type="agent").end(usage={"input_tokens": 3})
     telemetry_dev.start_span("embed", type="embedding").end(usage={"input_tokens": 4})
@@ -170,7 +409,9 @@ def test_filter_rejected_spans_record_no_metrics(make: MakeClient) -> None:
         return span.name != "rejected"
 
     env = make(span_filter=keep)
-    telemetry_dev.start_span("rejected", type="generation", usage={"input_tokens": 5}).end()
+    telemetry_dev.start_span(
+        "rejected", type="generation", usage={"input_tokens": 5}, time_to_first_chunk_ms=300
+    ).end()
     telemetry_dev.start_span("kept", type="generation", usage={"input_tokens": 3}).end()
     metrics = collect_metrics(env)
     points = histogram_points(metrics["gen_ai.client.operation.duration"])
@@ -178,3 +419,4 @@ def test_filter_rejected_spans_record_no_metrics(make: MakeClient) -> None:
     assert env.span_exporter.get_finished_spans()[0].name == "kept"
     token_points = histogram_points(metrics["gen_ai.client.token.usage"])
     assert {point.sum for point in token_points} == {3}
+    assert "gen_ai.client.operation.time_to_first_chunk" not in metrics


### PR DESCRIPTION
Adds GenAI first-chunk and inter-chunk latency histograms to the TypeScript and Python SDKs. Provider integrations record nonempty output arrivals before telemetry processing, including tool arguments, reasoning, and audio output. Empty deltas and completion snapshots do not add observations.

Intervals are exported in seconds after the span passes filtering at completion, including failed or interrupted streams. Fixed histogram buckets and a 2,000-series cap bound retained metric state. Pull-based streams include consumer delay between reads. Python's built-in OTLP exporter supports exact interval aggregates; custom metric readers retain ordinary metrics and first-chunk timing, with a one-time diagnostic for unavailable interval metrics. Python metric exemplars use the ended span's context.

Also applies the current lint conventions across the publishable TypeScript packages while preserving Cursor's public event carrier and the W3C propagation carrier contracts.

## Self-review

- Sibling symmetry: checked TypeScript/Python cores and provider stream variants, including sync/async, tool-only output, and alternate yielded iterator results.
- Unbounded work: checked fixed-size interval histograms and capped completed-span attribute sets; raw interval samples are not retained.
- Concurrency and atomicity: checked Python recording/end synchronization and locked aggregate drains; TypeScript collection snapshots synchronously.
- Error and defect paths: checked retained intervals after stream failure or cancellation and existing exporter failure reporting.
- Config validation: not applicable; no environment variables or configuration options added.
- Rollout order: checked optional provider hooks for older cores and use of existing OTLP endpoints; core SDK and OTel package changes must release together.
- No-JS and SSR states: not applicable; no UI changes.
- Privacy and documentation truth: checked metadata-only interval aggregates and documented consumer delay, filtering, custom-reader limits, and absent interval exemplars.
- Security surfaces: checked; no new credentials, sockets, temporary-file interfaces, or request destinations.
- Scope hygiene: checked streaming metrics, exemplar context, related instrumentation, tests, and repository lint compliance. No manifest or lockfile churn.
- Tests that encode the attack: checked empty and tool-only deltas, mapping delays, rejected spans, overflow, nonmonotonic clocks, interrupted streams, and concurrent end.
- Follow-ups: not applicable; no deferred work in this change.
