### PR TITLE
fix: correct package repository metadata

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/ai"
   },
   "files": [

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/anthropic"
   },
   "files": [

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/bedrock"
   },
   "files": [

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/cursor"
   },
   "bin": {

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/eve"
   },
   "files": [

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/google-genai"
   },
   "files": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/mcp"
   },
   "files": [

--- a/packages/omp/package.json
+++ b/packages/omp/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/omp"
   },
   "files": [

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/openai"
   },
   "files": [

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/opencode"
   },
   "files": [

--- a/packages/openrouter/package.json
+++ b/packages/openrouter/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/openrouter"
   },
   "files": [

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/otel"
   },
   "files": [

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/pi"
   },
   "files": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/sdk"
   },
   "files": [

--- a/packages/tanstack-ai/package.json
+++ b/packages/tanstack-ai/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telemetry-dev/sdks.git",
+    "url": "git+https://github.com/telemetry-dev/telemetry.git",
     "directory": "packages/tanstack-ai"
   },
   "files": [

--- a/sdks/python-anthropic/pyproject.toml
+++ b/sdks/python-anthropic/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [tool.uv.sources]
 telemetry-dev = { path = "../python", editable = true }

--- a/sdks/python-bedrock/pyproject.toml
+++ b/sdks/python-bedrock/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [tool.uv.sources]
 telemetry-dev = { path = "../python", editable = true }

--- a/sdks/python-google-genai/pyproject.toml
+++ b/sdks/python-google-genai/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [tool.uv.sources]
 telemetry-dev = { path = "../python", editable = true }

--- a/sdks/python-litellm/pyproject.toml
+++ b/sdks/python-litellm/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [dependency-groups]
 dev = [

--- a/sdks/python-openai/pyproject.toml
+++ b/sdks/python-openai/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [tool.uv.sources]
 telemetry-dev = { path = "../python", editable = true }

--- a/sdks/python-openrouter/pyproject.toml
+++ b/sdks/python-openrouter/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [tool.uv.sources]
 telemetry-dev = { path = "../python", editable = true }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://telemetry.dev"
-Repository = "https://github.com/telemetry-dev/sdks"
+Repository = "https://github.com/telemetry-dev/telemetry"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Align all published npm and PyPI package metadata with the renamed `telemetry-dev/telemetry` repository. npm provenance rejects releases when `package.json.repository.url` differs from the authenticated workflow repository.

Validation:
- `vp check`
- `vp run py:check`
- `bash .github/scripts/release_test.sh`

## Self-review
- Sibling symmetry: checked all 15 npm packages and all 7 Python packages.
- Unbounded work: not applicable; metadata-only change.
- Concurrency and atomicity: not applicable.
- Error and defect paths: checked the npm E422 provenance failure this corrects.
- Config validation: not applicable.
- Rollout order: checked; publish new patch versions rather than rewriting existing tags.
- No-JS and SSR states: not applicable.
- Privacy and documentation truth: checked every current package repository URL against the renamed repository.
- Security surfaces: not applicable.
- Scope hygiene: checked; only package repository metadata changed.
- Tests that encode the attack: release-safety test passes; npm OIDC publication is the external verification gate.
- Follow-ups: none in this PR.