### PR TITLE
ci: use Node 24 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
   typescript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.25.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
@@ -37,14 +37,14 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.25.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: "3.13"


### PR DESCRIPTION
GitHub warns that the CI action majors still use its deprecated Node 20 action runtime. This moves CI to the first compatible Node 24 majors, except `pnpm/action-setup`, where v6 is required for the repository's pnpm 11 toolchain.

The release workflow is unchanged because its immutable action pins already resolve to Node 24 releases.

## Self-review

- **Sibling symmetry:** Checked TypeScript and Python CI; the release workflow's immutable pins already use Node 24.
- **Unbounded work:** Not applicable; no loops, scans, buffers, or queries change.
- **Concurrency and atomicity:** Not applicable; job structure and execution order are unchanged.
- **Error and defect paths:** Checked; action setup failures retain the same job-failing behavior.
- **Config validation:** Checked; existing action inputs remain supported by the selected majors.
- **Rollout order:** Not applicable; no application, database, or package behavior changes.
- **No-JS and SSR states:** Not applicable; no interface behavior changes.
- **Privacy and documentation truth:** Checked each selected action's metadata declares the Node 24 runtime.
- **Security surfaces:** Checked; workflow permissions and credential handling are unchanged.
- **Scope hygiene:** Checked; only CI action references change.
- **Tests that encode the attack:** Actionlint validates the workflow contracts; the PR run is the executable compatibility check.
- **Follow-ups:** Update the parent repository's SDK pin after this commit is published.
